### PR TITLE
Use latest snapshot for upstream

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -25,20 +25,9 @@ jobs:
         with:
           java-version: ${{ matrix.java }}
 
-      # dependencies: OpenSearch
-      - name: Checkout OpenSearch
-        uses: actions/checkout@v2
-        with:
-          repository: 'opensearch-project/OpenSearch'
-          ref: '1.0'
-          path: OpenSearch
-      - name: Build OpenSearch
-        working-directory: ./OpenSearch
-        run: ./gradlew publishToMavenLocal -Dbuild.snapshot=false
-
       - name: Run build
         run: |
-          ./gradlew build -Dopensearch.version=1.0.0
+          ./gradlew build -Dopensearch.version=1.3.0-SNAPSHOT
 
       - name: Upload Coverage Report
         uses: codecov/codecov-action@v1

--- a/.github/workflows/links.yml
+++ b/.github/workflows/links.yml
@@ -16,7 +16,7 @@ jobs:
         id: lychee
         uses: lycheeverse/lychee-action@master
         with:
-          args: --accept=200,403,429  "**/*.html" "**/*.md" "**/*.txt" "**/*.json"
+          args: --accept=200,403,429  **/*.html **/*.md **/*.txt **/*.json
         env:
           GITHUB_TOKEN: ${{secrets.GITHUB_TOKEN}}
       - name: Fail if there were link errors

--- a/build.gradle
+++ b/build.gradle
@@ -37,15 +37,16 @@ validateNebulaPom.enabled = false
 
 buildscript {
     ext {
-        opensearch_version = System.getProperty("opensearch.version", "1.0.0")
+        opensearch_version = System.getProperty("opensearch.version", "1.3.0-SNAPSHOT")
         opensearch_group = "org.opensearch"
     }
 
     repositories {
+        mavenLocal()
+        maven { url "https://aws.oss.sonatype.org/content/repositories/snapshots" }
         mavenCentral()
         maven { url "https://plugins.gradle.org/m2/" }
         jcenter()
-        mavenLocal()
     }
 
     dependencies {
@@ -55,10 +56,18 @@ buildscript {
 
 repositories {
     mavenLocal()
+    maven { url "https://aws.oss.sonatype.org/content/repositories/snapshots" }
+    mavenCentral()
+    maven { url "https://plugins.gradle.org/m2/" }
+    jcenter()
 }
 
 test {
     include '**/*Tests.class'
+}
+
+dependencies {
+    runtimeClasspath "org.apache.logging.log4j:log4j-core:${versions.log4j}"
 }
 
 task integTest(type: RestIntegTestTask) {
@@ -84,4 +93,8 @@ testClusters.integTest {
 
 run {
     useCluster testClusters.integTest
+}
+
+tasks.withType(RestIntegTestTask)*.configure {
+    classpath += files(project.configurations.runtimeClasspath.findAll { it.name.contains("log4j-core") })
 }


### PR DESCRIPTION
Signed-off-by: Vijayan Balasubramanian <balasvij@amazon.com>

### Description
Update workflow and build to use 1.3.0 as upstream.
  
### Check List
- [x] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
