### PR TITLE
Include new route to support update index while upload

### DIFF
--- a/src/main/java/org/opensearch/geospatial/GeospatialParser.java
+++ b/src/main/java/org/opensearch/geospatial/GeospatialParser.java
@@ -78,7 +78,7 @@ public final class GeospatialParser {
      * getFeatures will return features from given map input. This function abstracts the logic to parse given input and returns
      * list of Features if exists in Map format.
      * @param geoJSON given input which may contain GeoJSON Object
-     * @return List of Feature in Map
+     * @return Optional List of Feature in Map, if Feature exist
      */
     public static Optional<List<Map<String, Object>>> getFeatures(final Map<String, Object> geoJSON) {
         final String type = extractValueAsString(geoJSON, TYPE_KEY);

--- a/src/main/java/org/opensearch/geospatial/GeospatialParser.java
+++ b/src/main/java/org/opensearch/geospatial/GeospatialParser.java
@@ -78,7 +78,8 @@ public final class GeospatialParser {
      * getFeatures will return features from given map input. This function abstracts the logic to parse given input and returns
      * list of Features if exists in Map format.
      * @param geoJSON given input which may contain GeoJSON Object
-     * @return Optional List of Feature in Map, if Feature exist
+     * @return Returns an Optional with the List of Features as map if input is GeoJSON,
+     * else, returns an empty Optional instance.
      */
     public static Optional<List<Map<String, Object>>> getFeatures(final Map<String, Object> geoJSON) {
         final String type = extractValueAsString(geoJSON, TYPE_KEY);

--- a/src/main/java/org/opensearch/geospatial/action/upload/geojson/UploadGeoJSONRequest.java
+++ b/src/main/java/org/opensearch/geospatial/action/upload/geojson/UploadGeoJSONRequest.java
@@ -19,22 +19,36 @@ import org.opensearch.action.ActionRequestValidationException;
 import org.opensearch.common.bytes.BytesReference;
 import org.opensearch.common.io.stream.StreamInput;
 import org.opensearch.common.io.stream.StreamOutput;
+import org.opensearch.rest.RestRequest;
 
 public class UploadGeoJSONRequest extends ActionRequest {
 
+    private final RestRequest.Method method;
     private BytesReference content;
 
-    public UploadGeoJSONRequest(BytesReference content) {
-        this.content = Objects.requireNonNull(content);
+    public UploadGeoJSONRequest(RestRequest.Method method, BytesReference content) {
+        super();
+        this.method = Objects.requireNonNull(method, "method cannot be null");
+        this.content = Objects.requireNonNull(content, "content cannot be null");
     }
 
     public UploadGeoJSONRequest(StreamInput in) throws IOException {
         super(in);
         this.content = Objects.requireNonNull(in.readBytesReference());
+        this.method = in.readEnum(RestRequest.Method.class);
     }
 
     public BytesReference getContent() {
         return content;
+    }
+
+    /**
+     * getter for Request method type. This will be useful to decide whether new index should
+     * be created for upload request or not.
+     * @return RestRequest.Method either PUT or POST
+     */
+    public RestRequest.Method getMethod() {
+        return method;
     }
 
     @Override
@@ -46,5 +60,6 @@ public class UploadGeoJSONRequest extends ActionRequest {
     public void writeTo(StreamOutput out) throws IOException {
         super.writeTo(out);
         out.writeBytesReference(content);
+        out.writeEnum(method);
     }
 }

--- a/src/main/java/org/opensearch/geospatial/action/upload/geojson/UploadGeoJSONRequest.java
+++ b/src/main/java/org/opensearch/geospatial/action/upload/geojson/UploadGeoJSONRequest.java
@@ -34,8 +34,8 @@ public class UploadGeoJSONRequest extends ActionRequest {
 
     public UploadGeoJSONRequest(StreamInput in) throws IOException {
         super(in);
-        this.content = Objects.requireNonNull(in.readBytesReference());
-        this.method = in.readEnum(RestRequest.Method.class);
+        this.content = Objects.requireNonNull(in.readBytesReference(), "data is missing");
+        this.method = Objects.requireNonNull(in.readEnum(RestRequest.Method.class), "RestRequest Method is missing");
     }
 
     public BytesReference getContent() {

--- a/src/main/java/org/opensearch/geospatial/action/upload/geojson/UploadGeoJSONRequestContent.java
+++ b/src/main/java/org/opensearch/geospatial/action/upload/geojson/UploadGeoJSONRequestContent.java
@@ -52,7 +52,7 @@ public final class UploadGeoJSONRequestContent {
             throw new IllegalArgumentException("field [ " + FIELD_GEOSPATIAL.getPreferredName() + " ] cannot be empty");
         }
         String fieldType = extractValueAsString(input, FIELD_GEOSPATIAL_TYPE.getPreferredName());
-        if (!Strings.hasText(fieldName)) {
+        if (!Strings.hasText(fieldType)) {
             throw new IllegalArgumentException("field [ " + FIELD_GEOSPATIAL_TYPE.getPreferredName() + " ] cannot be empty");
         }
         Object geoJSONData = Objects.requireNonNull(

--- a/src/main/java/org/opensearch/geospatial/action/upload/geojson/UploadGeoJSONRequestContent.java
+++ b/src/main/java/org/opensearch/geospatial/action/upload/geojson/UploadGeoJSONRequestContent.java
@@ -55,7 +55,6 @@ public final class UploadGeoJSONRequestContent {
         if (!Strings.hasText(fieldName)) {
             throw new IllegalArgumentException("field [ " + FIELD_GEOSPATIAL_TYPE.getPreferredName() + " ] cannot be empty");
         }
-
         Object geoJSONData = Objects.requireNonNull(
             input.get(FIELD_DATA.getPreferredName()),
             "field [ " + FIELD_DATA.getPreferredName() + " ] cannot be empty"

--- a/src/main/java/org/opensearch/geospatial/action/upload/geojson/UploadGeoJSONTransportAction.java
+++ b/src/main/java/org/opensearch/geospatial/action/upload/geojson/UploadGeoJSONTransportAction.java
@@ -35,14 +35,18 @@ public class UploadGeoJSONTransportAction extends HandledTransportAction<UploadG
     @Override
     protected void doExecute(Task task, UploadGeoJSONRequest request, ActionListener<AcknowledgedResponse> actionListener) {
         Map<String, Object> contentAsMap = GeospatialParser.convertToMap(request.getContent());
-        UploadGeoJSONRequestContent content = UploadGeoJSONRequestContent.create(contentAsMap);
-        // TODO https://github.com/opensearch-project/geospatial/issues/28 (Add logic to execute import action)
-        // 1. get index name and geospatial field from content
-        // 2. create index with mapping
-        // 3. Parse Data to get GeoJSON Object
-        // 4. Get features from GeoJSON
-        // 5. create Pipeline with GeoJSONFeatureProcessor
-        // 6. Create BulkIndex Request with features as documents.
-        actionListener.onResponse(new AcknowledgedResponse(true));
+        try {
+            UploadGeoJSONRequestContent content = UploadGeoJSONRequestContent.create(contentAsMap);
+            // TODO https://github.com/opensearch-project/geospatial/issues/28 (Add logic to execute import action)
+            // 1. get index name and geospatial field from content
+            // 2. create index with mapping
+            // 3. Parse Data to get GeoJSON Object
+            // 4. Get features from GeoJSON
+            // 5. create Pipeline with GeoJSONFeatureProcessor
+            // 6. Create BulkIndex Request with features as documents.
+            actionListener.onResponse(new AcknowledgedResponse(true));
+        } catch (Exception e) {
+            actionListener.onFailure(e);
+        }
     }
 }

--- a/src/main/java/org/opensearch/geospatial/plugin/GeospatialPlugin.java
+++ b/src/main/java/org/opensearch/geospatial/plugin/GeospatialPlugin.java
@@ -38,9 +38,10 @@ import org.opensearch.rest.RestHandler;
 public class GeospatialPlugin extends Plugin implements IngestPlugin, ActionPlugin {
     public static final String NAME = "geospatial";
     public static final String PLUGIN_PREFIX = "_plugins";
+    public static final String URL_DELIMITER = "/";
 
     public static String getPluginURLPrefix() {
-        return String.join("/", PLUGIN_PREFIX, NAME);
+        return String.join(URL_DELIMITER, PLUGIN_PREFIX, NAME);
     }
 
     @Override

--- a/src/main/java/org/opensearch/geospatial/rest/action/upload/geojson/RestUploadGeoJSONAction.java
+++ b/src/main/java/org/opensearch/geospatial/rest/action/upload/geojson/RestUploadGeoJSONAction.java
@@ -5,9 +5,11 @@
 
 package org.opensearch.geospatial.rest.action.upload.geojson;
 
-import static java.util.Collections.singletonList;
+import static java.util.Collections.unmodifiableList;
 import static org.opensearch.rest.RestRequest.Method.POST;
+import static org.opensearch.rest.RestRequest.Method.PUT;
 
+import java.util.Arrays;
 import java.util.List;
 
 import org.opensearch.client.node.NodeClient;
@@ -40,14 +42,46 @@ public class RestUploadGeoJSONAction extends BaseRestHandler {
      * Supported Routes are
      * POST /_plugins/geospatial/geojson/_upload
      * {
-     *     //TODO https://github.com/opensearch-project/geospatial/issues/29 (implement request body)
+     *   "index": "create_new_index",
+     *   "field" : "geospatial field name",
+     *   "type" : "geospatial field type",
+     *   "data" : [
+     *    {
+     *       "type": "Feature",
+     *       "geometry": {
+     *          "type": "Polygon",
+     *          "coordinates": [
+     *                [
+     *                    [100.0, 0.0],
+     *                    [101.0, 0.0],
+     *                    [101.0, 1.0],
+     *                    [100.0, 1.0],
+     *                    [100.0, 0.0]
+     *                ]
+     *           ]
+     *       },
+     *       "properties": {
+     *          "prop0": "value0",
+     *          "prop1": {
+     *             "this": "that"
+     *          }
+     *      }
+     *   }
+     *  ]
      * }
-     *
+     * PUT /_plugins/geospatial/geojson/_upload
+     * {
+     *   "index": "create_new_index_if_does_not_exists",
+     *   ....... same as POST ..........
+     * }
+     * The difference between PUT and POST is how index existence is tolerated.
+     * For POST, index should not exist, if found exists, operation will fail.
+     * For PUT, index existence doesn't matter, it will create if it doesn't exists.
      */
     @Override
     public List<Route> routes() {
         String path = String.join(URL_DELIMITER, GeospatialPlugin.getPluginURLPrefix(), ACTION_OBJECT, ACTION_UPLOAD);
-        return singletonList(new Route(POST, path));
+        return unmodifiableList(Arrays.asList(new Route(POST, path), new Route(PUT, path)));
     }
 
     @Override

--- a/src/main/java/org/opensearch/geospatial/rest/action/upload/geojson/RestUploadGeoJSONAction.java
+++ b/src/main/java/org/opensearch/geospatial/rest/action/upload/geojson/RestUploadGeoJSONAction.java
@@ -87,7 +87,8 @@ public class RestUploadGeoJSONAction extends BaseRestHandler {
     @Override
     protected RestChannelConsumer prepareRequest(RestRequest restRequest, NodeClient client) {
         Tuple<XContentType, BytesReference> sourceTuple = restRequest.contentOrSourceParam();
-        UploadGeoJSONRequest request = new UploadGeoJSONRequest(sourceTuple.v2());
+        RestRequest.Method method = restRequest.getHttpRequest().method();
+        UploadGeoJSONRequest request = new UploadGeoJSONRequest(method, sourceTuple.v2());
         return channel -> client.execute(UploadGeoJSONAction.INSTANCE, request, new RestToXContentListener<>(channel));
     }
 }

--- a/src/main/java/org/opensearch/geospatial/rest/action/upload/geojson/RestUploadGeoJSONAction.java
+++ b/src/main/java/org/opensearch/geospatial/rest/action/upload/geojson/RestUploadGeoJSONAction.java
@@ -28,10 +28,8 @@ import org.opensearch.rest.action.RestToXContentListener;
  */
 public class RestUploadGeoJSONAction extends BaseRestHandler {
 
-    public static final String ACTION_OBJECT = "geojson";
-    public static final String ACTION_UPLOAD = "_upload";
+    public static final String GEOJSON = "geojson";
     public static final String NAME = "upload_geojson_action";
-    public static final String URL_DELIMITER = "/";
 
     @Override
     public String getName() {
@@ -40,7 +38,7 @@ public class RestUploadGeoJSONAction extends BaseRestHandler {
 
     /**
      * Supported Routes are
-     * POST /_plugins/geospatial/geojson/_upload
+     * POST /_plugins/geospatial/geojson/
      * {
      *   "index": "create_new_index",
      *   "field" : "geospatial field name",
@@ -69,7 +67,7 @@ public class RestUploadGeoJSONAction extends BaseRestHandler {
      *   }
      *  ]
      * }
-     * PUT /_plugins/geospatial/geojson/_upload
+     * PUT /_plugins/geospatial/geojson
      * {
      *   "index": "create_new_index_if_does_not_exists",
      *   ....... same as POST ..........
@@ -80,7 +78,7 @@ public class RestUploadGeoJSONAction extends BaseRestHandler {
      */
     @Override
     public List<Route> routes() {
-        String path = String.join(URL_DELIMITER, GeospatialPlugin.getPluginURLPrefix(), ACTION_OBJECT, ACTION_UPLOAD);
+        String path = String.join(GeospatialPlugin.URL_DELIMITER, GeospatialPlugin.getPluginURLPrefix(), GEOJSON);
         return unmodifiableList(Arrays.asList(new Route(POST, path), new Route(PUT, path)));
     }
 

--- a/src/main/java/org/opensearch/geospatial/rest/action/upload/geojson/RestUploadGeoJSONAction.java
+++ b/src/main/java/org/opensearch/geospatial/rest/action/upload/geojson/RestUploadGeoJSONAction.java
@@ -6,6 +6,7 @@
 package org.opensearch.geospatial.rest.action.upload.geojson;
 
 import static java.util.Collections.unmodifiableList;
+import static org.opensearch.geospatial.plugin.GeospatialPlugin.URL_DELIMITER;
 import static org.opensearch.rest.RestRequest.Method.POST;
 import static org.opensearch.rest.RestRequest.Method.PUT;
 
@@ -28,7 +29,8 @@ import org.opensearch.rest.action.RestToXContentListener;
  */
 public class RestUploadGeoJSONAction extends BaseRestHandler {
 
-    public static final String GEOJSON = "geojson";
+    public static final String ACTION_OBJECT = "geojson";
+    public static final String ACTION_UPLOAD = "_upload";
     public static final String NAME = "upload_geojson_action";
 
     @Override
@@ -38,7 +40,7 @@ public class RestUploadGeoJSONAction extends BaseRestHandler {
 
     /**
      * Supported Routes are
-     * POST /_plugins/geospatial/geojson/
+     * POST /_plugins/geospatial/geojson/_upload
      * {
      *   "index": "create_new_index",
      *   "field" : "geospatial field name",
@@ -67,7 +69,7 @@ public class RestUploadGeoJSONAction extends BaseRestHandler {
      *   }
      *  ]
      * }
-     * PUT /_plugins/geospatial/geojson
+     * PUT /_plugins/geospatial/geojson/_upload
      * {
      *   "index": "create_new_index_if_does_not_exists",
      *   ....... same as POST ..........
@@ -78,7 +80,7 @@ public class RestUploadGeoJSONAction extends BaseRestHandler {
      */
     @Override
     public List<Route> routes() {
-        String path = String.join(GeospatialPlugin.URL_DELIMITER, GeospatialPlugin.getPluginURLPrefix(), GEOJSON);
+        String path = String.join(URL_DELIMITER, GeospatialPlugin.getPluginURLPrefix(), ACTION_OBJECT, ACTION_UPLOAD);
         return unmodifiableList(Arrays.asList(new Route(POST, path), new Route(PUT, path)));
     }
 

--- a/src/test/java/org/opensearch/geospatial/GeospatialObjectBuilder.java
+++ b/src/test/java/org/opensearch/geospatial/GeospatialObjectBuilder.java
@@ -11,6 +11,8 @@ import java.util.stream.IntStream;
 import org.json.JSONArray;
 import org.json.JSONObject;
 import org.opensearch.common.Randomness;
+import org.opensearch.common.Strings;
+import org.opensearch.common.UUIDs;
 import org.opensearch.common.collect.List;
 import org.opensearch.common.geo.GeoShapeType;
 import org.opensearch.geo.GeometryTestUtils;
@@ -80,8 +82,17 @@ public class GeospatialObjectBuilder {
         return Randomness.get().ints(min, max).findFirst().getAsInt();
     }
 
+    public static JSONObject randomGeoJSONFeature(final JSONObject properties, String featureId) {
+        JSONObject geoJSONFeature = buildGeoJSONFeature(randomGeoJSONGeometry(), properties);
+        if (!Strings.hasText(featureId)) {
+            return geoJSONFeature;
+        }
+        geoJSONFeature.put(featureId, UUIDs.randomBase64UUID());
+        return geoJSONFeature;
+    }
+
     public static JSONObject randomGeoJSONFeature(final JSONObject properties) {
-        return buildGeoJSONFeature(randomGeoJSONGeometry(), properties);
+        return randomGeoJSONFeature(properties, null);
     }
 
     public static JSONObject randomGeoJSONGeometry() {

--- a/src/test/java/org/opensearch/geospatial/GeospatialObjectBuilder.java
+++ b/src/test/java/org/opensearch/geospatial/GeospatialObjectBuilder.java
@@ -11,7 +11,6 @@ import java.util.stream.IntStream;
 import org.json.JSONArray;
 import org.json.JSONObject;
 import org.opensearch.common.Randomness;
-import org.opensearch.common.Strings;
 import org.opensearch.common.UUIDs;
 import org.opensearch.common.collect.List;
 import org.opensearch.common.geo.GeoShapeType;
@@ -32,6 +31,7 @@ public class GeospatialObjectBuilder {
     public static final int MIN_LINE_STRING_COORDINATES_SIZE = 2;
     public static final int MAX_POINTS = 10;
     public static final int POINTS_SIZE = 2;
+    public static final String GEOJSON_FIELD_ID = "id";
 
     public static JSONObject buildGeometry(String type, Object value) {
         JSONObject geometry = new JSONObject();
@@ -82,17 +82,12 @@ public class GeospatialObjectBuilder {
         return Randomness.get().ints(min, max).findFirst().getAsInt();
     }
 
-    public static JSONObject randomGeoJSONFeature(final JSONObject properties, String featureId) {
-        JSONObject geoJSONFeature = buildGeoJSONFeature(randomGeoJSONGeometry(), properties);
-        if (!Strings.hasText(featureId)) {
-            return geoJSONFeature;
-        }
-        geoJSONFeature.put(featureId, UUIDs.randomBase64UUID());
-        return geoJSONFeature;
-    }
-
     public static JSONObject randomGeoJSONFeature(final JSONObject properties) {
-        return randomGeoJSONFeature(properties, null);
+        JSONObject geoJSONFeature = buildGeoJSONFeature(randomGeoJSONGeometry(), properties);
+        if (Randomness.get().nextBoolean()) {
+            geoJSONFeature.put(GEOJSON_FIELD_ID, UUIDs.randomBase64UUID());
+        }
+        return geoJSONFeature;
     }
 
     public static JSONObject randomGeoJSONGeometry() {

--- a/src/test/java/org/opensearch/geospatial/GeospatialRestTestCase.java
+++ b/src/test/java/org/opensearch/geospatial/GeospatialRestTestCase.java
@@ -9,11 +9,13 @@ import static java.util.stream.Collectors.joining;
 import static org.opensearch.geospatial.GeospatialObjectBuilder.buildProperties;
 import static org.opensearch.geospatial.GeospatialObjectBuilder.randomGeoJSONFeature;
 import static org.opensearch.geospatial.action.upload.geojson.UploadGeoJSONRequestContent.FIELD_DATA;
+import static org.opensearch.ingest.RandomDocumentPicks.randomString;
 
 import java.io.IOException;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
+import java.util.Locale;
 import java.util.Map;
 import java.util.Optional;
 
@@ -110,15 +112,25 @@ public abstract class GeospatialRestTestCase extends OpenSearchRestTestCase {
     }
 
     // TODO This method is copied from unit test. Refactor to common class to share across tests
-    protected JSONObject buildRequestContent(String indexName, String fieldName) {
+    protected JSONObject buildUploadGeoJSONRequestContent() {
         JSONObject contents = new JSONObject();
-        contents.put(UploadGeoJSONRequestContent.FIELD_INDEX.getPreferredName(), indexName);
-        contents.put(UploadGeoJSONRequestContent.FIELD_GEOSPATIAL.getPreferredName(), fieldName);
+        contents.put(UploadGeoJSONRequestContent.FIELD_INDEX.getPreferredName(), randomLowerCaseString());
+        contents.put(UploadGeoJSONRequestContent.FIELD_GEOSPATIAL.getPreferredName(), randomString(random()));
+        String fieldId = null;
+        if (randomBoolean()) {
+            fieldId = randomLowerCaseString();
+            contents.put(UploadGeoJSONRequestContent.FIELD_FEATURE_ID.getPreferredName(), fieldId);
+        }
         JSONArray values = new JSONArray();
-        values.put(randomGeoJSONFeature(buildProperties(Collections.emptyMap())));
-        values.put(randomGeoJSONFeature(buildProperties(Collections.emptyMap())));
+        values.put(randomGeoJSONFeature(buildProperties(Collections.emptyMap()), fieldId));
+        values.put(randomGeoJSONFeature(buildProperties(Collections.emptyMap()), fieldId));
+        values.put(randomGeoJSONFeature(buildProperties(Collections.emptyMap()), fieldId));
         values.put(randomGeoJSONFeature(buildProperties(Collections.emptyMap())));
         contents.put(FIELD_DATA.getPreferredName(), values);
         return contents;
+    }
+
+    private String randomLowerCaseString() {
+        return randomString(random()).toLowerCase(Locale.getDefault());
     }
 }

--- a/src/test/java/org/opensearch/geospatial/GeospatialRestTestCase.java
+++ b/src/test/java/org/opensearch/geospatial/GeospatialRestTestCase.java
@@ -116,6 +116,7 @@ public abstract class GeospatialRestTestCase extends OpenSearchRestTestCase {
         JSONObject contents = new JSONObject();
         contents.put(UploadGeoJSONRequestContent.FIELD_INDEX.getPreferredName(), randomLowerCaseString());
         contents.put(UploadGeoJSONRequestContent.FIELD_GEOSPATIAL.getPreferredName(), randomString(random()));
+        contents.put(UploadGeoJSONRequestContent.FIELD_GEOSPATIAL_TYPE.getPreferredName(), "geo_shape");
         String fieldId = null;
         if (randomBoolean()) {
             fieldId = randomLowerCaseString();

--- a/src/test/java/org/opensearch/geospatial/GeospatialRestTestCase.java
+++ b/src/test/java/org/opensearch/geospatial/GeospatialRestTestCase.java
@@ -9,7 +9,6 @@ import static java.util.stream.Collectors.joining;
 import static org.opensearch.geospatial.GeospatialObjectBuilder.buildProperties;
 import static org.opensearch.geospatial.GeospatialObjectBuilder.randomGeoJSONFeature;
 import static org.opensearch.geospatial.action.upload.geojson.UploadGeoJSONRequestContent.FIELD_DATA;
-import static org.opensearch.ingest.RandomDocumentPicks.randomString;
 
 import java.io.IOException;
 import java.util.Collections;
@@ -41,6 +40,8 @@ public abstract class GeospatialRestTestCase extends OpenSearchRestTestCase {
     public static final String URL_DELIMITER = "/";
     public static final String FIELD_TYPE_KEY = "type";
     public static final String MAPPING_PROPERTIES_KEY = "properties";
+    public static final int RANDOM_STRING_MIN_LENGTH = 2;
+    public static final int RANDOM_STRING_MAX_LENGTH = 16;
 
     private static String buildPipelinePath(String name) {
         return String.join(URL_DELIMITER, "_ingest", "pipeline", name);
@@ -115,7 +116,7 @@ public abstract class GeospatialRestTestCase extends OpenSearchRestTestCase {
     protected JSONObject buildUploadGeoJSONRequestContent() {
         JSONObject contents = new JSONObject();
         contents.put(UploadGeoJSONRequestContent.FIELD_INDEX.getPreferredName(), randomLowerCaseString());
-        contents.put(UploadGeoJSONRequestContent.FIELD_GEOSPATIAL.getPreferredName(), randomString(random()));
+        contents.put(UploadGeoJSONRequestContent.FIELD_GEOSPATIAL.getPreferredName(), randomString());
         contents.put(UploadGeoJSONRequestContent.FIELD_GEOSPATIAL_TYPE.getPreferredName(), "geo_shape");
         String fieldId = null;
         if (randomBoolean()) {
@@ -131,7 +132,11 @@ public abstract class GeospatialRestTestCase extends OpenSearchRestTestCase {
         return contents;
     }
 
+    private String randomString() {
+        return randomAlphaOfLengthBetween(RANDOM_STRING_MIN_LENGTH, RANDOM_STRING_MAX_LENGTH);
+    }
+
     private String randomLowerCaseString() {
-        return randomString(random()).toLowerCase(Locale.getDefault());
+        return randomString().toLowerCase(Locale.getDefault());
     }
 }

--- a/src/test/java/org/opensearch/geospatial/GeospatialRestTestCase.java
+++ b/src/test/java/org/opensearch/geospatial/GeospatialRestTestCase.java
@@ -118,15 +118,10 @@ public abstract class GeospatialRestTestCase extends OpenSearchRestTestCase {
         contents.put(UploadGeoJSONRequestContent.FIELD_INDEX.getPreferredName(), randomLowerCaseString());
         contents.put(UploadGeoJSONRequestContent.FIELD_GEOSPATIAL.getPreferredName(), randomString());
         contents.put(UploadGeoJSONRequestContent.FIELD_GEOSPATIAL_TYPE.getPreferredName(), "geo_shape");
-        String fieldId = null;
-        if (randomBoolean()) {
-            fieldId = randomLowerCaseString();
-            contents.put(UploadGeoJSONRequestContent.FIELD_FEATURE_ID.getPreferredName(), fieldId);
-        }
         JSONArray values = new JSONArray();
-        values.put(randomGeoJSONFeature(buildProperties(Collections.emptyMap()), fieldId));
-        values.put(randomGeoJSONFeature(buildProperties(Collections.emptyMap()), fieldId));
-        values.put(randomGeoJSONFeature(buildProperties(Collections.emptyMap()), fieldId));
+        values.put(randomGeoJSONFeature(buildProperties(Collections.emptyMap())));
+        values.put(randomGeoJSONFeature(buildProperties(Collections.emptyMap())));
+        values.put(randomGeoJSONFeature(buildProperties(Collections.emptyMap())));
         values.put(randomGeoJSONFeature(buildProperties(Collections.emptyMap())));
         contents.put(FIELD_DATA.getPreferredName(), values);
         return contents;

--- a/src/test/java/org/opensearch/geospatial/action/upload/geojson/UploadGeoJSONRequestContentTests.java
+++ b/src/test/java/org/opensearch/geospatial/action/upload/geojson/UploadGeoJSONRequestContentTests.java
@@ -22,6 +22,7 @@ public class UploadGeoJSONRequestContentTests extends OpenSearchTestCase {
         JSONObject contents = new JSONObject();
         contents.put(UploadGeoJSONRequestContent.FIELD_INDEX.getPreferredName(), indexName);
         contents.put(UploadGeoJSONRequestContent.FIELD_GEOSPATIAL.getPreferredName(), fieldName);
+        contents.put(UploadGeoJSONRequestContent.FIELD_GEOSPATIAL_TYPE.getPreferredName(), "geo_shape");
         JSONArray values = new JSONArray();
         values.put(randomGeoJSONFeature(buildProperties(Collections.emptyMap())));
         values.put(randomGeoJSONFeature(buildProperties(Collections.emptyMap())));
@@ -46,7 +47,7 @@ public class UploadGeoJSONRequestContentTests extends OpenSearchTestCase {
             IllegalArgumentException.class,
             () -> UploadGeoJSONRequestContent.create(buildRequestContent("", "location"))
         );
-        assertTrue(invalidIndexName.getMessage().contains("cannot be empty"));
+        assertTrue(invalidIndexName.getMessage().contains("[ index ] cannot be empty"));
     }
 
     public void testCreateEmptyGeospatialFieldName() {
@@ -54,6 +55,18 @@ public class UploadGeoJSONRequestContentTests extends OpenSearchTestCase {
             IllegalArgumentException.class,
             () -> UploadGeoJSONRequestContent.create(buildRequestContent("some-index", ""))
         );
-        assertTrue(invalidIndexName.getMessage().contains("cannot be empty"));
+        assertTrue(invalidIndexName.getMessage().contains("[ field ] cannot be empty"));
+    }
+
+    public void testCreateEmptyGeospatialFieldType() {
+        final String indexName = "some-index";
+        final String fieldName = "location";
+        Map<String, Object> contents = buildRequestContent(indexName, fieldName);
+        contents.remove(UploadGeoJSONRequestContent.FIELD_GEOSPATIAL_TYPE.getPreferredName());
+        IllegalArgumentException invalidIndexName = assertThrows(
+            IllegalArgumentException.class,
+            () -> UploadGeoJSONRequestContent.create(contents)
+        );
+        assertTrue(invalidIndexName.getMessage().contains("[ type ] cannot be empty"));
     }
 }

--- a/src/test/java/org/opensearch/geospatial/action/upload/geojson/UploadGeoJSONRequestTests.java
+++ b/src/test/java/org/opensearch/geospatial/action/upload/geojson/UploadGeoJSONRequestTests.java
@@ -11,6 +11,9 @@
 
 package org.opensearch.geospatial.action.upload.geojson;
 
+import static org.opensearch.rest.RestRequest.Method.POST;
+import static org.opensearch.rest.RestRequest.Method.PUT;
+
 import java.io.IOException;
 import java.nio.charset.StandardCharsets;
 import java.util.Map;
@@ -19,6 +22,7 @@ import org.json.JSONObject;
 import org.opensearch.common.bytes.BytesArray;
 import org.opensearch.common.io.stream.BytesStreamOutput;
 import org.opensearch.common.io.stream.StreamInput;
+import org.opensearch.rest.RestRequest;
 import org.opensearch.test.OpenSearchTestCase;
 
 public class UploadGeoJSONRequestTests extends OpenSearchTestCase {
@@ -36,17 +40,22 @@ public class UploadGeoJSONRequestTests extends OpenSearchTestCase {
 
     public void testStreams() throws IOException {
         String requestBody = getRequestBody(null);
-        UploadGeoJSONRequest request = new UploadGeoJSONRequest(new BytesArray(requestBody.getBytes(StandardCharsets.UTF_8)));
+        RestRequest.Method method = PUT;
+        UploadGeoJSONRequest request = new UploadGeoJSONRequest(method, new BytesArray(requestBody.getBytes(StandardCharsets.UTF_8)));
         BytesStreamOutput output = new BytesStreamOutput();
         request.writeTo(output);
         StreamInput in = StreamInput.wrap(output.bytes().toBytesRef().bytes);
 
         UploadGeoJSONRequest serialized = new UploadGeoJSONRequest(in);
         assertEquals(requestBody, serialized.getContent().utf8ToString());
+        assertEquals(method, serialized.getMethod());
     }
 
     public void testRequestValidation() {
-        UploadGeoJSONRequest request = new UploadGeoJSONRequest(new BytesArray(getRequestBody(null).getBytes(StandardCharsets.UTF_8)));
+        UploadGeoJSONRequest request = new UploadGeoJSONRequest(
+            POST,
+            new BytesArray(getRequestBody(null).getBytes(StandardCharsets.UTF_8))
+        );
         assertNull(request.validate());
     }
 }

--- a/src/test/java/org/opensearch/geospatial/rest/action/upload/geojson/RestUploadGeoJSONActionIT.java
+++ b/src/test/java/org/opensearch/geospatial/rest/action/upload/geojson/RestUploadGeoJSONActionIT.java
@@ -24,7 +24,7 @@ import org.opensearch.rest.RestStatus;
 
 public class RestUploadGeoJSONActionIT extends GeospatialRestTestCase {
 
-    public void testGeoJSONUploadSuccess() throws IOException {
+    public void testGeoJSONUploadSuccessPostMethod() throws IOException {
 
         String path = String.join(
             RestUploadGeoJSONAction.URL_DELIMITER,
@@ -33,6 +33,23 @@ public class RestUploadGeoJSONActionIT extends GeospatialRestTestCase {
             RestUploadGeoJSONAction.ACTION_UPLOAD
         );
         Request request = new Request("POST", path);
+        String indexName = randomString(random()).toLowerCase(Locale.getDefault());
+        String geoShapeField = randomString(random());
+        request.setJsonEntity(buildRequestContent(indexName, geoShapeField).toString());
+        Response response = client().performRequest(request);
+        assertEquals(RestStatus.OK, RestStatus.fromCode(response.getStatusLine().getStatusCode()));
+
+    }
+
+    public void testGeoJSONUploadSuccessPutMethod() throws IOException {
+
+        String path = String.join(
+            RestUploadGeoJSONAction.URL_DELIMITER,
+            GeospatialPlugin.getPluginURLPrefix(),
+            RestUploadGeoJSONAction.ACTION_OBJECT,
+            RestUploadGeoJSONAction.ACTION_UPLOAD
+        );
+        Request request = new Request("PUT", path);
         String indexName = randomString(random()).toLowerCase(Locale.getDefault());
         String geoShapeField = randomString(random());
         request.setJsonEntity(buildRequestContent(indexName, geoShapeField).toString());

--- a/src/test/java/org/opensearch/geospatial/rest/action/upload/geojson/RestUploadGeoJSONActionIT.java
+++ b/src/test/java/org/opensearch/geospatial/rest/action/upload/geojson/RestUploadGeoJSONActionIT.java
@@ -11,10 +11,7 @@
 
 package org.opensearch.geospatial.rest.action.upload.geojson;
 
-import static org.opensearch.ingest.RandomDocumentPicks.randomString;
-
 import java.io.IOException;
-import java.util.Locale;
 
 import org.opensearch.client.Request;
 import org.opensearch.client.Response;
@@ -33,9 +30,7 @@ public class RestUploadGeoJSONActionIT extends GeospatialRestTestCase {
             RestUploadGeoJSONAction.ACTION_UPLOAD
         );
         Request request = new Request("POST", path);
-        String indexName = randomString(random()).toLowerCase(Locale.getDefault());
-        String geoShapeField = randomString(random());
-        request.setJsonEntity(buildRequestContent(indexName, geoShapeField).toString());
+        request.setJsonEntity(buildUploadGeoJSONRequestContent().toString());
         Response response = client().performRequest(request);
         assertEquals(RestStatus.OK, RestStatus.fromCode(response.getStatusLine().getStatusCode()));
 
@@ -50,9 +45,7 @@ public class RestUploadGeoJSONActionIT extends GeospatialRestTestCase {
             RestUploadGeoJSONAction.ACTION_UPLOAD
         );
         Request request = new Request("PUT", path);
-        String indexName = randomString(random()).toLowerCase(Locale.getDefault());
-        String geoShapeField = randomString(random());
-        request.setJsonEntity(buildRequestContent(indexName, geoShapeField).toString());
+        request.setJsonEntity(buildUploadGeoJSONRequestContent().toString());
         Response response = client().performRequest(request);
         assertEquals(RestStatus.OK, RestStatus.fromCode(response.getStatusLine().getStatusCode()));
 

--- a/src/test/java/org/opensearch/geospatial/rest/action/upload/geojson/RestUploadGeoJSONActionIT.java
+++ b/src/test/java/org/opensearch/geospatial/rest/action/upload/geojson/RestUploadGeoJSONActionIT.java
@@ -11,6 +11,9 @@
 
 package org.opensearch.geospatial.rest.action.upload.geojson;
 
+import static org.opensearch.geospatial.rest.action.upload.geojson.RestUploadGeoJSONAction.ACTION_OBJECT;
+import static org.opensearch.geospatial.rest.action.upload.geojson.RestUploadGeoJSONAction.ACTION_UPLOAD;
+
 import java.io.IOException;
 
 import org.opensearch.client.Request;
@@ -23,7 +26,7 @@ public class RestUploadGeoJSONActionIT extends GeospatialRestTestCase {
 
     public void testGeoJSONUploadSuccessPostMethod() throws IOException {
 
-        String path = String.join(GeospatialPlugin.URL_DELIMITER, GeospatialPlugin.getPluginURLPrefix(), RestUploadGeoJSONAction.GEOJSON);
+        String path = String.join(GeospatialPlugin.URL_DELIMITER, GeospatialPlugin.getPluginURLPrefix(), ACTION_OBJECT, ACTION_UPLOAD);
         Request request = new Request("POST", path);
         request.setJsonEntity(buildUploadGeoJSONRequestContent().toString());
         Response response = client().performRequest(request);
@@ -33,7 +36,7 @@ public class RestUploadGeoJSONActionIT extends GeospatialRestTestCase {
 
     public void testGeoJSONUploadSuccessPutMethod() throws IOException {
 
-        String path = String.join(GeospatialPlugin.URL_DELIMITER, GeospatialPlugin.getPluginURLPrefix(), RestUploadGeoJSONAction.GEOJSON);
+        String path = String.join(GeospatialPlugin.URL_DELIMITER, GeospatialPlugin.getPluginURLPrefix(), ACTION_OBJECT, ACTION_UPLOAD);
         Request request = new Request("PUT", path);
         request.setJsonEntity(buildUploadGeoJSONRequestContent().toString());
         Response response = client().performRequest(request);

--- a/src/test/java/org/opensearch/geospatial/rest/action/upload/geojson/RestUploadGeoJSONActionIT.java
+++ b/src/test/java/org/opensearch/geospatial/rest/action/upload/geojson/RestUploadGeoJSONActionIT.java
@@ -23,12 +23,7 @@ public class RestUploadGeoJSONActionIT extends GeospatialRestTestCase {
 
     public void testGeoJSONUploadSuccessPostMethod() throws IOException {
 
-        String path = String.join(
-            RestUploadGeoJSONAction.URL_DELIMITER,
-            GeospatialPlugin.getPluginURLPrefix(),
-            RestUploadGeoJSONAction.ACTION_OBJECT,
-            RestUploadGeoJSONAction.ACTION_UPLOAD
-        );
+        String path = String.join(GeospatialPlugin.URL_DELIMITER, GeospatialPlugin.getPluginURLPrefix(), RestUploadGeoJSONAction.GEOJSON);
         Request request = new Request("POST", path);
         request.setJsonEntity(buildUploadGeoJSONRequestContent().toString());
         Response response = client().performRequest(request);
@@ -38,12 +33,7 @@ public class RestUploadGeoJSONActionIT extends GeospatialRestTestCase {
 
     public void testGeoJSONUploadSuccessPutMethod() throws IOException {
 
-        String path = String.join(
-            RestUploadGeoJSONAction.URL_DELIMITER,
-            GeospatialPlugin.getPluginURLPrefix(),
-            RestUploadGeoJSONAction.ACTION_OBJECT,
-            RestUploadGeoJSONAction.ACTION_UPLOAD
-        );
+        String path = String.join(GeospatialPlugin.URL_DELIMITER, GeospatialPlugin.getPluginURLPrefix(), RestUploadGeoJSONAction.GEOJSON);
         Request request = new Request("PUT", path);
         request.setJsonEntity(buildUploadGeoJSONRequestContent().toString());
         Response response = client().performRequest(request);


### PR DESCRIPTION
### Description
1. User might want to append new GeoJSON Features to existing index. Hence, add new route using PUT. 
This route will accept same parameter as POST, except, it ignores, if index already exists. We need different API to support
users from not accidentally insert geoJSON to existing index and intentionally support append geoJSON to existing index. 
2. Add new field called "feature_id" , to identify, most commonly used identifier in GeoJSON as feature id. This will be used as id, while indexing GeoJSON if it exists.
 

### Issues Resolved
#29
 
### Check List
- [x] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
