### PR TITLE
Create UploadGeoJSONRequest content as an object

### DIFF
--- a/src/main/java/org/opensearch/geospatial/GeospatialParser.java
+++ b/src/main/java/org/opensearch/geospatial/GeospatialParser.java
@@ -7,19 +7,24 @@ package org.opensearch.geospatial;
 
 import java.util.HashMap;
 import java.util.Map;
+import java.util.Objects;
+
+import org.opensearch.common.bytes.BytesReference;
+import org.opensearch.common.xcontent.XContentHelper;
+import org.opensearch.common.xcontent.XContentType;
 
 /**
  * GeospatialParser provides helper methods to parse/extract/transform input to
  * desired formats.
  */
-public class GeospatialParser {
+public final class GeospatialParser {
 
     /**
      * Convert object into Map
      * @param input Object that is also an instance of Map
      * @return input object in Map type
      */
-    public static Map<String, Object> toStringObjectMap(Object input) {
+    public static Map<String, Object> toStringObjectMap(final Object input) {
         if (!(input instanceof Map)) {
             throw new IllegalArgumentException(input + " is not an instance of Map, but of type [ " + input.getClass().getName() + " ]");
         }
@@ -29,5 +34,35 @@ public class GeospatialParser {
             stringObjectMap.put(entry.getKey().toString(), entry.getValue());
         }
         return stringObjectMap;
+    }
+
+    /**
+     * User inputs are usually deserialized into Map. extractValueAsString will help caller to
+     * extract value from the Map and cast it to string with validation.
+     * @param input User input of type Map
+     * @param key property we would like to extract value of
+     * @return null if key doesn't exist, value as String if it exists, throw exception otherwise
+     */
+    public static String extractValueAsString(final Map<String, Object> input, final String key) {
+        Objects.requireNonNull(key);
+        Objects.requireNonNull(input);
+        Object value = input.get(key);
+        if (value == null) {
+            return null;
+        }
+        if (!(value instanceof String)) {
+            throw new IllegalArgumentException(value + " is not an instance of String, but of type [ " + value.getClass().getName() + " ]");
+        }
+        return value.toString();
+    }
+
+    /**
+     * Converts JSON Content from BytesReference to Map
+     * @param content JSON Content abstracted as BytesRefernce mostly by REST Interface
+     * @return JSON Content as Map
+     */
+    public static Map<String, Object> convertToMap(BytesReference content) {
+        Objects.requireNonNull(content);
+        return XContentHelper.convertToMap(content, false, XContentType.JSON).v2();
     }
 }

--- a/src/main/java/org/opensearch/geospatial/GeospatialParser.java
+++ b/src/main/java/org/opensearch/geospatial/GeospatialParser.java
@@ -39,13 +39,13 @@ public final class GeospatialParser {
     /**
      * User inputs are usually deserialized into Map. extractValueAsString will help caller to
      * extract value from the Map and cast it to string with validation.
-     * @param input User input of type Map
-     * @param key property we would like to extract value of
+     * @param input User input of type Map, cannot be null
+     * @param key property we would like to extract value of, cannot be null
      * @return null if key doesn't exist, value as String if it exists, throw exception otherwise
      */
     public static String extractValueAsString(final Map<String, Object> input, final String key) {
-        Objects.requireNonNull(key);
-        Objects.requireNonNull(input);
+        Objects.requireNonNull(key, "parameter 'key' cannot be null");
+        Objects.requireNonNull(input, "parameter 'input' cannot be null");
         Object value = input.get(key);
         if (value == null) {
             return null;

--- a/src/main/java/org/opensearch/geospatial/action/upload/geojson/UploadGeoJSONRequest.java
+++ b/src/main/java/org/opensearch/geospatial/action/upload/geojson/UploadGeoJSONRequest.java
@@ -12,7 +12,6 @@
 package org.opensearch.geospatial.action.upload.geojson;
 
 import java.io.IOException;
-import java.util.Map;
 import java.util.Objects;
 
 import org.opensearch.action.ActionRequest;
@@ -20,8 +19,6 @@ import org.opensearch.action.ActionRequestValidationException;
 import org.opensearch.common.bytes.BytesReference;
 import org.opensearch.common.io.stream.StreamInput;
 import org.opensearch.common.io.stream.StreamOutput;
-import org.opensearch.common.xcontent.XContentHelper;
-import org.opensearch.common.xcontent.XContentType;
 
 public class UploadGeoJSONRequest extends ActionRequest {
 
@@ -38,10 +35,6 @@ public class UploadGeoJSONRequest extends ActionRequest {
 
     public BytesReference getContent() {
         return content;
-    }
-
-    public Map<String, Object> contentAsMap() {
-        return XContentHelper.convertToMap(content, false, XContentType.JSON).v2();
     }
 
     @Override

--- a/src/main/java/org/opensearch/geospatial/action/upload/geojson/UploadGeoJSONRequestContent.java
+++ b/src/main/java/org/opensearch/geospatial/action/upload/geojson/UploadGeoJSONRequestContent.java
@@ -5,13 +5,17 @@
 
 package org.opensearch.geospatial.action.upload.geojson;
 
-import static java.util.Objects.requireNonNull;
 import static org.opensearch.geospatial.GeospatialParser.extractValueAsString;
 
 import java.util.Map;
+import java.util.Objects;
 
 import org.opensearch.common.ParseField;
+import org.opensearch.common.Strings;
 
+/**
+ * UploadGeoJSONRequestContent is the Data model for UploadGeoJSONRequest's body
+ */
 public final class UploadGeoJSONRequestContent {
 
     public static final ParseField FIELD_INDEX = new ParseField("index", new String[0]);
@@ -22,15 +26,26 @@ public final class UploadGeoJSONRequestContent {
     private final Object data;
 
     private UploadGeoJSONRequestContent(String indexName, String geospatialFieldName, Object data) {
-        this.indexName = requireNonNull(indexName);
-        this.geospatialFieldName = requireNonNull(geospatialFieldName);
-        this.data = requireNonNull(data);
+        this.indexName = indexName;
+        this.geospatialFieldName = geospatialFieldName;
+        this.data = data;
     }
 
     public static UploadGeoJSONRequestContent create(Map<String, Object> input) {
+        Objects.requireNonNull(input, "input cannot be null");
         String index = extractValueAsString(input, FIELD_INDEX.getPreferredName());
+        if (!Strings.hasText(index)) {
+            throw new IllegalArgumentException("field [ " + FIELD_INDEX.getPreferredName() + " ] cannot be empty");
+        }
         String geospatialField = extractValueAsString(input, FIELD_GEOSPATIAL.getPreferredName());
-        return new UploadGeoJSONRequestContent(index, geospatialField, input.get(FIELD_DATA.getPreferredName()));
+        if (!Strings.hasText(geospatialField)) {
+            throw new IllegalArgumentException("field [ " + FIELD_GEOSPATIAL.getPreferredName() + " ] cannot be empty");
+        }
+        Object geoJSONData = Objects.requireNonNull(
+            input.get(FIELD_DATA.getPreferredName()),
+            "field [ " + FIELD_DATA.getPreferredName() + " ] cannot be empty"
+        );
+        return new UploadGeoJSONRequestContent(index, geospatialField, geoJSONData);
     }
 
     public final String getIndexName() {

--- a/src/main/java/org/opensearch/geospatial/action/upload/geojson/UploadGeoJSONRequestContent.java
+++ b/src/main/java/org/opensearch/geospatial/action/upload/geojson/UploadGeoJSONRequestContent.java
@@ -1,0 +1,47 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package org.opensearch.geospatial.action.upload.geojson;
+
+import static java.util.Objects.requireNonNull;
+import static org.opensearch.geospatial.GeospatialParser.extractValueAsString;
+
+import java.util.Map;
+
+import org.opensearch.common.ParseField;
+
+public final class UploadGeoJSONRequestContent {
+
+    public static final ParseField FIELD_INDEX = new ParseField("index", new String[0]);
+    public static final ParseField FIELD_GEOSPATIAL = new ParseField("field", new String[0]);
+    public static final ParseField FIELD_DATA = new ParseField("data", new String[0]);
+    private final String indexName;
+    private final String geospatialFieldName;
+    private final Object data;
+
+    private UploadGeoJSONRequestContent(String indexName, String geospatialFieldName, Object data) {
+        this.indexName = requireNonNull(indexName);
+        this.geospatialFieldName = requireNonNull(geospatialFieldName);
+        this.data = requireNonNull(data);
+    }
+
+    public static UploadGeoJSONRequestContent create(Map<String, Object> input) {
+        String index = extractValueAsString(input, FIELD_INDEX.getPreferredName());
+        String geospatialField = extractValueAsString(input, FIELD_GEOSPATIAL.getPreferredName());
+        return new UploadGeoJSONRequestContent(index, geospatialField, input.get(FIELD_DATA.getPreferredName()));
+    }
+
+    public final String getIndexName() {
+        return indexName;
+    }
+
+    public final String getGeospatialFieldName() {
+        return geospatialFieldName;
+    }
+
+    public Object getData() {
+        return data;
+    }
+}

--- a/src/main/java/org/opensearch/geospatial/action/upload/geojson/UploadGeoJSONRequestContent.java
+++ b/src/main/java/org/opensearch/geospatial/action/upload/geojson/UploadGeoJSONRequestContent.java
@@ -20,43 +20,62 @@ public final class UploadGeoJSONRequestContent {
 
     public static final ParseField FIELD_INDEX = new ParseField("index", new String[0]);
     public static final ParseField FIELD_GEOSPATIAL = new ParseField("field", new String[0]);
+    public static final ParseField FIELD_GEOSPATIAL_TYPE = new ParseField("type", new String[0]);
     public static final ParseField FIELD_DATA = new ParseField("data", new String[0]);
     private final String indexName;
-    private final String geospatialFieldName;
+    private final String fieldName;
+    private final String fieldType;
     private final Object data;
 
-    private UploadGeoJSONRequestContent(String indexName, String geospatialFieldName, Object data) {
+    private UploadGeoJSONRequestContent(String indexName, String fieldName, String fieldType, Object data) {
         this.indexName = indexName;
-        this.geospatialFieldName = geospatialFieldName;
+        this.fieldName = fieldName;
+        this.fieldType = fieldType;
         this.data = data;
     }
 
+    /**
+     * Creates UploadGeoJSONRequestContent from the user input
+     * @param input user input of type Map
+     * @return UploadGeoJSONRequestContent based on value from input
+     * @throws NullPointerException if input is null
+     * @throws IllegalArgumentException if input doesn't have valid arguments
+     */
     public static UploadGeoJSONRequestContent create(Map<String, Object> input) {
         Objects.requireNonNull(input, "input cannot be null");
         String index = extractValueAsString(input, FIELD_INDEX.getPreferredName());
         if (!Strings.hasText(index)) {
             throw new IllegalArgumentException("field [ " + FIELD_INDEX.getPreferredName() + " ] cannot be empty");
         }
-        String geospatialField = extractValueAsString(input, FIELD_GEOSPATIAL.getPreferredName());
-        if (!Strings.hasText(geospatialField)) {
+        String fieldName = extractValueAsString(input, FIELD_GEOSPATIAL.getPreferredName());
+        if (!Strings.hasText(fieldName)) {
             throw new IllegalArgumentException("field [ " + FIELD_GEOSPATIAL.getPreferredName() + " ] cannot be empty");
         }
+        String fieldType = extractValueAsString(input, FIELD_GEOSPATIAL_TYPE.getPreferredName());
+        if (!Strings.hasText(fieldName)) {
+            throw new IllegalArgumentException("field [ " + FIELD_GEOSPATIAL_TYPE.getPreferredName() + " ] cannot be empty");
+        }
+
         Object geoJSONData = Objects.requireNonNull(
             input.get(FIELD_DATA.getPreferredName()),
             "field [ " + FIELD_DATA.getPreferredName() + " ] cannot be empty"
         );
-        return new UploadGeoJSONRequestContent(index, geospatialField, geoJSONData);
+        return new UploadGeoJSONRequestContent(index, fieldName, fieldType, geoJSONData);
     }
 
     public final String getIndexName() {
         return indexName;
     }
 
-    public final String getGeospatialFieldName() {
-        return geospatialFieldName;
+    public final String getFieldName() {
+        return fieldName;
     }
 
     public Object getData() {
         return data;
+    }
+
+    public String getFieldType() {
+        return fieldType;
     }
 }

--- a/src/main/java/org/opensearch/geospatial/action/upload/geojson/UploadGeoJSONTransportAction.java
+++ b/src/main/java/org/opensearch/geospatial/action/upload/geojson/UploadGeoJSONTransportAction.java
@@ -11,11 +11,14 @@
 
 package org.opensearch.geospatial.action.upload.geojson;
 
+import java.util.Map;
+
 import org.opensearch.action.ActionListener;
 import org.opensearch.action.support.ActionFilters;
 import org.opensearch.action.support.HandledTransportAction;
 import org.opensearch.action.support.master.AcknowledgedResponse;
 import org.opensearch.common.inject.Inject;
+import org.opensearch.geospatial.GeospatialParser;
 import org.opensearch.tasks.Task;
 import org.opensearch.transport.TransportService;
 
@@ -31,7 +34,15 @@ public class UploadGeoJSONTransportAction extends HandledTransportAction<UploadG
 
     @Override
     protected void doExecute(Task task, UploadGeoJSONRequest request, ActionListener<AcknowledgedResponse> actionListener) {
+        Map<String, Object> contentAsMap = GeospatialParser.convertToMap(request.getContent());
+        UploadGeoJSONRequestContent content = UploadGeoJSONRequestContent.create(contentAsMap);
         // TODO https://github.com/opensearch-project/geospatial/issues/28 (Add logic to execute import action)
+        // 1. get index name and geospatial field from content
+        // 2. create index with mapping
+        // 3. Parse Data to get GeoJSON Object
+        // 4. Get features from GeoJSON
+        // 5. create Pipeline with GeoJSONFeatureProcessor
+        // 6. Create BulkIndex Request with features as documents.
         actionListener.onResponse(new AcknowledgedResponse(true));
     }
 }

--- a/src/test/java/org/opensearch/geospatial/GeospatialObjectBuilder.java
+++ b/src/test/java/org/opensearch/geospatial/GeospatialObjectBuilder.java
@@ -21,6 +21,9 @@ public class GeospatialObjectBuilder {
 
     public static final String GEOMETRY_TYPE_KEY = "type";
     public static final String GEOMETRY_COORDINATES_KEY = "coordinates";
+    public static final int MIN_POSITIVE_VALUE = 1;
+    public static final int MAX_POINTS = 10;
+    public static final int MAX_DIMENSION = 4;
 
     public static JSONObject buildGeometry(String type, Object value) {
         JSONObject geometry = new JSONObject();

--- a/src/test/java/org/opensearch/geospatial/GeospatialObjectBuilder.java
+++ b/src/test/java/org/opensearch/geospatial/GeospatialObjectBuilder.java
@@ -10,8 +10,12 @@ import java.util.Random;
 
 import org.json.JSONObject;
 import org.opensearch.common.Randomness;
+import org.opensearch.common.collect.List;
 import org.opensearch.common.geo.GeoShapeType;
+import org.opensearch.geo.GeometryTestUtils;
 import org.opensearch.geospatial.geojson.Feature;
+
+import com.carrotsearch.randomizedtesting.generators.RandomPicks;
 
 /**
  * GeospatialObjectBuilder contains utility methods to generate geospatial objects
@@ -32,13 +36,13 @@ public class GeospatialObjectBuilder {
         return geometry;
     }
 
-    public static JSONObject getRandomGeometryPoint() {
+    public static JSONObject randomGeometryPoint() {
         Random random = Randomness.get();
         double[] point = new double[] { random.nextDouble(), random.nextDouble() };
         return buildGeometry(GeoShapeType.POINT.shapeName(), point);
     }
 
-    public static JSONObject getRandomGeometryLineString() {
+    public static JSONObject randomGeometryLineString() {
         int randomTotalPoints = randomPositiveInt(MAX_POINTS);
         int randomPointsDimension = randomPositiveInt(MAX_DIMENSION);
         double[][] lineString = new double[randomTotalPoints][randomPointsDimension];
@@ -49,8 +53,7 @@ public class GeospatialObjectBuilder {
     }
 
     private static double[] getRandomPoint() {
-        Random random = Randomness.get();
-        return new double[] { random.nextDouble(), random.nextDouble() };
+        return new double[] { GeometryTestUtils.randomLat(), GeometryTestUtils.randomLon() };
     }
 
     public static JSONObject buildGeoJSONFeature(JSONObject geometry, JSONObject properties) {
@@ -71,5 +74,13 @@ public class GeospatialObjectBuilder {
 
     public static int randomPositiveInt(int bound) {
         return Randomness.get().ints(MIN_POSITIVE_INTEGER_VALUE, bound).findFirst().getAsInt();
+    }
+
+    public static JSONObject randomGeoJSONFeature(final JSONObject properties) {
+        return buildGeoJSONFeature(randomGeoJSONGeometry(), properties);
+    }
+
+    public static JSONObject randomGeoJSONGeometry() {
+        return RandomPicks.randomFrom(Randomness.get(), List.of(randomGeometryLineString(), randomGeometryPoint()));
     }
 }

--- a/src/test/java/org/opensearch/geospatial/GeospatialObjectBuilder.java
+++ b/src/test/java/org/opensearch/geospatial/GeospatialObjectBuilder.java
@@ -21,9 +21,6 @@ public class GeospatialObjectBuilder {
 
     public static final String GEOMETRY_TYPE_KEY = "type";
     public static final String GEOMETRY_COORDINATES_KEY = "coordinates";
-    public static final int MIN_POSITIVE_VALUE = 1;
-    public static final int MAX_POINTS = 10;
-    public static final int MAX_DIMENSION = 4;
 
     public static JSONObject buildGeometry(String type, Object value) {
         JSONObject geometry = new JSONObject();

--- a/src/test/java/org/opensearch/geospatial/GeospatialObjectBuilder.java
+++ b/src/test/java/org/opensearch/geospatial/GeospatialObjectBuilder.java
@@ -21,6 +21,9 @@ public class GeospatialObjectBuilder {
 
     public static final String GEOMETRY_TYPE_KEY = "type";
     public static final String GEOMETRY_COORDINATES_KEY = "coordinates";
+    public static final int MIN_POSITIVE_INTEGER_VALUE = 1;
+    public static final int MAX_POINTS = 10;
+    public static final int MAX_DIMENSION = 4;
 
     public static JSONObject buildGeometry(String type, Object value) {
         JSONObject geometry = new JSONObject();
@@ -35,8 +38,10 @@ public class GeospatialObjectBuilder {
         return buildGeometry(GeoShapeType.POINT.shapeName(), point);
     }
 
-    public static JSONObject getRandomGeometryLineString(int totalPoints, int dimension) {
-        double[][] lineString = new double[totalPoints][dimension];
+    public static JSONObject getRandomGeometryLineString() {
+        int randomTotalPoints = randomPositiveInt(MAX_POINTS);
+        int randomPointsDimension = randomPositiveInt(MAX_DIMENSION);
+        double[][] lineString = new double[randomTotalPoints][randomPointsDimension];
         for (int i = 0; i < lineString.length; i++) {
             lineString[i] = getRandomPoint();
         }
@@ -62,5 +67,9 @@ public class GeospatialObjectBuilder {
             propertiesObject.put(entry.getKey(), entry.getValue());
         }
         return propertiesObject;
+    }
+
+    public static int randomPositiveInt(int bound) {
+        return Randomness.get().ints(MIN_POSITIVE_INTEGER_VALUE, bound).findFirst().getAsInt();
     }
 }

--- a/src/test/java/org/opensearch/geospatial/GeospatialParserTests.java
+++ b/src/test/java/org/opensearch/geospatial/GeospatialParserTests.java
@@ -1,19 +1,16 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
- * The OpenSearch Contributors require contributions made to
- * this file be licensed under the Apache-2.0 license or a
- * compatible open source license.
- *
- * Modifications Copyright OpenSearch Contributors. See
- * GitHub history for details.
  */
 
 package org.opensearch.geospatial;
 
+import java.nio.charset.StandardCharsets;
 import java.util.HashMap;
 import java.util.Map;
 
+import org.json.JSONObject;
+import org.opensearch.common.bytes.BytesArray;
 import org.opensearch.test.OpenSearchTestCase;
 
 public class GeospatialParserTests extends OpenSearchTestCase {
@@ -25,13 +22,53 @@ public class GeospatialParserTests extends OpenSearchTestCase {
         assertTrue(exception.getMessage().contains("is not an instance of Map"));
     }
 
-    public void testToStringObjectMap() {
+    private Map<String, Object> getStringObjectMap() {
         Map<String, Object> testData = new HashMap<>();
         testData.put("key1", 1);
         testData.put("key2", "two");
         testData.put("key3", new HashMap<>());
+        return testData;
+    }
 
+    public void testToStringObjectMap() {
+        Map<String, Object> testData = getStringObjectMap();
         Map<String, Object> stringObjectMap = GeospatialParser.toStringObjectMap(testData);
         assertEquals(testData, stringObjectMap);
     }
+
+    public void testExtractValueAsString() {
+        final Map<String, Object> testData = getStringObjectMap();
+        // assert invalid instance
+        {
+            IllegalArgumentException exception = assertThrows(
+                IllegalArgumentException.class,
+                () -> GeospatialParser.extractValueAsString(testData, "key1")
+            );
+            assertTrue(exception.getMessage().contains("is not an instance of String"));
+        }
+        // assert invalid input
+        {
+            assertThrows(java.lang.NullPointerException.class, () -> GeospatialParser.extractValueAsString(null, "key1"));
+            assertThrows(java.lang.NullPointerException.class, () -> GeospatialParser.extractValueAsString(testData, null));
+        }
+        // assert key doesn't exist
+        {
+            assertNull(GeospatialParser.extractValueAsString(testData, "invalid"));
+        }
+
+        // assert valid response
+        {
+            String expectedKey = "key2";
+            assertEquals(String.valueOf(testData.get(expectedKey)), GeospatialParser.extractValueAsString(testData, expectedKey));
+        }
+
+    }
+
+    public void testConvertToMap() {
+        JSONObject input = new JSONObject();
+        input.put("index", "test-index");
+        Map<String, Object> actualMap = GeospatialParser.convertToMap(new BytesArray(input.toString().getBytes(StandardCharsets.UTF_8)));
+        assertEquals(input.toMap(), actualMap);
+    }
+
 }

--- a/src/test/java/org/opensearch/geospatial/GeospatialRestTestCase.java
+++ b/src/test/java/org/opensearch/geospatial/GeospatialRestTestCase.java
@@ -6,10 +6,8 @@
 package org.opensearch.geospatial;
 
 import static java.util.stream.Collectors.joining;
-import static org.opensearch.geospatial.GeospatialObjectBuilder.buildGeoJSONFeature;
 import static org.opensearch.geospatial.GeospatialObjectBuilder.buildProperties;
-import static org.opensearch.geospatial.GeospatialObjectBuilder.getRandomGeometryLineString;
-import static org.opensearch.geospatial.GeospatialObjectBuilder.getRandomGeometryPoint;
+import static org.opensearch.geospatial.GeospatialObjectBuilder.randomGeoJSONFeature;
 import static org.opensearch.geospatial.action.upload.geojson.UploadGeoJSONRequestContent.FIELD_DATA;
 
 import java.io.IOException;
@@ -117,9 +115,9 @@ public abstract class GeospatialRestTestCase extends OpenSearchRestTestCase {
         contents.put(UploadGeoJSONRequestContent.FIELD_INDEX.getPreferredName(), indexName);
         contents.put(UploadGeoJSONRequestContent.FIELD_GEOSPATIAL.getPreferredName(), fieldName);
         JSONArray values = new JSONArray();
-        values.put(buildGeoJSONFeature(getRandomGeometryPoint(), buildProperties(Collections.emptyMap())));
-        values.put(buildGeoJSONFeature(getRandomGeometryPoint(), buildProperties(Collections.emptyMap())));
-        values.put(buildGeoJSONFeature(getRandomGeometryLineString(), buildProperties(Collections.emptyMap())));
+        values.put(randomGeoJSONFeature(buildProperties(Collections.emptyMap())));
+        values.put(randomGeoJSONFeature(buildProperties(Collections.emptyMap())));
+        values.put(randomGeoJSONFeature(buildProperties(Collections.emptyMap())));
         contents.put(FIELD_DATA.getPreferredName(), values);
         return contents;
     }

--- a/src/test/java/org/opensearch/geospatial/GeospatialRestTestCase.java
+++ b/src/test/java/org/opensearch/geospatial/GeospatialRestTestCase.java
@@ -115,17 +115,6 @@ public abstract class GeospatialRestTestCase extends OpenSearchRestTestCase {
         return docMap;
     }
 
-    protected String convertToString(Map<String, Object> input) {
-        JSONObject json = new JSONObject();
-        if (input == null) {
-            return json.toString();
-        }
-        for (Map.Entry<String, Object> entry : input.entrySet()) {
-            json.put(entry.getKey(), entry.getValue());
-        }
-        return json.toString();
-    }
-
     // TODO This method is copied from unit test. Refactor to common class to share across tests
     protected JSONObject buildRequestContent(String indexName, String fieldName) {
         JSONObject contents = new JSONObject();

--- a/src/test/java/org/opensearch/geospatial/GeospatialRestTestCase.java
+++ b/src/test/java/org/opensearch/geospatial/GeospatialRestTestCase.java
@@ -36,10 +36,6 @@ import org.opensearch.test.rest.OpenSearchRestTestCase;
 
 public abstract class GeospatialRestTestCase extends OpenSearchRestTestCase {
 
-    public static final int MIN_POSITIVE_VALUE = 1;
-    public static final int MAX_POINTS = 10;
-    public static final int MAX_DIMENSION = 4;
-
     public static final String SOURCE = "_source";
     public static final String DOC = "_doc";
     public static final String URL_DELIMITER = "/";
@@ -123,15 +119,7 @@ public abstract class GeospatialRestTestCase extends OpenSearchRestTestCase {
         JSONArray values = new JSONArray();
         values.put(buildGeoJSONFeature(getRandomGeometryPoint(), buildProperties(Collections.emptyMap())));
         values.put(buildGeoJSONFeature(getRandomGeometryPoint(), buildProperties(Collections.emptyMap())));
-        values.put(
-            buildGeoJSONFeature(
-                getRandomGeometryLineString(
-                    randomIntBetween(MIN_POSITIVE_VALUE, MAX_POINTS),
-                    randomIntBetween(MIN_POSITIVE_VALUE, MAX_DIMENSION)
-                ),
-                buildProperties(Collections.emptyMap())
-            )
-        );
+        values.put(buildGeoJSONFeature(getRandomGeometryLineString(), buildProperties(Collections.emptyMap())));
         contents.put(FIELD_DATA.getPreferredName(), values);
         return contents;
     }

--- a/src/test/java/org/opensearch/geospatial/action/upload/geojson/UploadGeoJSONRequestContentTests.java
+++ b/src/test/java/org/opensearch/geospatial/action/upload/geojson/UploadGeoJSONRequestContentTests.java
@@ -5,11 +5,8 @@
 
 package org.opensearch.geospatial.action.upload.geojson;
 
-import static org.junit.Assert.*;
-import static org.opensearch.geospatial.GeospatialObjectBuilder.buildGeoJSONFeature;
 import static org.opensearch.geospatial.GeospatialObjectBuilder.buildProperties;
-import static org.opensearch.geospatial.GeospatialObjectBuilder.getRandomGeometryLineString;
-import static org.opensearch.geospatial.GeospatialObjectBuilder.getRandomGeometryPoint;
+import static org.opensearch.geospatial.GeospatialObjectBuilder.randomGeoJSONFeature;
 import static org.opensearch.geospatial.action.upload.geojson.UploadGeoJSONRequestContent.FIELD_DATA;
 
 import java.util.Collections;
@@ -26,9 +23,9 @@ public class UploadGeoJSONRequestContentTests extends OpenSearchTestCase {
         contents.put(UploadGeoJSONRequestContent.FIELD_INDEX.getPreferredName(), indexName);
         contents.put(UploadGeoJSONRequestContent.FIELD_GEOSPATIAL.getPreferredName(), fieldName);
         JSONArray values = new JSONArray();
-        values.put(buildGeoJSONFeature(getRandomGeometryPoint(), buildProperties(Collections.emptyMap())));
-        values.put(buildGeoJSONFeature(getRandomGeometryPoint(), buildProperties(Collections.emptyMap())));
-        values.put(buildGeoJSONFeature(getRandomGeometryLineString(), buildProperties(Collections.emptyMap())));
+        values.put(randomGeoJSONFeature(buildProperties(Collections.emptyMap())));
+        values.put(randomGeoJSONFeature(buildProperties(Collections.emptyMap())));
+        values.put(randomGeoJSONFeature(buildProperties(Collections.emptyMap())));
         contents.put(FIELD_DATA.getPreferredName(), values);
         return contents.toMap();
     }

--- a/src/test/java/org/opensearch/geospatial/action/upload/geojson/UploadGeoJSONRequestContentTests.java
+++ b/src/test/java/org/opensearch/geospatial/action/upload/geojson/UploadGeoJSONRequestContentTests.java
@@ -36,7 +36,7 @@ public class UploadGeoJSONRequestContentTests extends OpenSearchTestCase {
         Map<String, Object> contents = buildRequestContent(indexName, fieldName);
         UploadGeoJSONRequestContent content = UploadGeoJSONRequestContent.create(contents);
         assertNotNull(content);
-        assertEquals(fieldName, content.getGeospatialFieldName());
+        assertEquals(fieldName, content.getFieldName());
         assertEquals(indexName, content.getIndexName());
         assertEquals(contents.get(FIELD_DATA.getPreferredName()), content.getData());
     }

--- a/src/test/java/org/opensearch/geospatial/action/upload/geojson/UploadGeoJSONRequestContentTests.java
+++ b/src/test/java/org/opensearch/geospatial/action/upload/geojson/UploadGeoJSONRequestContentTests.java
@@ -21,10 +21,6 @@ import org.opensearch.test.OpenSearchTestCase;
 
 public class UploadGeoJSONRequestContentTests extends OpenSearchTestCase {
 
-    public static final int MIN_POSITIVE_VALUE = 1;
-    public static final int MAX_POINTS = 10;
-    public static final int MAX_DIMENSION = 4;
-
     private Map<String, Object> buildRequestContent(String indexName, String fieldName) {
         JSONObject contents = new JSONObject();
         contents.put(UploadGeoJSONRequestContent.FIELD_INDEX.getPreferredName(), indexName);
@@ -32,15 +28,7 @@ public class UploadGeoJSONRequestContentTests extends OpenSearchTestCase {
         JSONArray values = new JSONArray();
         values.put(buildGeoJSONFeature(getRandomGeometryPoint(), buildProperties(Collections.emptyMap())));
         values.put(buildGeoJSONFeature(getRandomGeometryPoint(), buildProperties(Collections.emptyMap())));
-        values.put(
-            buildGeoJSONFeature(
-                getRandomGeometryLineString(
-                    randomIntBetween(MIN_POSITIVE_VALUE, MAX_POINTS),
-                    randomIntBetween(MIN_POSITIVE_VALUE, MAX_DIMENSION)
-                ),
-                buildProperties(Collections.emptyMap())
-            )
-        );
+        values.put(buildGeoJSONFeature(getRandomGeometryLineString(), buildProperties(Collections.emptyMap())));
         contents.put(FIELD_DATA.getPreferredName(), values);
         return contents.toMap();
     }

--- a/src/test/java/org/opensearch/geospatial/action/upload/geojson/UploadGeoJSONRequestContentTests.java
+++ b/src/test/java/org/opensearch/geospatial/action/upload/geojson/UploadGeoJSONRequestContentTests.java
@@ -40,4 +40,20 @@ public class UploadGeoJSONRequestContentTests extends OpenSearchTestCase {
         assertEquals(indexName, content.getIndexName());
         assertEquals(contents.get(FIELD_DATA.getPreferredName()), content.getData());
     }
+
+    public void testCreateEmptyIndexName() {
+        IllegalArgumentException invalidIndexName = assertThrows(
+            IllegalArgumentException.class,
+            () -> UploadGeoJSONRequestContent.create(buildRequestContent("", "location"))
+        );
+        assertTrue(invalidIndexName.getMessage().contains("cannot be empty"));
+    }
+
+    public void testCreateEmptyGeospatialFieldName() {
+        IllegalArgumentException invalidIndexName = assertThrows(
+            IllegalArgumentException.class,
+            () -> UploadGeoJSONRequestContent.create(buildRequestContent("some-index", ""))
+        );
+        assertTrue(invalidIndexName.getMessage().contains("cannot be empty"));
+    }
 }

--- a/src/test/java/org/opensearch/geospatial/action/upload/geojson/UploadGeoJSONRequestContentTests.java
+++ b/src/test/java/org/opensearch/geospatial/action/upload/geojson/UploadGeoJSONRequestContentTests.java
@@ -1,0 +1,58 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package org.opensearch.geospatial.action.upload.geojson;
+
+import static org.junit.Assert.*;
+import static org.opensearch.geospatial.GeospatialObjectBuilder.buildGeoJSONFeature;
+import static org.opensearch.geospatial.GeospatialObjectBuilder.buildProperties;
+import static org.opensearch.geospatial.GeospatialObjectBuilder.getRandomGeometryLineString;
+import static org.opensearch.geospatial.GeospatialObjectBuilder.getRandomGeometryPoint;
+import static org.opensearch.geospatial.action.upload.geojson.UploadGeoJSONRequestContent.FIELD_DATA;
+
+import java.util.Collections;
+import java.util.Map;
+
+import org.json.JSONArray;
+import org.json.JSONObject;
+import org.opensearch.test.OpenSearchTestCase;
+
+public class UploadGeoJSONRequestContentTests extends OpenSearchTestCase {
+
+    public static final int MIN_POSITIVE_VALUE = 1;
+    public static final int MAX_POINTS = 10;
+    public static final int MAX_DIMENSION = 4;
+
+    private Map<String, Object> buildRequestContent(String indexName, String fieldName) {
+        JSONObject contents = new JSONObject();
+        contents.put(UploadGeoJSONRequestContent.FIELD_INDEX.getPreferredName(), indexName);
+        contents.put(UploadGeoJSONRequestContent.FIELD_GEOSPATIAL.getPreferredName(), fieldName);
+        JSONArray values = new JSONArray();
+        values.put(buildGeoJSONFeature(getRandomGeometryPoint(), buildProperties(Collections.emptyMap())));
+        values.put(buildGeoJSONFeature(getRandomGeometryPoint(), buildProperties(Collections.emptyMap())));
+        values.put(
+            buildGeoJSONFeature(
+                getRandomGeometryLineString(
+                    randomIntBetween(MIN_POSITIVE_VALUE, MAX_POINTS),
+                    randomIntBetween(MIN_POSITIVE_VALUE, MAX_DIMENSION)
+                ),
+                buildProperties(Collections.emptyMap())
+            )
+        );
+        contents.put(FIELD_DATA.getPreferredName(), values);
+        return contents.toMap();
+    }
+
+    public void testCreate() {
+        final String indexName = "some-index";
+        final String fieldName = "location";
+        Map<String, Object> contents = buildRequestContent(indexName, fieldName);
+        UploadGeoJSONRequestContent content = UploadGeoJSONRequestContent.create(contents);
+        assertNotNull(content);
+        assertEquals(fieldName, content.getGeospatialFieldName());
+        assertEquals(indexName, content.getIndexName());
+        assertEquals(contents.get(FIELD_DATA.getPreferredName()), content.getData());
+    }
+}

--- a/src/test/java/org/opensearch/geospatial/action/upload/geojson/UploadGeoJSONRequestTests.java
+++ b/src/test/java/org/opensearch/geospatial/action/upload/geojson/UploadGeoJSONRequestTests.java
@@ -13,7 +13,6 @@ package org.opensearch.geospatial.action.upload.geojson;
 
 import java.io.IOException;
 import java.nio.charset.StandardCharsets;
-import java.util.HashMap;
 import java.util.Map;
 
 import org.json.JSONObject;
@@ -49,12 +48,5 @@ public class UploadGeoJSONRequestTests extends OpenSearchTestCase {
     public void testRequestValidation() {
         UploadGeoJSONRequest request = new UploadGeoJSONRequest(new BytesArray(getRequestBody(null).getBytes(StandardCharsets.UTF_8)));
         assertNull(request.validate());
-    }
-
-    public void testGetSourceAsMap() {
-        Map<String, Object> content = new HashMap<>();
-        content.put("index", "test-index");
-        UploadGeoJSONRequest request = new UploadGeoJSONRequest(new BytesArray(getRequestBody(content).getBytes(StandardCharsets.UTF_8)));
-        assertEquals(content, request.contentAsMap());
     }
 }

--- a/src/test/java/org/opensearch/geospatial/processor/FeatureProcessorIT.java
+++ b/src/test/java/org/opensearch/geospatial/processor/FeatureProcessorIT.java
@@ -6,9 +6,8 @@
 package org.opensearch.geospatial.processor;
 
 import static org.opensearch.geospatial.GeospatialObjectBuilder.GEOMETRY_TYPE_KEY;
-import static org.opensearch.geospatial.GeospatialObjectBuilder.buildGeoJSONFeature;
 import static org.opensearch.geospatial.GeospatialObjectBuilder.buildProperties;
-import static org.opensearch.geospatial.GeospatialObjectBuilder.getRandomGeometryLineString;
+import static org.opensearch.geospatial.GeospatialObjectBuilder.randomGeoJSONFeature;
 import static org.opensearch.ingest.RandomDocumentPicks.randomString;
 
 import java.io.IOException;
@@ -23,7 +22,6 @@ import org.apache.http.util.EntityUtils;
 import org.json.JSONObject;
 import org.opensearch.client.Request;
 import org.opensearch.client.Response;
-import org.opensearch.common.geo.GeoShapeType;
 import org.opensearch.common.settings.Settings;
 import org.opensearch.geospatial.GeospatialRestTestCase;
 import org.opensearch.rest.RestStatus;
@@ -65,7 +63,7 @@ public class FeatureProcessorIT extends GeospatialRestTestCase {
         properties.put(randomString(random()), randomString(random()));
         properties.put(randomString(random()), randomString(random()));
 
-        JSONObject feature = buildGeoJSONFeature(getRandomGeometryLineString(), buildProperties(properties));
+        JSONObject feature = randomGeoJSONFeature(buildProperties(properties));
         String requestBody = feature.toString();
         Map<String, String> params = new HashMap<>();
         params.put("pipeline", pipelineName);
@@ -81,7 +79,8 @@ public class FeatureProcessorIT extends GeospatialRestTestCase {
         }
 
         Map<String, Object> geoShapeFieldValue = (Map<String, Object>) document.get(geoShapeField);
-        assertEquals(geoShapeFieldValue.get(GEOMETRY_TYPE_KEY), GeoShapeType.LINESTRING.shapeName());
+        assertNotNull(geoShapeFieldValue);
+        assertNotNull(geoShapeFieldValue.get(GEOMETRY_TYPE_KEY));
 
         deletePipeline(pipelineName);
         deleteIndex(indexName);

--- a/src/test/java/org/opensearch/geospatial/processor/FeatureProcessorIT.java
+++ b/src/test/java/org/opensearch/geospatial/processor/FeatureProcessorIT.java
@@ -30,19 +30,6 @@ import org.opensearch.rest.RestStatus;
 
 public class FeatureProcessorIT extends GeospatialRestTestCase {
 
-    public static final int LINESTRING_TOTAL_POINTS = 4;
-    public static final int LINESTRING_POINT_DIMENSION = 2;
-
-    private double[][] randomDoubleArray(int row, int col) {
-        double[][] randomArray = new double[row][col];
-        for (int i = 0; i < row; i++) {
-            for (int j = 0; j < col; j++) {
-                randomArray[i][j] = randomDouble();
-            }
-        }
-        return randomArray;
-    }
-
     public void testProcessorAvailable() throws IOException {
         String nodeIngestURL = String.join("/", "_nodes", "ingest");
         String endpoint = nodeIngestURL + "?filter_path=nodes.*.ingest.processors&pretty";
@@ -78,10 +65,7 @@ public class FeatureProcessorIT extends GeospatialRestTestCase {
         properties.put(randomString(random()), randomString(random()));
         properties.put(randomString(random()), randomString(random()));
 
-        JSONObject feature = buildGeoJSONFeature(
-            getRandomGeometryLineString(LINESTRING_TOTAL_POINTS, LINESTRING_POINT_DIMENSION),
-            buildProperties(properties)
-        );
+        JSONObject feature = buildGeoJSONFeature(getRandomGeometryLineString(), buildProperties(properties));
         String requestBody = feature.toString();
         Map<String, String> params = new HashMap<>();
         params.put("pipeline", pipelineName);

--- a/src/test/java/org/opensearch/geospatial/processor/FeatureProcessorTests.java
+++ b/src/test/java/org/opensearch/geospatial/processor/FeatureProcessorTests.java
@@ -5,9 +5,8 @@
 
 package org.opensearch.geospatial.processor;
 
-import static org.opensearch.geospatial.GeospatialObjectBuilder.buildGeoJSONFeature;
 import static org.opensearch.geospatial.GeospatialObjectBuilder.buildProperties;
-import static org.opensearch.geospatial.GeospatialObjectBuilder.getRandomGeometryPoint;
+import static org.opensearch.geospatial.GeospatialObjectBuilder.randomGeoJSONFeature;
 
 import java.util.Collections;
 import java.util.HashMap;
@@ -24,7 +23,7 @@ public class FeatureProcessorTests extends OpenSearchTestCase {
     private Map<String, Object> buildTestFeature() {
         Map<String, Object> properties = new HashMap<>();
         properties.put("name", "Dinagat Islands");
-        return buildGeoJSONFeature(getRandomGeometryPoint(), buildProperties(properties)).toMap();
+        return randomGeoJSONFeature(buildProperties(properties)).toMap();
     }
 
     public void testCreateFeatureProcessor() {

--- a/src/test/java/org/opensearch/geospatial/rest/action/upload/geojson/RestUploadGeoJSONActionIT.java
+++ b/src/test/java/org/opensearch/geospatial/rest/action/upload/geojson/RestUploadGeoJSONActionIT.java
@@ -14,9 +14,7 @@ package org.opensearch.geospatial.rest.action.upload.geojson;
 import static org.opensearch.ingest.RandomDocumentPicks.randomString;
 
 import java.io.IOException;
-import java.util.HashMap;
 import java.util.Locale;
-import java.util.Map;
 
 import org.opensearch.client.Request;
 import org.opensearch.client.Response;
@@ -35,9 +33,9 @@ public class RestUploadGeoJSONActionIT extends GeospatialRestTestCase {
             RestUploadGeoJSONAction.ACTION_UPLOAD
         );
         Request request = new Request("POST", path);
-        Map<String, Object> contentMap = new HashMap<>();
-        contentMap.put("index", randomString(random()).toLowerCase(Locale.getDefault()));
-        request.setJsonEntity(convertToString(contentMap));
+        String indexName = randomString(random()).toLowerCase(Locale.getDefault());
+        String geoShapeField = randomString(random());
+        request.setJsonEntity(buildRequestContent(indexName, geoShapeField).toString());
         Response response = client().performRequest(request);
         assertEquals(RestStatus.OK, RestStatus.fromCode(response.getStatusLine().getStatusCode()));
 


### PR DESCRIPTION
Signed-off-by: Vijayan Balasubramanian <balasvij@amazon.com>

### Description
Create Request content object to deserialize into an object. This will be used by Transport action
to build logic to index request content as document into an index.
 
 
### Check List
- [x] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
