### PR TITLE
Adding JDK 11 to CI matrix

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -11,7 +11,7 @@ jobs:
   Build:
     strategy:
       matrix:
-        java: [14]
+        java: [11, 14]
 
     name: Build and Test geospatial Plugin
     runs-on: ubuntu-latest


### PR DESCRIPTION
Signed-off-by: Vijayan Balasubramanian <balasvij@amazon.com>

### Description
OpenSearch has lowered the JDK to 11, hence, include this
in CI matrix.

 
### Check List
- [x] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
