### PR TITLE
Add GeoJSON object of type FeatureCollection

### DIFF
--- a/src/main/java/org/opensearch/geospatial/GeospatialParser.java
+++ b/src/main/java/org/opensearch/geospatial/GeospatialParser.java
@@ -5,13 +5,21 @@
 
 package org.opensearch.geospatial;
 
+import static org.opensearch.geospatial.geojson.Feature.TYPE_KEY;
+
+import java.util.Arrays;
+import java.util.Collections;
 import java.util.HashMap;
+import java.util.List;
 import java.util.Map;
 import java.util.Objects;
+import java.util.Optional;
 
 import org.opensearch.common.bytes.BytesReference;
 import org.opensearch.common.xcontent.XContentHelper;
 import org.opensearch.common.xcontent.XContentType;
+import org.opensearch.geospatial.geojson.Feature;
+import org.opensearch.geospatial.geojson.FeatureCollection;
 
 /**
  * GeospatialParser provides helper methods to parse/extract/transform input to
@@ -64,5 +72,23 @@ public final class GeospatialParser {
     public static Map<String, Object> convertToMap(BytesReference content) {
         Objects.requireNonNull(content);
         return XContentHelper.convertToMap(content, false, XContentType.JSON).v2();
+    }
+
+    /**
+     * getFeatures will return features from given map input. This function abstracts the logic to parse given input and returns
+     * list of Features if exists in Map format.
+     * @param geoJSON given input which may contain GeoJSON Object
+     * @return List of Feature in Map
+     */
+    public static Optional<List<Map<String, Object>>> getFeatures(final Map<String, Object> geoJSON) {
+        final String type = extractValueAsString(geoJSON, TYPE_KEY);
+        Objects.requireNonNull(type, TYPE_KEY + " cannot be null");
+        if (Feature.TYPE.equalsIgnoreCase(type)) {
+            return Optional.ofNullable(Collections.unmodifiableList(Arrays.asList(geoJSON)));
+        }
+        if (FeatureCollection.TYPE.equalsIgnoreCase(type)) {
+            return Optional.ofNullable(Collections.unmodifiableList(FeatureCollection.create(geoJSON).getFeatures()));
+        }
+        return Optional.empty();
     }
 }

