### PR TITLE
Add feature processor to convert geojson feature to geoshape field

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -1,3 +1,8 @@
+/*
+ *  Copyright OpenSearch Contributors
+ *  SPDX-License-Identifier: Apache-2.0
+ */
+
 import org.opensearch.gradle.test.RestIntegTestTask
 
 apply plugin: 'java'

--- a/src/main/java/org/opensearch/geospatial/geojson/Feature.java
+++ b/src/main/java/org/opensearch/geospatial/geojson/Feature.java
@@ -1,12 +1,6 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
- * The OpenSearch Contributors require contributions made to
- * this file be licensed under the Apache-2.0 license or a
- * compatible open source license.
- *
- * Modifications Copyright OpenSearch Contributors. See
- * GitHub history for details.
  */
 
 package org.opensearch.geospatial.geojson;

--- a/src/main/java/org/opensearch/geospatial/geojson/Feature.java
+++ b/src/main/java/org/opensearch/geospatial/geojson/Feature.java
@@ -1,0 +1,83 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ *
+ * Modifications Copyright OpenSearch Contributors. See
+ * GitHub history for details.
+ */
+
+package org.opensearch.geospatial.geojson;
+
+import java.util.HashMap;
+import java.util.Map;
+
+/**
+ * Feature object represents GEOJSON of type Feature.
+ */
+public class Feature {
+    public static final String TYPE = "Feature";
+    public static final String GEOMETRY_KEY = "geometry";
+    public static final String PROPERTIES_KEY = "properties";
+    public static final String TYPE_KEY = "type";
+    private final Map<String, Object> geometry;
+    private Map<String, Object> properties;
+
+    private Feature(Map<String, Object> geometry) {
+        this.geometry = new HashMap<>();
+        this.geometry.putAll(geometry);
+        this.properties = new HashMap<>();
+    }
+
+    /**
+     * Gets the geometry value of this Feature
+     *
+     * @return Feature's Geometry as Map
+     */
+    public Map<String, Object> getGeometry() {
+        return geometry;
+    }
+
+    /**
+     * Gets the properties of this Feature
+     *
+     * @return Feature's properties as Map
+     */
+    public Map<String, Object> getProperties() {
+        return properties;
+    }
+
+    /**
+     * FeatureBuilder represents the Builder Object to build Feature instance
+     */
+    static class FeatureBuilder {
+
+        private final Feature feature;
+
+        public FeatureBuilder(Map<String, Object> geometry) {
+            this.feature = new Feature(geometry);
+        }
+
+        /**
+         * Returns Feature instance based on FeatureBuilder values.
+         *
+         * @return Feature, which is a GeoJSON Object of type Feature
+         */
+        public Feature build() {
+            return feature;
+        }
+
+        /**
+         * Adds given properties to existing properties
+         *
+         * @param properties
+         * @return FeatureBuilder instance
+         */
+        public FeatureBuilder properties(Map<String, Object> properties) {
+            this.feature.properties.putAll(properties);
+            return this;
+        }
+    }
+}

