### PR TITLE
Add spotless to project

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -55,8 +55,10 @@ buildscript {
 
     dependencies {
         classpath "${opensearch_group}.gradle:build-tools:${opensearch_version}"
+        classpath "com.diffplug.spotless:spotless-plugin-gradle:5.6.1"
     }
 }
+apply plugin: "com.diffplug.spotless"
 
 ext {
     isSnapshot = "true" == System.getProperty("build.snapshot", "true")
@@ -126,4 +128,12 @@ run {
 
 tasks.withType(RestIntegTestTask)*.configure {
     classpath += files(project.configurations.runtimeClasspath.findAll { it.name.contains("log4j-core") })
+}
+
+spotless {
+    java {
+        removeUnusedImports()
+        importOrder 'java', 'javax', 'org', 'com'
+        endWithNewline()
+    }
 }

--- a/src/main/java/org/opensearch/geospatial/geojson/FeatureFactory.java
+++ b/src/main/java/org/opensearch/geospatial/geojson/FeatureFactory.java
@@ -6,10 +6,10 @@
 package org.opensearch.geospatial.geojson;
 
 
-import org.opensearch.geospatial.geojson.Feature.FeatureBuilder;
-
 import java.util.HashMap;
 import java.util.Map;
+
+import org.opensearch.geospatial.geojson.Feature.FeatureBuilder;
 
 /**
  * FeatureFactory helps to create {@link Feature} instance based on user input

--- a/src/main/java/org/opensearch/geospatial/plugin/GeospatialPlugin.java
+++ b/src/main/java/org/opensearch/geospatial/plugin/GeospatialPlugin.java
@@ -5,13 +5,13 @@
 
 package org.opensearch.geospatial.plugin;
 
+import java.util.Map;
+
 import org.opensearch.common.collect.MapBuilder;
 import org.opensearch.geospatial.processor.FeatureProcessor;
 import org.opensearch.ingest.Processor;
 import org.opensearch.plugins.IngestPlugin;
 import org.opensearch.plugins.Plugin;
-
-import java.util.Map;
 
 /*
 

--- a/src/main/java/org/opensearch/geospatial/processor/FeatureProcessor.java
+++ b/src/main/java/org/opensearch/geospatial/processor/FeatureProcessor.java
@@ -5,15 +5,15 @@
 
 package org.opensearch.geospatial.processor;
 
+import static org.opensearch.ingest.ConfigurationUtils.readStringProperty;
+
+import java.util.Map;
+
 import org.opensearch.geospatial.geojson.Feature;
 import org.opensearch.geospatial.geojson.FeatureFactory;
 import org.opensearch.ingest.AbstractProcessor;
 import org.opensearch.ingest.IngestDocument;
 import org.opensearch.ingest.Processor;
-
-import java.util.Map;
-
-import static org.opensearch.ingest.ConfigurationUtils.readStringProperty;
 
 /**
  * {@link FeatureProcessor} converts GeoJSON Feature into a document by extracting properties as its own field,

--- a/src/test/java/org/opensearch/geospatial/GeospatialRestTestCase.java
+++ b/src/test/java/org/opensearch/geospatial/GeospatialRestTestCase.java
@@ -5,6 +5,14 @@
 
 package org.opensearch.geospatial;
 
+import static java.util.stream.Collectors.joining;
+
+import java.io.IOException;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+
 import org.apache.http.util.EntityUtils;
 import org.opensearch.client.Request;
 import org.opensearch.client.Response;
@@ -17,14 +25,6 @@ import org.opensearch.geospatial.geojson.Feature;
 import org.opensearch.geospatial.processor.FeatureProcessor;
 import org.opensearch.ingest.Pipeline;
 import org.opensearch.test.rest.OpenSearchRestTestCase;
-
-import java.io.IOException;
-import java.util.HashMap;
-import java.util.List;
-import java.util.Map;
-import java.util.Optional;
-
-import static java.util.stream.Collectors.joining;
 
 public abstract class GeospatialRestTestCase extends OpenSearchRestTestCase {
 

--- a/src/test/java/org/opensearch/geospatial/plugin/GeospatialPluginIT.java
+++ b/src/test/java/org/opensearch/geospatial/plugin/GeospatialPluginIT.java
@@ -5,13 +5,13 @@
 
 package org.opensearch.geospatial.plugin;
 
+import java.io.IOException;
+
 import org.apache.http.util.EntityUtils;
 import org.opensearch.client.Request;
 import org.opensearch.client.Response;
 import org.opensearch.rest.RestStatus;
 import org.opensearch.test.rest.OpenSearchRestTestCase;
-
-import java.io.IOException;
 
 public class GeospatialPluginIT extends OpenSearchRestTestCase {
 

--- a/src/test/java/org/opensearch/geospatial/processor/FeatureProcessorIT.java
+++ b/src/test/java/org/opensearch/geospatial/processor/FeatureProcessorIT.java
@@ -5,13 +5,7 @@
 
 package org.opensearch.geospatial.processor;
 
-import org.apache.http.util.EntityUtils;
-import org.opensearch.client.Request;
-import org.opensearch.client.Response;
-import org.opensearch.common.geo.GeoShapeType;
-import org.opensearch.common.settings.Settings;
-import org.opensearch.geospatial.GeospatialRestTestCase;
-import org.opensearch.rest.RestStatus;
+import static org.opensearch.ingest.RandomDocumentPicks.randomString;
 
 import java.io.IOException;
 import java.util.ArrayList;
@@ -21,7 +15,13 @@ import java.util.Locale;
 import java.util.Map;
 import java.util.Optional;
 
-import static org.opensearch.ingest.RandomDocumentPicks.randomString;
+import org.apache.http.util.EntityUtils;
+import org.opensearch.client.Request;
+import org.opensearch.client.Response;
+import org.opensearch.common.geo.GeoShapeType;
+import org.opensearch.common.settings.Settings;
+import org.opensearch.geospatial.GeospatialRestTestCase;
+import org.opensearch.rest.RestStatus;
 
 public class FeatureProcessorIT extends GeospatialRestTestCase {
 

--- a/src/test/java/org/opensearch/geospatial/processor/FeatureProcessorTests.java
+++ b/src/test/java/org/opensearch/geospatial/processor/FeatureProcessorTests.java
@@ -5,17 +5,17 @@
 
 package org.opensearch.geospatial.processor;
 
+import static org.opensearch.geospatial.GeospatialRestTestCase.GEOMETRY_COORDINATES_KEY;
+import static org.opensearch.geospatial.GeospatialRestTestCase.GEOMETRY_TYPE_KEY;
+
+import java.util.HashMap;
+import java.util.Map;
+
 import org.opensearch.common.geo.GeoShapeType;
 import org.opensearch.geospatial.geojson.Feature;
 import org.opensearch.ingest.IngestDocument;
 import org.opensearch.ingest.RandomDocumentPicks;
 import org.opensearch.test.OpenSearchTestCase;
-
-import java.util.HashMap;
-import java.util.Map;
-
-import static org.opensearch.geospatial.GeospatialRestTestCase.GEOMETRY_COORDINATES_KEY;
-import static org.opensearch.geospatial.GeospatialRestTestCase.GEOMETRY_TYPE_KEY;
 
 public class FeatureProcessorTests extends OpenSearchTestCase {
 

--- a/src/yamlRestTest/java/org/opensearch/geospatial/plugin/GeospatialClientYamlTestSuiteIT.java
+++ b/src/yamlRestTest/java/org/opensearch/geospatial/plugin/GeospatialClientYamlTestSuiteIT.java
@@ -5,10 +5,11 @@
 
 package org.opensearch.geospatial.plugin;
 
-import com.carrotsearch.randomizedtesting.annotations.Name;
-import com.carrotsearch.randomizedtesting.annotations.ParametersFactory;
 import org.opensearch.test.rest.yaml.ClientYamlTestCandidate;
 import org.opensearch.test.rest.yaml.OpenSearchClientYamlSuiteTestCase;
+
+import com.carrotsearch.randomizedtesting.annotations.Name;
+import com.carrotsearch.randomizedtesting.annotations.ParametersFactory;
 
 
 public class GeospatialClientYamlTestSuiteIT extends OpenSearchClientYamlSuiteTestCase {


### PR DESCRIPTION
Signed-off-by: Vijayan Balasubramanian <balasvij@amazon.com>

### Description
* Add spotless and fix import order error. 
* By default, spotlessCheck will be executed during `./gradlew build` and report error if it does't follow expected formatting. In order to fix those formatting errors, developers can run `./gradlew :spotlessApply`. This will format all java files, but, it is the responsibility of the developers to run this command before creating PR, else, build will fail.
  
### Check List
- [x] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