--- a/src/main/java/org/opensearch/geospatial/geojson/FeatureCollection.java
+++ b/src/main/java/org/opensearch/geospatial/geojson/FeatureCollection.java
@@ -43,9 +43,10 @@ public final class FeatureCollection {
     /**
      * Add Features to this collection
      * @param features List of {@link Feature}
+     * @throws NullPointerException if feature is null
      */
     public void addFeatures(List<Feature> features) {
-        Objects.requireNonNull(features);
+        Objects.requireNonNull(features, "cannot add null to features");
         this.features.addAll(features);
     }
 
@@ -54,8 +55,11 @@ public final class FeatureCollection {
      *
      * @param input the object from where {@link FeatureCollection} will be extracted
      * @return FeatureCollection Instance from given input
+     * @throws NullPointerException if input is null
+     * @throws IllegalArgumentException if input doesn't have valid arguments
      */
     public static FeatureCollection create(final Map<String, Object> input) {
+        Objects.requireNonNull(input, "input cannot be null");
         Object geoJSONType = input.get(TYPE_KEY);
         if (geoJSONType == null) {
             throw new IllegalArgumentException(TYPE_KEY + " cannot be null");
@@ -69,7 +73,7 @@ public final class FeatureCollection {
     private static FeatureCollection extract(Map<String, Object> input) {
         FeatureCollection collection = new FeatureCollection();
         Object featureObject = input.get(FEATURES_KEY);
-        if (featureObject == null) { // empty features are allowed
+        if (featureObject == null) { // empty features are valid based on definition
             return collection;
         }
         if (!(featureObject instanceof Object[])) {

--- a/src/main/java/org/opensearch/geospatial/geojson/FeatureCollection.java
+++ b/src/main/java/org/opensearch/geospatial/geojson/FeatureCollection.java
@@ -10,7 +10,6 @@ import java.util.Collections;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
-import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
 import org.opensearch.geospatial.GeospatialParser;
@@ -18,36 +17,35 @@ import org.opensearch.geospatial.GeospatialParser;
 /**
  * FeatureCollection represents GEOJSON of type FeatureCollection. A FeatureCollection object has a member
  * with the name "features".  The value of "features" is a List.
- * Each element of the list is a {@link Feature} object.  It
- * is possible for this list to be empty.
+ * and it is possible for this list to be empty, if {@link FeatureCollection} has no Features.
  */
 public final class FeatureCollection {
     public static final String TYPE = "FeatureCollection";
     public static final String FEATURES_KEY = "features";
     public static final String TYPE_KEY = "type";
-    private final List<Feature> features;
+    private final List<Map<String, Object>> features;
 
     private FeatureCollection() {
         this.features = new ArrayList<>();
     }
 
     /**
-     * Gets the list of Features
+     * Gets the list of Features in Map format
      *
-     * @return List of {@link Feature}
+     * @return List of Feature as Map from the {@link FeatureCollection}
      */
-    public List<Feature> getFeatures() {
+    public List<Map<String, Object>> getFeatures() {
         return Collections.unmodifiableList(features);
     }
 
     /**
      * Add Features to this collection
-     * @param features List of {@link Feature}
+     * @param featureMap feature in Map format
      * @throws NullPointerException if feature is null
      */
-    public void addFeatures(List<Feature> features) {
-        Objects.requireNonNull(features, "cannot add null to features");
-        this.features.addAll(features);
+    public void addFeature(Map<String, Object> featureMap) {
+        Objects.requireNonNull(featureMap, "cannot add null to features");
+        this.features.add(featureMap);
     }
 
     /**
@@ -82,11 +80,7 @@ public final class FeatureCollection {
             );
         }
         Object[] featureArray = (Object[]) featureObject;
-        List<Feature> features = Stream.of(featureArray)
-            .map(GeospatialParser::toStringObjectMap)
-            .map(FeatureFactory::create)
-            .collect(Collectors.toList());
-        collection.addFeatures(features);
+        Stream.of(featureArray).map(GeospatialParser::toStringObjectMap).forEach(collection::addFeature);
         return collection;
     }
 

--- a/src/main/java/org/opensearch/geospatial/geojson/FeatureCollection.java
+++ b/src/main/java/org/opensearch/geospatial/geojson/FeatureCollection.java
@@ -1,0 +1,89 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package org.opensearch.geospatial.geojson;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+import java.util.Map;
+import java.util.Objects;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
+
+import org.opensearch.geospatial.GeospatialParser;
+
+/**
+ * FeatureCollection represents GEOJSON of type FeatureCollection. A FeatureCollection object has a member
+ * with the name "features".  The value of "features" is a List.
+ * Each element of the list is a {@link Feature} object.  It
+ * is possible for this list to be empty.
+ */
+public final class FeatureCollection {
+    public static final String TYPE = "FeatureCollection";
+    public static final String FEATURES_KEY = "features";
+    public static final String TYPE_KEY = "type";
+    private final List<Feature> features;
+
+    private FeatureCollection() {
+        this.features = new ArrayList<>();
+    }
+
+    /**
+     * Gets the list of Features
+     *
+     * @return List of {@link Feature}
+     */
+    public List<Feature> getFeatures() {
+        return Collections.unmodifiableList(features);
+    }
+
+    /**
+     * Add Features to this collection
+     * @param features List of {@link Feature}
+     */
+    public void addFeatures(List<Feature> features) {
+        Objects.requireNonNull(features);
+        this.features.addAll(features);
+    }
+
+    /**
+     * The static method to create an instance of {@link FeatureCollection} from input.
+     *
+     * @param input the object from where {@link FeatureCollection} will be extracted
+     * @return FeatureCollection Instance from given input
+     */
+    public static FeatureCollection create(final Map<String, Object> input) {
+        Object geoJSONType = input.get(TYPE_KEY);
+        if (geoJSONType == null) {
+            throw new IllegalArgumentException(TYPE_KEY + " cannot be null");
+        }
+        if (!TYPE.equalsIgnoreCase(geoJSONType.toString())) {
+            throw new IllegalArgumentException("Unknown type [ " + geoJSONType + " ], expected type [ " + TYPE + " ]");
+        }
+        return extract(input);
+    }
+
+    private static FeatureCollection extract(Map<String, Object> input) {
+        FeatureCollection collection = new FeatureCollection();
+        Object featureObject = input.get(FEATURES_KEY);
+        if (featureObject == null) { // empty features are allowed
+            return collection;
+        }
+        if (!(featureObject instanceof Object[])) {
+            throw new IllegalArgumentException(
+                FEATURES_KEY + " is not an instance of type Object[], but of type [ " + featureObject.getClass().getName() + " ]"
+            );
+        }
+        Object[] featureArray = (Object[]) featureObject;
+        List<Feature> features = Stream.of(featureArray)
+            .map(GeospatialParser::toStringObjectMap)
+            .map(FeatureFactory::create)
+            .collect(Collectors.toList());
+        collection.addFeatures(features);
+        return collection;
+    }
+
+}

--- a/src/main/java/org/opensearch/geospatial/geojson/FeatureFactory.java
+++ b/src/main/java/org/opensearch/geospatial/geojson/FeatureFactory.java
@@ -9,6 +9,7 @@ import static org.opensearch.geospatial.GeospatialParser.toStringObjectMap;
 import static org.opensearch.geospatial.geojson.Feature.TYPE;
 
 import java.util.Map;
+import java.util.Objects;
 
 import org.opensearch.geospatial.geojson.Feature.FeatureBuilder;
 
@@ -22,8 +23,11 @@ public class FeatureFactory {
      *
      * @param input the object from where {@link Feature} will be extracted
      * @return Feature Instance from input
+     * @throws NullPointerException if input is null
+     * @throws IllegalArgumentException if input doesn't have valid arguments
      */
     public static Feature create(Map<String, Object> input) {
+        Objects.requireNonNull(input, "input cannot be null");
         Object geoJSONType = input.get(Feature.TYPE_KEY);
         if (geoJSONType == null) {
             throw new IllegalArgumentException(Feature.TYPE_KEY + " cannot be null");

--- a/src/main/java/org/opensearch/geospatial/geojson/FeatureFactory.java
+++ b/src/main/java/org/opensearch/geospatial/geojson/FeatureFactory.java
@@ -6,6 +6,7 @@
 package org.opensearch.geospatial.geojson;
 
 import static org.opensearch.geospatial.GeospatialParser.toStringObjectMap;
+import static org.opensearch.geospatial.geojson.Feature.TYPE;
 
 import java.util.Map;
 
@@ -27,8 +28,8 @@ public class FeatureFactory {
         if (geoJSONType == null) {
             throw new IllegalArgumentException(Feature.TYPE_KEY + " cannot be null");
         }
-        if (!Feature.TYPE.equalsIgnoreCase(geoJSONType.toString())) {
-            throw new IllegalArgumentException(geoJSONType + " is not supported. Only type " + Feature.TYPE + " is supported");
+        if (!TYPE.equalsIgnoreCase(geoJSONType.toString())) {
+            throw new IllegalArgumentException("Unknown type [ " + geoJSONType + " ], expected type [ " + TYPE + " ]");
         }
         return extractFeature(input).build();
     }

--- a/src/test/java/org/opensearch/geospatial/GeospatialObjectBuilder.java
+++ b/src/test/java/org/opensearch/geospatial/GeospatialObjectBuilder.java
@@ -8,12 +8,14 @@ package org.opensearch.geospatial;
 import java.util.Map;
 import java.util.Random;
 
+import org.json.JSONArray;
 import org.json.JSONObject;
 import org.opensearch.common.Randomness;
 import org.opensearch.common.collect.List;
 import org.opensearch.common.geo.GeoShapeType;
 import org.opensearch.geo.GeometryTestUtils;
 import org.opensearch.geospatial.geojson.Feature;
+import org.opensearch.geospatial.geojson.FeatureCollection;
 
 import com.carrotsearch.randomizedtesting.generators.RandomPicks;
 
@@ -70,6 +72,13 @@ public class GeospatialObjectBuilder {
             propertiesObject.put(entry.getKey(), entry.getValue());
         }
         return propertiesObject;
+    }
+
+    public static JSONObject buildGeoJSONFeatureCollection(JSONArray features) {
+        JSONObject collection = new JSONObject();
+        collection.put(FeatureCollection.TYPE_KEY, FeatureCollection.TYPE);
+        collection.put(FeatureCollection.FEATURES_KEY, features.toList().toArray());
+        return collection;
     }
 
     public static int randomPositiveInt(int bound) {

--- a/src/test/java/org/opensearch/geospatial/GeospatialObjectBuilder.java
+++ b/src/test/java/org/opensearch/geospatial/GeospatialObjectBuilder.java
@@ -6,7 +6,6 @@
 package org.opensearch.geospatial;
 
 import java.util.Map;
-import java.util.Random;
 
 import org.json.JSONArray;
 import org.json.JSONObject;
@@ -27,9 +26,9 @@ public class GeospatialObjectBuilder {
 
     public static final String GEOMETRY_TYPE_KEY = "type";
     public static final String GEOMETRY_COORDINATES_KEY = "coordinates";
-    public static final int MIN_POSITIVE_INTEGER_VALUE = 1;
+    public static final int MIN_LINE_STRING_COORDINATES_SIZE = 2;
     public static final int MAX_POINTS = 10;
-    public static final int MAX_DIMENSION = 4;
+    public static final int POINTS_SIZE = 2;
 
     public static JSONObject buildGeometry(String type, Object value) {
         JSONObject geometry = new JSONObject();
@@ -39,15 +38,12 @@ public class GeospatialObjectBuilder {
     }
 
     public static JSONObject randomGeometryPoint() {
-        Random random = Randomness.get();
-        double[] point = new double[] { random.nextDouble(), random.nextDouble() };
-        return buildGeometry(GeoShapeType.POINT.shapeName(), point);
+        return buildGeometry(GeoShapeType.POINT.shapeName(), getRandomPoint());
     }
 
     public static JSONObject randomGeometryLineString() {
-        int randomTotalPoints = randomPositiveInt(MAX_POINTS);
-        int randomPointsDimension = randomPositiveInt(MAX_DIMENSION);
-        double[][] lineString = new double[randomTotalPoints][randomPointsDimension];
+        int randomTotalPoints = randomBoundedInt(MIN_LINE_STRING_COORDINATES_SIZE, MAX_POINTS);
+        double[][] lineString = new double[randomTotalPoints][POINTS_SIZE];
         for (int i = 0; i < lineString.length; i++) {
             lineString[i] = getRandomPoint();
         }
@@ -81,8 +77,8 @@ public class GeospatialObjectBuilder {
         return collection;
     }
 
-    public static int randomPositiveInt(int bound) {
-        return Randomness.get().ints(MIN_POSITIVE_INTEGER_VALUE, bound).findFirst().getAsInt();
+    public static int randomBoundedInt(int min, int max) {
+        return Randomness.get().ints(min, max).findFirst().getAsInt();
     }
 
     public static JSONObject randomGeoJSONFeature(final JSONObject properties) {

--- a/src/test/java/org/opensearch/geospatial/GeospatialObjectBuilder.java
+++ b/src/test/java/org/opensearch/geospatial/GeospatialObjectBuilder.java
@@ -6,6 +6,7 @@
 package org.opensearch.geospatial;
 
 import java.util.Map;
+import java.util.stream.IntStream;
 
 import org.json.JSONArray;
 import org.json.JSONObject;
@@ -44,9 +45,7 @@ public class GeospatialObjectBuilder {
     public static JSONObject randomGeometryLineString() {
         int randomTotalPoints = randomBoundedInt(MIN_LINE_STRING_COORDINATES_SIZE, MAX_POINTS);
         double[][] lineString = new double[randomTotalPoints][POINTS_SIZE];
-        for (int i = 0; i < lineString.length; i++) {
-            lineString[i] = getRandomPoint();
-        }
+        IntStream.range(0, lineString.length).forEach(index -> lineString[index] = getRandomPoint());
         return buildGeometry(GeoShapeType.LINESTRING.shapeName(), lineString);
     }
 

--- a/src/test/java/org/opensearch/geospatial/geojson/FeatureCollectionTests.java
+++ b/src/test/java/org/opensearch/geospatial/geojson/FeatureCollectionTests.java
@@ -1,0 +1,58 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ *
+ * Modifications Copyright OpenSearch Contributors. See
+ * GitHub history for details.
+ */
+
+package org.opensearch.geospatial.geojson;
+
+import static org.opensearch.geospatial.GeospatialObjectBuilder.buildGeoJSONFeatureCollection;
+import static org.opensearch.geospatial.GeospatialObjectBuilder.randomGeoJSONFeature;
+import static org.opensearch.geospatial.geojson.FeatureCollection.FEATURES_KEY;
+
+import java.util.HashMap;
+import java.util.Map;
+
+import org.json.JSONArray;
+import org.json.JSONObject;
+import org.opensearch.test.OpenSearchTestCase;
+
+public class FeatureCollectionTests extends OpenSearchTestCase {
+
+    public void testCreateFeatureCollection() {
+        JSONArray features = new JSONArray();
+        features.put(randomGeoJSONFeature(new JSONObject()));
+        features.put(randomGeoJSONFeature(new JSONObject()));
+        features.put(randomGeoJSONFeature(new JSONObject()));
+        features.put(randomGeoJSONFeature(new JSONObject()));
+        Map<String, Object> featureCollectionAsMap = buildGeoJSONFeatureCollection(features).toMap();
+        FeatureCollection collection = FeatureCollection.create(featureCollectionAsMap);
+        assertNotNull(collection);
+        assertEquals(features.toList().size(), collection.getFeatures().size());
+    }
+
+    public void testCreateFeatureCollectionInvalidType() {
+        Map<String, Object> featureCollectionAsMap = new HashMap<>();
+        featureCollectionAsMap.put(FeatureCollection.TYPE_KEY, Feature.TYPE);
+        IllegalArgumentException ex = assertThrows(IllegalArgumentException.class, () -> FeatureCollection.create(featureCollectionAsMap));
+        assertTrue(ex.getMessage().contains("expected type [ FeatureCollection ]"));
+    }
+
+    public void testCreateFeatureCollectionTypeMissing() {
+        IllegalArgumentException ex = assertThrows(IllegalArgumentException.class, () -> FeatureCollection.create(new HashMap<>()));
+        assertTrue(ex.getMessage().contains("type cannot be null"));
+    }
+
+    public void testCreateFeatureCollectionInvalidFeature() {
+        Map<String, Object> featureCollectionAsMap = new HashMap<>();
+        featureCollectionAsMap.put(FeatureCollection.TYPE_KEY, FeatureCollection.TYPE);
+        featureCollectionAsMap.put(FEATURES_KEY, "invalid");
+        IllegalArgumentException ex = assertThrows(IllegalArgumentException.class, () -> FeatureCollection.create(featureCollectionAsMap));
+        assertTrue(ex.getMessage().contains(FEATURES_KEY + " is not an instance of type Object[]"));
+    }
+}

--- a/src/test/java/org/opensearch/geospatial/geojson/FeatureCollectionTests.java
+++ b/src/test/java/org/opensearch/geospatial/geojson/FeatureCollectionTests.java
@@ -16,10 +16,13 @@ import static org.opensearch.geospatial.GeospatialObjectBuilder.randomGeoJSONFea
 import static org.opensearch.geospatial.geojson.FeatureCollection.FEATURES_KEY;
 
 import java.util.HashMap;
+import java.util.List;
 import java.util.Map;
+import java.util.stream.Collectors;
 
 import org.json.JSONArray;
 import org.json.JSONObject;
+import org.opensearch.geospatial.GeospatialParser;
 import org.opensearch.test.OpenSearchTestCase;
 
 public class FeatureCollectionTests extends OpenSearchTestCase {
@@ -34,6 +37,13 @@ public class FeatureCollectionTests extends OpenSearchTestCase {
         FeatureCollection collection = FeatureCollection.create(featureCollectionAsMap);
         assertNotNull(collection);
         assertEquals(features.toList().size(), collection.getFeatures().size());
+
+        List<Map<String, Object>> expected = features.toList()
+            .stream()
+            .map(GeospatialParser::toStringObjectMap)
+            .collect(Collectors.toList());
+
+        assertArrayEquals("features are not equal", expected.toArray(), collection.getFeatures().toArray());
     }
 
     public void testCreateFeatureCollectionInvalidType() {

--- a/src/test/java/org/opensearch/geospatial/geojson/FeatureCollectionTests.java
+++ b/src/test/java/org/opensearch/geospatial/geojson/FeatureCollectionTests.java
@@ -43,6 +43,11 @@ public class FeatureCollectionTests extends OpenSearchTestCase {
         assertTrue(ex.getMessage().contains("expected type [ FeatureCollection ]"));
     }
 
+    public void testCreateFeatureCollectionInvalidInput() {
+        NullPointerException ex = assertThrows(NullPointerException.class, () -> FeatureCollection.create(null));
+        assertTrue(ex.getMessage().equals("input cannot be null"));
+    }
+
     public void testCreateFeatureCollectionTypeMissing() {
         IllegalArgumentException ex = assertThrows(IllegalArgumentException.class, () -> FeatureCollection.create(new HashMap<>()));
         assertTrue(ex.getMessage().contains("type cannot be null"));

--- a/src/test/java/org/opensearch/geospatial/processor/FeatureProcessorTests.java
+++ b/src/test/java/org/opensearch/geospatial/processor/FeatureProcessorTests.java
@@ -7,15 +7,18 @@ package org.opensearch.geospatial.processor;
 
 import static org.opensearch.geospatial.GeospatialObjectBuilder.buildProperties;
 import static org.opensearch.geospatial.GeospatialObjectBuilder.randomGeoJSONFeature;
+import static org.opensearch.geospatial.geojson.Feature.GEOMETRY_KEY;
+import static org.opensearch.geospatial.geojson.Feature.PROPERTIES_KEY;
+import static org.opensearch.geospatial.geojson.Feature.TYPE_KEY;
+import static org.opensearch.geospatial.geojson.FeatureCollection.TYPE;
+import static org.opensearch.ingest.RandomDocumentPicks.randomIngestDocument;
 
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.Map;
 
-import org.opensearch.geospatial.geojson.Feature;
 import org.opensearch.ingest.IngestDocument;
 import org.opensearch.ingest.Processor;
-import org.opensearch.ingest.RandomDocumentPicks;
 import org.opensearch.test.OpenSearchTestCase;
 
 public class FeatureProcessorTests extends OpenSearchTestCase {
@@ -37,53 +40,53 @@ public class FeatureProcessorTests extends OpenSearchTestCase {
 
     public void testFeatureProcessor() {
         Map<String, Object> document = buildTestFeature();
-        IngestDocument ingestDocument = RandomDocumentPicks.randomIngestDocument(random(), document);
+        IngestDocument ingestDocument = randomIngestDocument(random(), document);
         FeatureProcessor processor = new FeatureProcessor("sample", "description", "location");
         processor.execute(ingestDocument);
         Map<String, Object> location = (Map<String, Object>) ingestDocument.getFieldValue("location", Object.class);
         assertNotNull(location);
-        assertEquals(document.get(Feature.GEOMETRY_KEY), location);
+        assertEquals(document.get(GEOMETRY_KEY), location);
         assertEquals("Dinagat Islands", ingestDocument.getSourceAndMetadata().get("name"));
-        assertNull(ingestDocument.getSourceAndMetadata().get(Feature.GEOMETRY_KEY));
-        assertNull(ingestDocument.getSourceAndMetadata().get(Feature.TYPE_KEY));
-        assertNull(ingestDocument.getSourceAndMetadata().get(Feature.PROPERTIES_KEY));
+        assertNull(ingestDocument.getSourceAndMetadata().get(GEOMETRY_KEY));
+        assertNull(ingestDocument.getSourceAndMetadata().get(TYPE_KEY));
+        assertNull(ingestDocument.getSourceAndMetadata().get(PROPERTIES_KEY));
     }
 
     public void testFeatureProcessorWithoutProperties() {
         Map<String, Object> document = buildTestFeature();
-        document.remove(Feature.PROPERTIES_KEY);
-        IngestDocument ingestDocument = RandomDocumentPicks.randomIngestDocument(random(), document);
+        document.remove(PROPERTIES_KEY);
+        IngestDocument ingestDocument = randomIngestDocument(random(), document);
         FeatureProcessor processor = new FeatureProcessor("sample", "description", "location");
         processor.execute(ingestDocument);
         Map<String, Object> location = (Map<String, Object>) ingestDocument.getFieldValue("location", Object.class);
         assertNotNull(location);
-        assertEquals(document.get(Feature.GEOMETRY_KEY), location);
-        assertNull(ingestDocument.getSourceAndMetadata().get(Feature.GEOMETRY_KEY));
-        assertNull(ingestDocument.getSourceAndMetadata().get(Feature.TYPE_KEY));
+        assertEquals(document.get(GEOMETRY_KEY), location);
+        assertNull(ingestDocument.getSourceAndMetadata().get(GEOMETRY_KEY));
+        assertNull(ingestDocument.getSourceAndMetadata().get(TYPE_KEY));
     }
 
     public void testFeatureProcessorWithInvalidProperties() {
         Map<String, Object> document = buildTestFeature();
-        document.put(Feature.PROPERTIES_KEY, "invalid-value");
-        IngestDocument ingestDocument = RandomDocumentPicks.randomIngestDocument(random(), document);
+        document.put(PROPERTIES_KEY, "invalid-value");
+        IngestDocument ingestDocument = randomIngestDocument(random(), document);
         FeatureProcessor processor = new FeatureProcessor("sample", "description", "location");
         IllegalArgumentException exception = assertThrows(IllegalArgumentException.class, () -> processor.execute(ingestDocument));
-        assertTrue(exception.getMessage().contains(Feature.PROPERTIES_KEY + " is not an instance of type Map"));
+        assertTrue(exception.getMessage().contains(PROPERTIES_KEY + " is not an instance of type Map"));
     }
 
     public void testFeatureProcessorUnSupportedType() {
         Map<String, Object> document = new HashMap<>();
-        document.put("type", "FeatureCollection");
-        IngestDocument ingestDocument = RandomDocumentPicks.randomIngestDocument(random(), document);
+        document.put(TYPE_KEY, TYPE);
+        IngestDocument ingestDocument = randomIngestDocument(random(), document);
         FeatureProcessor processor = new FeatureProcessor("sample", "description", "location");
         IllegalArgumentException exception = assertThrows(IllegalArgumentException.class, () -> processor.execute(ingestDocument));
-        assertTrue(exception.getMessage().contains("Only type Feature is supported"));
+        assertTrue(exception.getMessage().contains("expected type [ Feature ]"));
     }
 
     public void testFeatureProcessorTypeNotFound() {
         Map<String, Object> document = buildTestFeature();
-        document.remove(Feature.TYPE_KEY);
-        IngestDocument ingestDocument = RandomDocumentPicks.randomIngestDocument(random(), document);
+        document.remove(TYPE_KEY);
+        IngestDocument ingestDocument = randomIngestDocument(random(), document);
         FeatureProcessor processor = new FeatureProcessor("sample", "description", "location");
         IllegalArgumentException exception = assertThrows(IllegalArgumentException.class, () -> processor.execute(ingestDocument));
         assertTrue(exception.getMessage().contains("type cannot be null"));
@@ -91,19 +94,19 @@ public class FeatureProcessorTests extends OpenSearchTestCase {
 
     public void testFeatureProcessorWithoutGeometry() {
         Map<String, Object> document = buildTestFeature();
-        document.remove(Feature.GEOMETRY_KEY);
-        IngestDocument ingestDocument = RandomDocumentPicks.randomIngestDocument(random(), document);
+        document.remove(GEOMETRY_KEY);
+        IngestDocument ingestDocument = randomIngestDocument(random(), document);
         FeatureProcessor processor = new FeatureProcessor("sample", "description", "location");
         IllegalArgumentException exception = assertThrows(IllegalArgumentException.class, () -> processor.execute(ingestDocument));
-        assertTrue(exception.getMessage().contains(Feature.GEOMETRY_KEY + " cannot be null"));
+        assertTrue(exception.getMessage().contains(GEOMETRY_KEY + " cannot be null"));
     }
 
     public void testFeatureProcessorWithInvalidGeometry() {
         Map<String, Object> document = buildTestFeature();
-        document.put(Feature.GEOMETRY_KEY, "invalid-value");
-        IngestDocument ingestDocument = RandomDocumentPicks.randomIngestDocument(random(), document);
+        document.put(GEOMETRY_KEY, "invalid-value");
+        IngestDocument ingestDocument = randomIngestDocument(random(), document);
         FeatureProcessor processor = new FeatureProcessor("sample", "description", "location");
         IllegalArgumentException exception = assertThrows(IllegalArgumentException.class, () -> processor.execute(ingestDocument));
-        assertTrue(exception.getMessage().contains(Feature.GEOMETRY_KEY + " is not an instance of type Map"));
+        assertTrue(exception.getMessage().contains(GEOMETRY_KEY + " is not an instance of type Map"));
     }
 }


### PR DESCRIPTION
### Description
Feature Collection represents GeoJSON of type "FeatureCollection".
A FeatureCollection object has a member with the name "features" of type Feature,
which can be empty.
 
 
### Check List
- [x] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