--- a/src/main/java/org/opensearch/geospatial/geojson/FeatureFactory.java
+++ b/src/main/java/org/opensearch/geospatial/geojson/FeatureFactory.java
@@ -1,0 +1,67 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package org.opensearch.geospatial.geojson;
+
+
+import org.opensearch.geospatial.geojson.Feature.FeatureBuilder;
+
+import java.util.HashMap;
+import java.util.Map;
+
+/**
+ * FeatureFactory helps to create {@link Feature} instance based on user input
+ */
+public class FeatureFactory {
+
+    /**
+     * The factory method to create an instance of Feature from input.
+     *
+     * @param input the object from where {@link Feature} will be extracted
+     * @return Feature Instance from input
+     */
+    public static Feature create(Map<String, Object> input) {
+        Object geoJSONType = input.get(Feature.TYPE_KEY);
+        if (geoJSONType == null) {
+            throw new IllegalArgumentException(Feature.TYPE_KEY + " cannot be null");
+        }
+        if (!Feature.TYPE.equalsIgnoreCase(geoJSONType.toString())) {
+            throw new IllegalArgumentException(geoJSONType + " is not supported. Only type " + Feature.TYPE + " is supported");
+        }
+        return extractFeature(input).build();
+    }
+
+    private static Map<String, Object> toStringObjectMap(Object input) {
+        if (!(input instanceof Map)) {
+            throw new IllegalArgumentException(input + " is not an instance of Map");
+        }
+        Map<Object, Object> inputMap = (Map<Object, Object>) input;
+        Map<String, Object> stringObjectMap = new HashMap<>();
+        for (Map.Entry<Object, Object> entry : inputMap.entrySet()) {
+            stringObjectMap.put(entry.getKey().toString(), entry.getValue());
+        }
+        return stringObjectMap;
+    }
+
+    private static FeatureBuilder extractFeature(Map<String, Object> input) {
+        Object geometry = input.get(Feature.GEOMETRY_KEY);
+        if (geometry == null) {
+            throw new IllegalArgumentException("key: " + Feature.GEOMETRY_KEY + " cannot be null");
+        }
+        if (!(geometry instanceof Map)) {
+            throw new IllegalArgumentException("key: " + Feature.GEOMETRY_KEY + "is not an instance of type Map");
+        }
+        Map<String, Object> geometryMap = toStringObjectMap(geometry);
+        FeatureBuilder featureBuilder = new FeatureBuilder(geometryMap);
+        Object properties = input.get(Feature.PROPERTIES_KEY);
+        if (properties == null) {
+            return featureBuilder;
+        }
+        if (!(properties instanceof Map)) {
+            throw new IllegalArgumentException("key: " + Feature.PROPERTIES_KEY + "is not an instance of type Map");
+        }
+        return featureBuilder.properties(toStringObjectMap(properties));
+    }
+}

--- a/src/main/java/org/opensearch/geospatial/plugin/GeospatialPlugin.java
+++ b/src/main/java/org/opensearch/geospatial/plugin/GeospatialPlugin.java
@@ -1,10 +1,8 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
- * The OpenSearch Contributors require contributions made to
- * this file be licensed under the Apache-2.0 license or a
- * compatible open source license.
  */
+
 package org.opensearch.geospatial.plugin;
 
 import org.opensearch.common.collect.MapBuilder;

--- a/src/main/java/org/opensearch/geospatial/plugin/GeospatialPlugin.java
+++ b/src/main/java/org/opensearch/geospatial/plugin/GeospatialPlugin.java
@@ -7,9 +7,22 @@
  */
 package org.opensearch.geospatial.plugin;
 
+import org.opensearch.common.collect.MapBuilder;
+import org.opensearch.geospatial.processor.FeatureProcessor;
+import org.opensearch.ingest.Processor;
+import org.opensearch.plugins.IngestPlugin;
 import org.opensearch.plugins.Plugin;
 
+import java.util.Map;
 
-public class GeospatialPlugin extends Plugin {
-    // Implement the relevant Plugin Interfaces here
+/*
+
+ */
+public class GeospatialPlugin extends Plugin implements IngestPlugin {
+    @Override
+    public Map<String, Processor.Factory> getProcessors(Processor.Parameters parameters) {
+        return MapBuilder.<String, Processor.Factory>newMapBuilder()
+            .put(FeatureProcessor.TYPE, new FeatureProcessor.Factory())
+            .immutableMap();
+    }
 }

--- a/src/main/java/org/opensearch/geospatial/processor/FeatureProcessor.java
+++ b/src/main/java/org/opensearch/geospatial/processor/FeatureProcessor.java
@@ -1,12 +1,6 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
- * The OpenSearch Contributors require contributions made to
- * this file be licensed under the Apache-2.0 license or a
- * compatible open source license.
- *
- * Modifications Copyright OpenSearch Contributors. See
- * GitHub history for details.
  */
 
 package org.opensearch.geospatial.processor;

--- a/src/main/java/org/opensearch/geospatial/processor/FeatureProcessor.java
+++ b/src/main/java/org/opensearch/geospatial/processor/FeatureProcessor.java
@@ -1,0 +1,70 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ *
+ * Modifications Copyright OpenSearch Contributors. See
+ * GitHub history for details.
+ */
+
+package org.opensearch.geospatial.processor;
+
+import org.opensearch.geospatial.geojson.Feature;
+import org.opensearch.geospatial.geojson.FeatureFactory;
+import org.opensearch.ingest.AbstractProcessor;
+import org.opensearch.ingest.IngestDocument;
+import org.opensearch.ingest.Processor;
+
+import java.util.Map;
+
+import static org.opensearch.ingest.ConfigurationUtils.readStringProperty;
+
+/**
+ * {@link FeatureProcessor} converts GeoJSON Feature into a document by extracting properties as its own field,
+ * move GeoJSON Geometry object into OpenSearch geo_shape field, and, remove fields like "type"
+ */
+public class FeatureProcessor extends AbstractProcessor {
+
+    public static final String FIELD_KEY = "field";
+    public static final String TYPE = "geojson-feature";
+    private final String geoShapeField;
+
+    public FeatureProcessor(String tag, String description, String geoShapeField) {
+        super(tag, description);
+        this.geoShapeField = geoShapeField;
+    }
+
+
+    @Override
+    public IngestDocument execute(IngestDocument ingestDocument) {
+        // 1. Create Feature from ingesting document
+        // 2. Remove field "type", since, we are not storing as geo-json
+        // 3. Move properties.* as document's fields, since, we don't have to group it inside "properties"
+        // 5. Move geojson's geometry object to geoshape field.
+        Feature feature = FeatureFactory.create(ingestDocument.getSourceAndMetadata());
+        ingestDocument.removeField(Feature.TYPE_KEY);
+        feature.getProperties().forEach((k, v) -> ingestDocument.setFieldValue(k, v));
+        if (ingestDocument.hasField(Feature.PROPERTIES_KEY)) { // properties are optional in Feature
+            ingestDocument.removeField(Feature.PROPERTIES_KEY);
+        }
+        ingestDocument.setFieldValue(this.geoShapeField, feature.getGeometry());
+        ingestDocument.removeField(Feature.GEOMETRY_KEY);
+        return ingestDocument;
+    }
+
+    @Override
+    public String getType() {
+        return TYPE;
+    }
+
+    public static final class Factory implements org.opensearch.ingest.Processor.Factory {
+        @Override
+        public FeatureProcessor create(Map<String, Processor.Factory> registry, String processorTag,
+                                       String description, Map<String, Object> config) {
+            String geoShapeField = readStringProperty(TYPE, processorTag, config, FIELD_KEY);
+            return new FeatureProcessor(processorTag, description, geoShapeField);
+        }
+    }
+}

--- a/src/test/java/org/opensearch/geospatial/GeospatialRestTestCase.java
+++ b/src/test/java/org/opensearch/geospatial/GeospatialRestTestCase.java
@@ -1,12 +1,6 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
- * The OpenSearch Contributors require contributions made to
- * this file be licensed under the Apache-2.0 license or a
- * compatible open source license.
- *
- * Modifications Copyright OpenSearch Contributors. See
- * GitHub history for details.
  */
 
 package org.opensearch.geospatial;

--- a/src/test/java/org/opensearch/geospatial/GeospatialRestTestCase.java
+++ b/src/test/java/org/opensearch/geospatial/GeospatialRestTestCase.java
@@ -1,0 +1,130 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ *
+ * Modifications Copyright OpenSearch Contributors. See
+ * GitHub history for details.
+ */
+
+package org.opensearch.geospatial;
+
+import org.apache.http.util.EntityUtils;
+import org.opensearch.client.Request;
+import org.opensearch.client.Response;
+import org.opensearch.common.Strings;
+import org.opensearch.common.settings.Settings;
+import org.opensearch.common.xcontent.XContentBuilder;
+import org.opensearch.common.xcontent.XContentFactory;
+import org.opensearch.common.xcontent.XContentType;
+import org.opensearch.geospatial.geojson.Feature;
+import org.opensearch.geospatial.processor.FeatureProcessor;
+import org.opensearch.ingest.Pipeline;
+import org.opensearch.test.rest.OpenSearchRestTestCase;
+
+import java.io.IOException;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+
+import static java.util.stream.Collectors.joining;
+
+public abstract class GeospatialRestTestCase extends OpenSearchRestTestCase {
+
+    public static final String SOURCE = "_source";
+    public static final String DOC = "_doc";
+    public static final String URL_DELIMITER = "/";
+    public static final String GEOMETRY_TYPE_KEY = "type";
+    public static final String GEOMETRY_COORDINATES_KEY = "coordinates";
+
+    private static String buildPipelinePath(String name) {
+        return String.join(URL_DELIMITER, "_ingest", "pipeline", name);
+    }
+
+    protected static void createPipeline(String name, Optional<String> description, List<Map<String, Object>> processorConfigs) throws IOException {
+        XContentBuilder builder = XContentFactory.jsonBuilder().startObject();
+        if (description.isPresent()) {
+            builder.field(Pipeline.DESCRIPTION_KEY, description.get());
+        }
+        if (processorConfigs != null && !processorConfigs.isEmpty()) {
+            builder.field(Pipeline.PROCESSORS_KEY, processorConfigs);
+        }
+        builder.endObject();
+
+        Request request = new Request("PUT", buildPipelinePath(name));
+        request.setJsonEntity(Strings.toString(builder));
+        client().performRequest(request);
+    }
+
+    protected static void deletePipeline(String name) throws IOException {
+        Request request = new Request("DELETE", buildPipelinePath(name));
+        client().performRequest(request);
+    }
+
+    protected static void createIndex(String name, Settings settings, Map<String, String> fieldMap) throws IOException {
+        XContentBuilder xContentBuilder = XContentFactory.jsonBuilder().startObject().startObject(Feature.PROPERTIES_KEY);
+        for (Map.Entry<String, String> entry : fieldMap.entrySet()) {
+            xContentBuilder.startObject(entry.getKey())
+                .field(Feature.TYPE_KEY, entry.getValue())
+                .endObject();
+        }
+        xContentBuilder.endObject().endObject();
+        String mapping = Strings.toString(xContentBuilder);
+        createIndex(name, settings, mapping.substring(1, mapping.length() - 1));
+    }
+
+    public static void indexDocument(String indexName, String docID, String body, Map<String, String> params) throws IOException {
+
+        String path = String.join(URL_DELIMITER, indexName, DOC, docID);
+        String queryParams = params.entrySet().stream()
+            .map(Object::toString)
+            .collect(joining("&"));
+        StringBuilder endpoint = new StringBuilder();
+        endpoint.append(path);
+        endpoint.append("?");
+        endpoint.append(queryParams);
+
+        Request request = new Request("PUT", endpoint.toString());
+        request.setJsonEntity(body);
+        client().performRequest(request);
+    }
+
+    protected Map<String, Object> buildGeoJSONProcessorConfig(Map<String, String> properties) {
+        Map<String, Object> geoJSONProcessor = new HashMap<>();
+        geoJSONProcessor.put(FeatureProcessor.TYPE, properties);
+        return geoJSONProcessor;
+    }
+
+    public String buildGeoJSONFeatureAsString(String type, Object value, Map<String, Object> properties) throws IOException {
+
+        XContentBuilder builder = XContentFactory.jsonBuilder().startObject()
+            .field(Feature.TYPE_KEY, Feature.TYPE)
+            .startObject(Feature.GEOMETRY_KEY)
+            .field(GEOMETRY_TYPE_KEY, type)
+            .field(GEOMETRY_COORDINATES_KEY, value)
+            .endObject();
+        builder.startObject(Feature.PROPERTIES_KEY);
+        for (Map.Entry<String, Object> entry : properties.entrySet()) {
+            builder.field(entry.getKey(), entry.getValue());
+        }
+        builder.endObject().endObject();
+        return Strings.toString(builder);
+    }
+
+    public Map<String, Object> getDocument(String docID, String indexName) throws IOException {
+        String path = String.join(URL_DELIMITER, indexName, DOC, docID);
+        final Request request = new Request("GET", path);
+        final Response response = client().performRequest(request);
+
+        final Map<String, Object> responseMap =
+            createParser(XContentType.JSON.xContent(), EntityUtils.toString(response.getEntity())).map();
+        if (!responseMap.containsKey(SOURCE)) {
+            return null;
+        }
+        final Map<String, Object> docMap = (Map<String, Object>) responseMap.get(SOURCE);
+        return docMap;
+    }
+}

--- a/src/test/java/org/opensearch/geospatial/plugin/GeospatialPluginIT.java
+++ b/src/test/java/org/opensearch/geospatial/plugin/GeospatialPluginIT.java
@@ -1,10 +1,8 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
- * The OpenSearch Contributors require contributions made to
- * this file be licensed under the Apache-2.0 license or a
- * compatible open source license.
  */
+
 package org.opensearch.geospatial.plugin;
 
 import org.apache.http.util.EntityUtils;

--- a/src/test/java/org/opensearch/geospatial/plugin/GeospatialPluginIT.java
+++ b/src/test/java/org/opensearch/geospatial/plugin/GeospatialPluginIT.java
@@ -15,9 +15,13 @@ import org.opensearch.test.rest.OpenSearchRestTestCase;
 
 import java.io.IOException;
 
-
 public class GeospatialPluginIT extends OpenSearchRestTestCase {
 
+    /**
+     * Tests whether plugin is installed or not
+     *
+     * @throws IOException
+     */
     public void testPluginInstalled() throws IOException {
         String restURI = String.join("/", "_cat", "plugins");
 

--- a/src/test/java/org/opensearch/geospatial/plugin/GeospatialTests.java
+++ b/src/test/java/org/opensearch/geospatial/plugin/GeospatialTests.java
@@ -1,10 +1,8 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
- * The OpenSearch Contributors require contributions made to
- * this file be licensed under the Apache-2.0 license or a
- * compatible open source license.
  */
+
 package org.opensearch.geospatial.plugin;
 
 import org.opensearch.test.OpenSearchTestCase;

--- a/src/test/java/org/opensearch/geospatial/processor/FeatureProcessorIT.java
+++ b/src/test/java/org/opensearch/geospatial/processor/FeatureProcessorIT.java
@@ -1,12 +1,6 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
- * The OpenSearch Contributors require contributions made to
- * this file be licensed under the Apache-2.0 license or a
- * compatible open source license.
- *
- * Modifications Copyright OpenSearch Contributors. See
- * GitHub history for details.
  */
 
 package org.opensearch.geospatial.processor;

--- a/src/test/java/org/opensearch/geospatial/processor/FeatureProcessorIT.java
+++ b/src/test/java/org/opensearch/geospatial/processor/FeatureProcessorIT.java
@@ -1,0 +1,107 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ *
+ * Modifications Copyright OpenSearch Contributors. See
+ * GitHub history for details.
+ */
+
+package org.opensearch.geospatial.processor;
+
+import org.apache.http.util.EntityUtils;
+import org.opensearch.client.Request;
+import org.opensearch.client.Response;
+import org.opensearch.common.geo.GeoShapeType;
+import org.opensearch.common.settings.Settings;
+import org.opensearch.geospatial.GeospatialRestTestCase;
+import org.opensearch.rest.RestStatus;
+
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Locale;
+import java.util.Map;
+import java.util.Optional;
+
+import static org.opensearch.ingest.RandomDocumentPicks.randomString;
+
+public class FeatureProcessorIT extends GeospatialRestTestCase {
+
+    public static final int LINESTRING_TOTAL_POINTS = 4;
+    public static final int LINESTRING_POINT_DIMENSION = 2;
+
+    private double[][] randomDoubleArray(int row, int col) {
+        double[][] randomArray = new double[row][col];
+        for (int i = 0; i < row; i++) {
+            for (int j = 0; j < col; j++) {
+                randomArray[i][j] = randomDouble();
+            }
+        }
+        return randomArray;
+    }
+
+    public void testProcessorAvailable() throws IOException {
+        String nodeIngestURL = String.join("/", "_nodes", "ingest");
+        String endpoint = nodeIngestURL + "?filter_path=nodes.*.ingest.processors&pretty";
+        Request request = new Request("GET", endpoint);
+        Response response = client().performRequest(request);
+        assertEquals(RestStatus.OK, RestStatus.fromCode(response.getStatusLine().getStatusCode()));
+
+        String responseBody = EntityUtils.toString(response.getEntity());
+        assertNotNull(responseBody);
+        assertTrue(responseBody.contains(FeatureProcessor.TYPE));
+    }
+
+    public void testIndexGeoJSONSuccess() throws IOException {
+
+        String indexName = randomString(random()).toLowerCase(Locale.getDefault());
+        String geoShapeField = randomString(random());
+        String pipelineName = randomString(random());
+
+        Map<String, String> geoFields = new HashMap<>();
+        geoFields.put(geoShapeField, "geo_shape");
+
+
+        Map<String, String> processorProperties = new HashMap<>();
+        processorProperties.put(FeatureProcessor.FIELD_KEY, geoShapeField);
+        Map<String, Object> geoJSONProcessorConfig = buildGeoJSONProcessorConfig(processorProperties);
+        List<Map<String, Object>> configs = new ArrayList<>();
+        configs.add(geoJSONProcessorConfig);
+
+        createPipeline(pipelineName, Optional.empty(), configs);
+
+        createIndex(indexName, Settings.EMPTY, geoFields);
+
+        Map<String, Object> properties = new HashMap<>();
+        properties.put(randomString(random()), randomString(random()));
+        properties.put(randomString(random()), randomString(random()));
+
+
+        String body = buildGeoJSONFeatureAsString(
+            GeoShapeType.LINESTRING.shapeName(),
+            randomDoubleArray(LINESTRING_TOTAL_POINTS, LINESTRING_POINT_DIMENSION), properties);
+        Map<String, String> params = new HashMap<>();
+        params.put("pipeline", pipelineName);
+
+        String docID = randomString(random());
+        indexDocument(indexName, docID, body, params);
+
+        Map<String, Object> document = getDocument(docID, indexName);
+        assertNotNull(document);
+
+        for (Map.Entry<String, Object> property : properties.entrySet()) {
+            assertEquals(document.get(property.getKey()), property.getValue());
+        }
+
+        Map<String, Object> geoShapeFieldValue = (Map<String, Object>) document.get(geoShapeField);
+        assertEquals(geoShapeFieldValue.get(GEOMETRY_TYPE_KEY), GeoShapeType.LINESTRING.shapeName());
+
+        deletePipeline(pipelineName);
+        deleteIndex(indexName);
+
+    }
+}

--- a/src/test/java/org/opensearch/geospatial/processor/FeatureProcessorTests.java
+++ b/src/test/java/org/opensearch/geospatial/processor/FeatureProcessorTests.java
@@ -1,12 +1,6 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
- * The OpenSearch Contributors require contributions made to
- * this file be licensed under the Apache-2.0 license or a
- * compatible open source license.
- *
- * Modifications Copyright OpenSearch Contributors. See
- * GitHub history for details.
  */
 
 package org.opensearch.geospatial.processor;

--- a/src/test/java/org/opensearch/geospatial/processor/FeatureProcessorTests.java
+++ b/src/test/java/org/opensearch/geospatial/processor/FeatureProcessorTests.java
@@ -1,0 +1,75 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ *
+ * Modifications Copyright OpenSearch Contributors. See
+ * GitHub history for details.
+ */
+
+package org.opensearch.geospatial.processor;
+
+import org.opensearch.common.geo.GeoShapeType;
+import org.opensearch.geospatial.geojson.Feature;
+import org.opensearch.ingest.IngestDocument;
+import org.opensearch.ingest.RandomDocumentPicks;
+import org.opensearch.test.OpenSearchTestCase;
+
+import java.util.HashMap;
+import java.util.Map;
+
+import static org.opensearch.geospatial.GeospatialRestTestCase.GEOMETRY_COORDINATES_KEY;
+import static org.opensearch.geospatial.GeospatialRestTestCase.GEOMETRY_TYPE_KEY;
+
+public class FeatureProcessorTests extends OpenSearchTestCase {
+
+    private Map<String, Object> buildGeoJSON(String type) {
+        Map<String, Object> geoJSON = new HashMap<>();
+        geoJSON.put(Feature.TYPE_KEY, type);
+
+        Map<String, Object> properties = new HashMap<>();
+        properties.put("name", "Dinagat Islands");
+        geoJSON.put("properties", properties);
+
+        Map<String, Object> geometry = new HashMap<>();
+        geometry.put(GEOMETRY_TYPE_KEY, GeoShapeType.POINT.shapeName());
+        geometry.put(GEOMETRY_COORDINATES_KEY, "[125.6, 10.1]");
+        geoJSON.put(Feature.GEOMETRY_KEY, geometry);
+
+        return geoJSON;
+
+    }
+
+    public void testGeoJSONProcessorSuccess() {
+        Map<String, Object> document = buildGeoJSON(Feature.TYPE);
+        IngestDocument ingestDocument = RandomDocumentPicks.randomIngestDocument(random(), document);
+        FeatureProcessor processor = new FeatureProcessor("sample", "description", "location");
+        processor.execute(ingestDocument);
+        Map<String, Object> location = (Map<String, Object>) ingestDocument.getFieldValue("location", Object.class);
+        assertNotNull(location);
+        assertEquals(document.get(Feature.GEOMETRY_KEY), location);
+        assertEquals("Dinagat Islands", ingestDocument.getSourceAndMetadata().get("name"));
+        assertNull(ingestDocument.getSourceAndMetadata().get(Feature.GEOMETRY_KEY));
+        assertNull(ingestDocument.getSourceAndMetadata().get(Feature.TYPE_KEY));
+        assertNull(ingestDocument.getSourceAndMetadata().get(Feature.PROPERTIES_KEY));
+    }
+
+    public void testGeoJSONProcessorUnSupportedType() {
+        Map<String, Object> document = buildGeoJSON("FeatureCollection");
+        IngestDocument ingestDocument = RandomDocumentPicks.randomIngestDocument(random(), document);
+        FeatureProcessor processor = new FeatureProcessor("sample", "description", "location");
+        IllegalArgumentException exception = assertThrows(IllegalArgumentException.class, () -> processor.execute(ingestDocument));
+        assertTrue(exception.getMessage().contains("Only type Feature is supported"));
+    }
+
+    public void testGeoJSONProcessorTypeNotFound() {
+        Map<String, Object> document = buildGeoJSON(Feature.TYPE);
+        document.remove(Feature.TYPE_KEY);
+        IngestDocument ingestDocument = RandomDocumentPicks.randomIngestDocument(random(), document);
+        FeatureProcessor processor = new FeatureProcessor("sample", "description", "location");
+        IllegalArgumentException exception = assertThrows(IllegalArgumentException.class, () -> processor.execute(ingestDocument));
+        assertTrue(exception.getMessage().contains("type cannot be null"));
+    }
+}

--- a/src/yamlRestTest/java/org/opensearch/geospatial/plugin/GeospatialClientYamlTestSuiteIT.java
+++ b/src/yamlRestTest/java/org/opensearch/geospatial/plugin/GeospatialClientYamlTestSuiteIT.java
@@ -1,10 +1,8 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
- * The OpenSearch Contributors require contributions made to
- * this file be licensed under the Apache-2.0 license or a
- * compatible open source license.
  */
+
 package org.opensearch.geospatial.plugin;
 
 import com.carrotsearch.randomizedtesting.annotations.Name;


### PR DESCRIPTION
### Description
Added new Processor of type geojson-feature to intercept GeoJSON Feature and convert into typical OpenSearch document.
Example: A GeoJSON object of type “Feature”, contains geometry object of type “LineString”. 
```
{
    "type": "Feature",
    "geometry": {
        "type": "LineString",
        "coordinates": [
            [102.0, 0.0],
            [103.0, 1.0],
            [104.0, 0.0],
            [105.0, 1.0]
        ]
    },
    "properties": {
        "key0": "value0",
        "key1": "value1",
        "key2": "value2"
    }
}
```
The above feature can be converted to typical document for an index which has "location" as type geo_shape, by FeatureProcessor.

```
{
    "location": {
        "type": "LineString",
        "coordinates": [
            [102.0, 0.0],
            [103.0, 1.0],
            [104.0, 0.0],
            [105.0, 1.0]
        ]
    },
     "key0": "value0",
     "key1": "value1",
     "key2": "value2"
}
```

This processor converts Geometry Object into geo_shape field value, removes GeoJSON metadata like type, and convert properties into direct fields.
 
### Check List
- [x] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
