### PR TITLE
Add uploader to upload user input

### DIFF
--- a/src/main/java/org/opensearch/geospatial/GeospatialParser.java
+++ b/src/main/java/org/opensearch/geospatial/GeospatialParser.java
@@ -41,7 +41,7 @@ public final class GeospatialParser {
         for (Map.Entry<Object, Object> entry : inputMap.entrySet()) {
             stringObjectMap.put(entry.getKey().toString(), entry.getValue());
         }
-        return stringObjectMap;
+        return Collections.unmodifiableMap(stringObjectMap);
     }
 
     /**
@@ -71,7 +71,7 @@ public final class GeospatialParser {
      */
     public static Map<String, Object> convertToMap(BytesReference content) {
         Objects.requireNonNull(content);
-        return XContentHelper.convertToMap(content, false, XContentType.JSON).v2();
+        return Collections.unmodifiableMap(XContentHelper.convertToMap(content, false, XContentType.JSON).v2());
     }
 
     /**

--- a/src/main/java/org/opensearch/geospatial/action/upload/geojson/ContentBuilder.java
+++ b/src/main/java/org/opensearch/geospatial/action/upload/geojson/ContentBuilder.java
@@ -34,10 +34,6 @@ public class ContentBuilder {
         return prepareContentRequest(content, pipeline);
     }
 
-    private BulkRequestBuilder prepareBulkRequestBuilder() {
-        return client.prepareBulk().setRefreshPolicy(WriteRequest.RefreshPolicy.WAIT_UNTIL);
-    }
-
     // build BulkRequestBuilder, by, iterating, UploadGeoJSONRequestContent's data. This depends on
     // GeospatialParser.getFeatures to extract features from user input, create IndexRequestBuilder
     // with index name and pipeline.
@@ -59,6 +55,10 @@ public class ContentBuilder {
             return Optional.empty();
         }
         return Optional.of(builder);
+    }
+
+    private BulkRequestBuilder prepareBulkRequestBuilder() {
+        return client.prepareBulk().setRefreshPolicy(WriteRequest.RefreshPolicy.WAIT_UNTIL);
     }
 
     private IndexRequestBuilder createIndexRequestBuilder(Map<String, Object> source) {

--- a/src/main/java/org/opensearch/geospatial/action/upload/geojson/ContentBuilder.java
+++ b/src/main/java/org/opensearch/geospatial/action/upload/geojson/ContentBuilder.java
@@ -38,9 +38,12 @@ public class ContentBuilder {
     // GeospatialParser.getFeatures to extract features from user input, create IndexRequestBuilder
     // with index name and pipeline.
     private Optional<BulkRequestBuilder> prepareContentRequest(UploadGeoJSONRequestContent content, String pipeline) {
+        if (content.getData().isEmpty()) {
+            return Optional.empty();
+        }
         BulkRequestBuilder builder = prepareBulkRequestBuilder();
-        List<Object> documents = (List<Object>) content.getData();
-        documents.stream()
+        content.getData()
+            .stream()
             .map(GeospatialParser::toStringObjectMap)
             .map(GeospatialParser::getFeatures)
             .filter(Optional::isPresent)

--- a/src/main/java/org/opensearch/geospatial/action/upload/geojson/ContentBuilder.java
+++ b/src/main/java/org/opensearch/geospatial/action/upload/geojson/ContentBuilder.java
@@ -1,0 +1,75 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ *
+ * Modifications Copyright OpenSearch Contributors. See
+ * GitHub history for details.
+ */
+
+package org.opensearch.geospatial.action.upload.geojson;
+
+import java.util.List;
+import java.util.Map;
+import java.util.Objects;
+import java.util.Optional;
+
+import org.opensearch.action.bulk.BulkRequestBuilder;
+import org.opensearch.action.index.IndexRequestBuilder;
+import org.opensearch.action.support.WriteRequest;
+import org.opensearch.client.Client;
+import org.opensearch.common.Strings;
+import org.opensearch.geospatial.GeospatialParser;
+
+/**
+ * ContentBuilder is responsible for preparing Request that can be executed
+ * to upload GeoJSON Features as Documents.
+ */
+public class ContentBuilder {
+    public static final String GEOJSON_FEATURE_ID_FIELD = "id";
+    public static final String DOCUMENT_TYPE = "_doc";
+    private final Client client;
+
+    public ContentBuilder(Client client) {
+        this.client = Objects.requireNonNull(client, "Client cannot be null");
+    }
+
+    public Optional<BulkRequestBuilder> prepare(UploadGeoJSONRequestContent content, String pipeline) {
+        return prepareContentRequest(content, pipeline);
+    }
+
+    private BulkRequestBuilder prepareBulkRequestBuilder() {
+        return client.prepareBulk().setRefreshPolicy(WriteRequest.RefreshPolicy.WAIT_UNTIL);
+    }
+
+    // build BulkRequestBuilder, by, iterating, UploadGeoJSONRequestContent's data. This depends on
+    // GeospatialParser.getFeatures to extract features from user input, create IndexRequestBuilder
+    // with index name and pipeline.
+    private Optional<BulkRequestBuilder> prepareContentRequest(UploadGeoJSONRequestContent content, String pipeline) {
+        BulkRequestBuilder builder = prepareBulkRequestBuilder();
+        List<Object> documents = (List<Object>) content.getData();
+        documents.stream()
+            .map(GeospatialParser::toStringObjectMap)
+            .map(GeospatialParser::getFeatures)
+            .filter(Optional::isPresent)
+            .map(Optional::get)
+            .flatMap(List::stream)
+            .map(documentSource -> createIndexRequestBuilder(documentSource))
+            .map(indexRequestBuilder -> indexRequestBuilder.setIndex(content.getIndexName()))
+            .map(indexRequestBuilder -> indexRequestBuilder.setPipeline(pipeline))
+            .map(indexRequestBuilder -> indexRequestBuilder.setType(DOCUMENT_TYPE))
+            .forEach(builder::add);
+        if (builder.numberOfActions() < 1) { // check any features to upload
+            return Optional.empty();
+        }
+        return Optional.of(builder);
+    }
+
+    private IndexRequestBuilder createIndexRequestBuilder(Map<String, Object> source) {
+        final IndexRequestBuilder requestBuilder = client.prepareIndex().setSource(source);
+        String id = GeospatialParser.extractValueAsString(source, GEOJSON_FEATURE_ID_FIELD);
+        return Strings.hasText(id) ? requestBuilder.setId(id) : requestBuilder;
+    }
+}

--- a/src/main/java/org/opensearch/geospatial/action/upload/geojson/ContentBuilder.java
+++ b/src/main/java/org/opensearch/geospatial/action/upload/geojson/ContentBuilder.java
@@ -23,7 +23,7 @@ import org.opensearch.geospatial.GeospatialParser;
  */
 public class ContentBuilder {
     public static final String GEOJSON_FEATURE_ID_FIELD = "id";
-    public static final String DOCUMENT_TYPE = "_doc";
+    private static final String DOCUMENT_TYPE = "_doc";
     private final Client client;
 
     public ContentBuilder(Client client) {
@@ -41,7 +41,7 @@ public class ContentBuilder {
         if (content.getData().isEmpty()) {
             return Optional.empty();
         }
-        BulkRequestBuilder builder = prepareBulkRequestBuilder();
+        final BulkRequestBuilder builder = prepareBulkRequestBuilder();
         content.getData()
             .stream()
             .map(GeospatialParser::toStringObjectMap)

--- a/src/main/java/org/opensearch/geospatial/action/upload/geojson/ContentBuilder.java
+++ b/src/main/java/org/opensearch/geospatial/action/upload/geojson/ContentBuilder.java
@@ -1,12 +1,6 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
- * The OpenSearch Contributors require contributions made to
- * this file be licensed under the Apache-2.0 license or a
- * compatible open source license.
- *
- * Modifications Copyright OpenSearch Contributors. See
- * GitHub history for details.
  */
 
 package org.opensearch.geospatial.action.upload.geojson;

--- a/src/main/java/org/opensearch/geospatial/action/upload/geojson/IndexManager.java
+++ b/src/main/java/org/opensearch/geospatial/action/upload/geojson/IndexManager.java
@@ -25,10 +25,10 @@ public class IndexManager {
     public static final String FIELD_TYPE_KEY = "type";
     public static final String MAPPING_PROPERTIES_KEY = "properties";
     public static final String DOCUMENT_TYPE = "_doc";
-    private final Logger logger = LogManager.getLogger(IndexManager.class);
+    private static final Logger LOGGER = LogManager.getLogger(IndexManager.class);
     private final IndicesAdminClient client;
 
-    public IndexManager(IndicesAdminClient client) {
+    public IndexManager(final IndicesAdminClient client) {
         this.client = Objects.requireNonNull(client, "Index admin client cannot be null");
     }
 
@@ -38,7 +38,7 @@ public class IndexManager {
      * @param fieldNameTypeMap Map of field name and type, that will be used for creating mapping.
      * @param createIndexStep Notification Listener that will notify status of action
      */
-    public void create(String indexName, Map<String, String> fieldNameTypeMap, StepListener<Void> createIndexStep) {
+    public void create(final String indexName, final Map<String, String> fieldNameTypeMap, final StepListener<Void> createIndexStep) {
         try (XContentBuilder mapping = buildMapping(fieldNameTypeMap)) {
             createIndex(indexName, mapping, createIndexStep);
         } catch (IOException mappingFailedException) {
@@ -59,7 +59,7 @@ public class IndexManager {
         CreateIndexRequest request = new CreateIndexRequest(indexName).mapping(DOCUMENT_TYPE, mapping);
         client.create(request, ActionListener.wrap(createIndexResponse -> {
             StringBuilder message = new StringBuilder("Created index: ").append(indexName);
-            logger.info(message.toString());
+            LOGGER.info(message.toString());
             createIndexStep.onResponse(null);
         }, createIndexStep::onFailure));
     }

--- a/src/main/java/org/opensearch/geospatial/action/upload/geojson/IndexManager.java
+++ b/src/main/java/org/opensearch/geospatial/action/upload/geojson/IndexManager.java
@@ -1,0 +1,72 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ *
+ * Modifications Copyright OpenSearch Contributors. See
+ * GitHub history for details.
+ */
+
+package org.opensearch.geospatial.action.upload.geojson;
+
+import java.io.IOException;
+import java.util.Map;
+import java.util.Objects;
+
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+import org.opensearch.action.ActionListener;
+import org.opensearch.action.StepListener;
+import org.opensearch.action.admin.indices.create.CreateIndexRequest;
+import org.opensearch.client.IndicesAdminClient;
+import org.opensearch.common.xcontent.XContentBuilder;
+import org.opensearch.common.xcontent.XContentFactory;
+
+/**
+ * IndexManager is responsible for managing index operations like create, delete, etc...
+ */
+public class IndexManager {
+    public static final String FIELD_TYPE_KEY = "type";
+    public static final String MAPPING_PROPERTIES_KEY = "properties";
+    public static final String DOCUMENT_TYPE = "_doc";
+    private final Logger logger = LogManager.getLogger(IndexManager.class);
+    private final IndicesAdminClient client;
+
+    public IndexManager(IndicesAdminClient client) {
+        this.client = Objects.requireNonNull(client, "Index admin client cannot be null");
+    }
+
+    /**
+     * Creates an index and notifies the listener on status of action.
+     * @param indexName Index Name to be created
+     * @param fieldNameTypeMap Map of field name and type, that will be used for creating mapping.
+     * @param createIndexStep Notification Listener that will notify status of action
+     */
+    public void create(String indexName, Map<String, String> fieldNameTypeMap, StepListener<Void> createIndexStep) {
+        try (XContentBuilder mapping = buildMapping(fieldNameTypeMap)) {
+            createIndex(indexName, mapping, createIndexStep);
+        } catch (IOException mappingFailedException) {
+            createIndexStep.onFailure(mappingFailedException);
+        }
+    }
+
+    private XContentBuilder buildMapping(Map<String, String> fieldMap) throws IOException {
+        final XContentBuilder mapBuilder = XContentFactory.jsonBuilder().startObject().startObject(MAPPING_PROPERTIES_KEY);
+        for (Map.Entry<String, String> field : fieldMap.entrySet()) {
+            mapBuilder.startObject(field.getKey()).field(FIELD_TYPE_KEY, field.getValue()).endObject();
+        }
+        mapBuilder.endObject().endObject();
+        return mapBuilder;
+    }
+
+    private void createIndex(String indexName, XContentBuilder mapping, StepListener<Void> createIndexStep) {
+        CreateIndexRequest request = new CreateIndexRequest(indexName).mapping(DOCUMENT_TYPE, mapping);
+        client.create(request, ActionListener.wrap(createIndexResponse -> {
+            StringBuilder message = new StringBuilder("Created index: ").append(indexName);
+            logger.info(message.toString());
+            createIndexStep.onResponse(null);
+        }, createIndexStep::onFailure));
+    }
+}

--- a/src/main/java/org/opensearch/geospatial/action/upload/geojson/IndexManager.java
+++ b/src/main/java/org/opensearch/geospatial/action/upload/geojson/IndexManager.java
@@ -1,12 +1,6 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
- * The OpenSearch Contributors require contributions made to
- * this file be licensed under the Apache-2.0 license or a
- * compatible open source license.
- *
- * Modifications Copyright OpenSearch Contributors. See
- * GitHub history for details.
  */
 
 package org.opensearch.geospatial.action.upload.geojson;

--- a/src/main/java/org/opensearch/geospatial/action/upload/geojson/PipelineManager.java
+++ b/src/main/java/org/opensearch/geospatial/action/upload/geojson/PipelineManager.java
@@ -1,0 +1,119 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ *
+ * Modifications Copyright OpenSearch Contributors. See
+ * GitHub history for details.
+ */
+
+package org.opensearch.geospatial.action.upload.geojson;
+
+import java.io.IOException;
+import java.util.Objects;
+import java.util.function.Supplier;
+
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+import org.opensearch.action.ActionListener;
+import org.opensearch.action.StepListener;
+import org.opensearch.action.ingest.DeletePipelineRequest;
+import org.opensearch.action.ingest.PutPipelineRequest;
+import org.opensearch.client.ClusterAdminClient;
+import org.opensearch.common.UUIDs;
+import org.opensearch.common.bytes.BytesReference;
+import org.opensearch.common.xcontent.XContentBuilder;
+import org.opensearch.common.xcontent.XContentFactory;
+import org.opensearch.common.xcontent.XContentType;
+import org.opensearch.geospatial.processor.FeatureProcessor;
+import org.opensearch.ingest.Pipeline;
+
+/**
+ * PipelineManager is responsible for managing pipeline operations like create and delete
+ */
+public class PipelineManager {
+
+    private final Logger logger = LogManager.getLogger(PipelineManager.class);
+
+    private final ClusterAdminClient client;
+
+    /**
+     * Pipeline operations are cluster operations, hence we need {@link ClusterAdminClient} to manage
+     * @param client {@link ClusterAdminClient}
+     */
+    public PipelineManager(ClusterAdminClient client) {
+        this.client = Objects.requireNonNull(client, "Cluster admin client cannot be null");
+    }
+
+    /**
+     * Creates a new pipeline with GeoJSON Feature Processor
+     * @param fieldName Geospatial field that is required for {@link FeatureProcessor}
+     * @param createPipelineStep notify listener that publishes status of the action.
+     */
+    public void create(String fieldName, StepListener<String> createPipelineStep) {
+        final String pipeline = UUIDs.randomBase64UUID();
+        create(pipeline, fieldName, createPipelineStep);
+    }
+
+    private void create(String pipelineName, String fieldName, StepListener<String> createPipelineStep) {
+        try (final XContentBuilder pipelineRequestContent = buildPipelineRequestContent(fieldName)) {
+            createPipeline(pipelineRequestContent, pipelineName, createPipelineStep);
+        } catch (IOException mappingException) {
+            createPipelineStep.onFailure(mappingException);
+        }
+    }
+
+    /**
+     * Delete pipleine based on given name, notify the status of action using {@link StepListener}
+     * @param pipeline pipeline name to be deleted.
+     * @param deletePipelineStep  notifies the status of this action
+     * @param supplier Exception to be passed to the listener.
+     */
+    public void delete(String pipeline, StepListener<Exception> deletePipelineStep, final Supplier<Exception> supplier) {
+        DeletePipelineRequest pipelineRequest = new DeletePipelineRequest(pipeline);
+        client.deletePipeline(pipelineRequest, ActionListener.wrap(acknowledgedResponse -> {
+            StringBuilder message = new StringBuilder("Deleted pipeline: ").append(pipeline);
+            logger.info(message.toString());
+            deletePipelineStep.onResponse(supplier.get());
+        }, deletePipelineRequestFailed -> {
+            StringBuilder message = new StringBuilder("Failed to delete the pipeline: ").append(pipeline)
+                .append(" due to ")
+                .append(deletePipelineRequestFailed.getMessage());
+            if (supplier.get() != null) {
+                message.append("\n").append("Another exception occurred: ").append(supplier.get().getMessage());
+            }
+            deletePipelineStep.onFailure(new IllegalStateException(message.toString()));
+        }));
+    }
+
+    private XContentBuilder buildPipelineRequestContent(String fieldName) throws IOException {
+        return XContentFactory.jsonBuilder()
+            .startObject()
+            .startArray(Pipeline.PROCESSORS_KEY)
+            .startObject()
+            .startObject(FeatureProcessor.TYPE)
+            .field(FeatureProcessor.FIELD_KEY, fieldName)
+            .endObject()
+            .endObject()
+            .endArray()
+            .endObject();
+    }
+
+    private void createPipeline(XContentBuilder pipelineRequestXContent, String pipelineID, StepListener<String> createPipelineStep) {
+        BytesReference pipelineRequestBodyBytes = BytesReference.bytes(pipelineRequestXContent);
+        PutPipelineRequest pipelineRequest = new PutPipelineRequest(pipelineID, pipelineRequestBodyBytes, XContentType.JSON);
+        client.putPipeline(pipelineRequest, ActionListener.wrap(acknowledgedResponse -> {
+            StringBuilder pipelineMessage = new StringBuilder("Created pipeline: ").append(pipelineID);
+            logger.info(pipelineMessage.toString());
+            createPipelineStep.onResponse(pipelineID);
+        }, putPipelineRequestFailedException -> {
+            StringBuilder message = new StringBuilder("Failed to create the pipeline: ").append(pipelineID)
+                .append(" due to ")
+                .append(putPipelineRequestFailedException.getMessage());
+            createPipelineStep.onFailure(new IllegalStateException(message.toString()));
+        }));
+    }
+
+}

--- a/src/main/java/org/opensearch/geospatial/action/upload/geojson/PipelineManager.java
+++ b/src/main/java/org/opensearch/geospatial/action/upload/geojson/PipelineManager.java
@@ -1,12 +1,6 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
- * The OpenSearch Contributors require contributions made to
- * this file be licensed under the Apache-2.0 license or a
- * compatible open source license.
- *
- * Modifications Copyright OpenSearch Contributors. See
- * GitHub history for details.
  */
 
 package org.opensearch.geospatial.action.upload.geojson;

--- a/src/main/java/org/opensearch/geospatial/action/upload/geojson/PipelineManager.java
+++ b/src/main/java/org/opensearch/geospatial/action/upload/geojson/PipelineManager.java
@@ -29,7 +29,7 @@ import org.opensearch.ingest.Pipeline;
  */
 public class PipelineManager {
 
-    private final Logger logger = LogManager.getLogger(PipelineManager.class);
+    private static final Logger LOGGER = LogManager.getLogger(PipelineManager.class);
 
     private final ClusterAdminClient client;
 
@@ -66,10 +66,10 @@ public class PipelineManager {
      * @param supplier Exception to be passed to the listener.
      */
     public void delete(String pipeline, StepListener<Exception> deletePipelineStep, final Supplier<Exception> supplier) {
-        DeletePipelineRequest pipelineRequest = new DeletePipelineRequest(pipeline);
+        final DeletePipelineRequest pipelineRequest = new DeletePipelineRequest(pipeline);
         client.deletePipeline(pipelineRequest, ActionListener.wrap(acknowledgedResponse -> {
             StringBuilder message = new StringBuilder("Deleted pipeline: ").append(pipeline);
-            logger.info(message.toString());
+            LOGGER.info(message.toString());
             deletePipelineStep.onResponse(supplier.get());
         }, deletePipelineRequestFailed -> {
             StringBuilder message = new StringBuilder("Failed to delete the pipeline: ").append(pipeline)
@@ -96,11 +96,11 @@ public class PipelineManager {
     }
 
     private void createPipeline(XContentBuilder pipelineRequestXContent, String pipelineID, StepListener<String> createPipelineStep) {
-        BytesReference pipelineRequestBodyBytes = BytesReference.bytes(pipelineRequestXContent);
-        PutPipelineRequest pipelineRequest = new PutPipelineRequest(pipelineID, pipelineRequestBodyBytes, XContentType.JSON);
+        final BytesReference pipelineRequestBodyBytes = BytesReference.bytes(pipelineRequestXContent);
+        final PutPipelineRequest pipelineRequest = new PutPipelineRequest(pipelineID, pipelineRequestBodyBytes, XContentType.JSON);
         client.putPipeline(pipelineRequest, ActionListener.wrap(acknowledgedResponse -> {
             StringBuilder pipelineMessage = new StringBuilder("Created pipeline: ").append(pipelineID);
-            logger.info(pipelineMessage.toString());
+            LOGGER.info(pipelineMessage.toString());
             createPipelineStep.onResponse(pipelineID);
         }, putPipelineRequestFailedException -> {
             StringBuilder message = new StringBuilder("Failed to create the pipeline: ").append(pipelineID)

--- a/src/main/java/org/opensearch/geospatial/action/upload/geojson/UploadGeoJSONRequest.java
+++ b/src/main/java/org/opensearch/geospatial/action/upload/geojson/UploadGeoJSONRequest.java
@@ -24,7 +24,7 @@ import org.opensearch.rest.RestRequest;
 public class UploadGeoJSONRequest extends ActionRequest {
 
     private final RestRequest.Method method;
-    private BytesReference content;
+    private final BytesReference content;
 
     public UploadGeoJSONRequest(RestRequest.Method method, BytesReference content) {
         super();

--- a/src/main/java/org/opensearch/geospatial/action/upload/geojson/UploadGeoJSONRequestContent.java
+++ b/src/main/java/org/opensearch/geospatial/action/upload/geojson/UploadGeoJSONRequestContent.java
@@ -7,6 +7,7 @@ package org.opensearch.geospatial.action.upload.geojson;
 
 import static org.opensearch.geospatial.GeospatialParser.extractValueAsString;
 
+import java.util.List;
 import java.util.Map;
 import java.util.Objects;
 
@@ -25,9 +26,9 @@ public final class UploadGeoJSONRequestContent {
     private final String indexName;
     private final String fieldName;
     private final String fieldType;
-    private final Object data;
+    private final List<Object> data;
 
-    private UploadGeoJSONRequestContent(String indexName, String fieldName, String fieldType, Object data) {
+    private UploadGeoJSONRequestContent(String indexName, String fieldName, String fieldType, List<Object> data) {
         this.indexName = indexName;
         this.fieldName = fieldName;
         this.fieldType = fieldType;
@@ -59,7 +60,12 @@ public final class UploadGeoJSONRequestContent {
             input.get(FIELD_DATA.getPreferredName()),
             "field [ " + FIELD_DATA.getPreferredName() + " ] cannot be empty"
         );
-        return new UploadGeoJSONRequestContent(index, fieldName, fieldType, geoJSONData);
+        if (!(geoJSONData instanceof List)) {
+            throw new IllegalArgumentException(
+                geoJSONData + " is not an instance of List, but of type [ " + geoJSONData.getClass().getName() + " ]"
+            );
+        }
+        return new UploadGeoJSONRequestContent(index, fieldName, fieldType, (List<Object>) geoJSONData);
     }
 
     public final String getIndexName() {
@@ -70,7 +76,7 @@ public final class UploadGeoJSONRequestContent {
         return fieldName;
     }
 
-    public Object getData() {
+    public List<Object> getData() {
         return data;
     }
 

--- a/src/main/java/org/opensearch/geospatial/action/upload/geojson/UploadGeoJSONTransportAction.java
+++ b/src/main/java/org/opensearch/geospatial/action/upload/geojson/UploadGeoJSONTransportAction.java
@@ -12,13 +12,18 @@
 package org.opensearch.geospatial.action.upload.geojson;
 
 import java.util.Map;
+import java.util.Objects;
 
+import org.opensearch.ResourceAlreadyExistsException;
 import org.opensearch.action.ActionListener;
 import org.opensearch.action.support.ActionFilters;
 import org.opensearch.action.support.HandledTransportAction;
 import org.opensearch.action.support.master.AcknowledgedResponse;
+import org.opensearch.client.Client;
+import org.opensearch.cluster.service.ClusterService;
 import org.opensearch.common.inject.Inject;
 import org.opensearch.geospatial.GeospatialParser;
+import org.opensearch.rest.RestRequest;
 import org.opensearch.tasks.Task;
 import org.opensearch.transport.TransportService;
 
@@ -27,26 +32,60 @@ import org.opensearch.transport.TransportService;
  */
 public class UploadGeoJSONTransportAction extends HandledTransportAction<UploadGeoJSONRequest, AcknowledgedResponse> {
 
+    private final ClusterService clusterService;
+    private final Client client;
+
     @Inject
-    public UploadGeoJSONTransportAction(TransportService transportService, ActionFilters actionFilters) {
+    public UploadGeoJSONTransportAction(
+        ClusterService clusterService,
+        TransportService transportService,
+        ActionFilters actionFilters,
+        Client client
+    ) {
         super(UploadGeoJSONAction.NAME, transportService, actionFilters, UploadGeoJSONRequest::new);
+        this.clusterService = clusterService;
+        this.client = client;
     }
 
     @Override
     protected void doExecute(Task task, UploadGeoJSONRequest request, ActionListener<AcknowledgedResponse> actionListener) {
         Map<String, Object> contentAsMap = GeospatialParser.convertToMap(request.getContent());
+        UploadGeoJSONRequestContent content;
+        // 1. extract content from request.
         try {
-            UploadGeoJSONRequestContent content = UploadGeoJSONRequestContent.create(contentAsMap);
-            // TODO https://github.com/opensearch-project/geospatial/issues/28 (Add logic to execute import action)
-            // 1. get index name and geospatial field from content
-            // 2. create index with mapping
-            // 3. Parse Data to get GeoJSON Object
-            // 4. Get features from GeoJSON
-            // 5. create Pipeline with GeoJSONFeatureProcessor
-            // 6. Create BulkIndex Request with features as documents.
-            actionListener.onResponse(new AcknowledgedResponse(true));
+            content = UploadGeoJSONRequestContent.create(contentAsMap);
+        } catch (Exception e) {
+            actionListener.onFailure(e);
+            return;
+        }
+
+        // 2. Check should continue upload if index exist.
+        boolean failIfIndexExist = shouldFailIfIndexExist(request.getMethod());
+        final boolean indexExists = clusterService.state().getRoutingTable().hasIndex(content.getIndexName());
+        if (indexExists && failIfIndexExist) {
+            actionListener.onFailure(new ResourceAlreadyExistsException(content.getIndexName()));
+            return;
+        }
+
+        Uploader uploader = new Uploader(client, actionListener);
+        // 3. upload GeoJSON as index document.
+        try {
+            uploader.upload(content, indexExists);
         } catch (Exception e) {
             actionListener.onFailure(e);
         }
+
+    }
+
+    /*
+     * Uploader needs to know whether to continue upload if index doesn't exist.
+     * If method is POST, then, request should fail if index exist.
+     */
+    private boolean shouldFailIfIndexExist(RestRequest.Method method) {
+        Objects.requireNonNull(method, "method cannot be empty");
+        if (RestRequest.Method.POST.equals(method)) {
+            return true;
+        }
+        return false;
     }
 }

--- a/src/main/java/org/opensearch/geospatial/action/upload/geojson/UploadGeoJSONTransportAction.java
+++ b/src/main/java/org/opensearch/geospatial/action/upload/geojson/UploadGeoJSONTransportAction.java
@@ -48,39 +48,20 @@ public class UploadGeoJSONTransportAction extends HandledTransportAction<UploadG
 
     @Override
     protected void doExecute(Task task, UploadGeoJSONRequest request, ActionListener<AcknowledgedResponse> actionListener) {
+        Map<String, Object> contentAsMap = GeospatialParser.convertToMap(request.getContent());
         // 1. parse request's data and extract into UploadGeoJSONRequestContent
-        UploadGeoJSONRequestContent content = getContent(request, actionListener);
-        if (content == null) {
-            return;
-        }
-
+        UploadGeoJSONRequestContent content = UploadGeoJSONRequestContent.create(contentAsMap);
         // 2. Check should we continue upload if index exist.
         boolean failIfIndexExist = shouldFailIfIndexExist(request.getMethod());
         final boolean indexExists = clusterService.state().getRoutingTable().hasIndex(content.getIndexName());
         if (indexExists && failIfIndexExist) {
-            actionListener.onFailure(new ResourceAlreadyExistsException(content.getIndexName()));
-            return;
+            throw new ResourceAlreadyExistsException(content.getIndexName());
         }
         IndexManager indexManager = new IndexManager(client.admin().indices());
         PipelineManager pipelineManager = new PipelineManager(client.admin().cluster());
         ContentBuilder contentBuilder = new ContentBuilder(client);
-        Uploader uploader = new Uploader(indexManager, pipelineManager, contentBuilder);
         // 3. upload GeoJSON as index document.
-        try {
-            uploader.upload(content, indexExists, actionListener);
-        } catch (Exception e) { // doExecute should not throw any Exception since it is executed asynchronously
-            actionListener.onFailure(e);
-        }
-    }
-
-    private UploadGeoJSONRequestContent getContent(UploadGeoJSONRequest request, ActionListener<AcknowledgedResponse> actionListener) {
-        Map<String, Object> contentAsMap = GeospatialParser.convertToMap(request.getContent());
-        try {
-            return UploadGeoJSONRequestContent.create(contentAsMap);
-        } catch (Exception e) {
-            actionListener.onFailure(e);
-            return null;
-        }
+        new Uploader(indexManager, pipelineManager, contentBuilder).upload(content, indexExists, actionListener);
     }
 
     /*

--- a/src/main/java/org/opensearch/geospatial/action/upload/geojson/UploadGeoJSONTransportAction.java
+++ b/src/main/java/org/opensearch/geospatial/action/upload/geojson/UploadGeoJSONTransportAction.java
@@ -48,18 +48,18 @@ public class UploadGeoJSONTransportAction extends HandledTransportAction<UploadG
 
     @Override
     protected void doExecute(Task task, UploadGeoJSONRequest request, ActionListener<AcknowledgedResponse> actionListener) {
-        Map<String, Object> contentAsMap = GeospatialParser.convertToMap(request.getContent());
+        final Map<String, Object> contentAsMap = GeospatialParser.convertToMap(request.getContent());
         // 1. parse request's data and extract into UploadGeoJSONRequestContent
-        UploadGeoJSONRequestContent content = UploadGeoJSONRequestContent.create(contentAsMap);
+        final UploadGeoJSONRequestContent content = UploadGeoJSONRequestContent.create(contentAsMap);
         // 2. Check should we continue upload if index exist.
         boolean failIfIndexExist = shouldFailIfIndexExist(request.getMethod());
         final boolean indexExists = clusterService.state().getRoutingTable().hasIndex(content.getIndexName());
         if (indexExists && failIfIndexExist) {
             throw new ResourceAlreadyExistsException(content.getIndexName());
         }
-        IndexManager indexManager = new IndexManager(client.admin().indices());
-        PipelineManager pipelineManager = new PipelineManager(client.admin().cluster());
-        ContentBuilder contentBuilder = new ContentBuilder(client);
+        final IndexManager indexManager = new IndexManager(client.admin().indices());
+        final PipelineManager pipelineManager = new PipelineManager(client.admin().cluster());
+        final ContentBuilder contentBuilder = new ContentBuilder(client);
         // 3. upload GeoJSON as index document.
         new Uploader(indexManager, pipelineManager, contentBuilder).upload(content, indexExists, actionListener);
     }

--- a/src/main/java/org/opensearch/geospatial/action/upload/geojson/UploadGeoJSONTransportAction.java
+++ b/src/main/java/org/opensearch/geospatial/action/upload/geojson/UploadGeoJSONTransportAction.java
@@ -48,6 +48,7 @@ public class UploadGeoJSONTransportAction extends HandledTransportAction<UploadG
 
     @Override
     protected void doExecute(Task task, UploadGeoJSONRequest request, ActionListener<AcknowledgedResponse> actionListener) {
+        // 1. parse request's data and extract into UploadGeoJSONRequestContent
         UploadGeoJSONRequestContent content = getContent(request, actionListener);
         if (content == null) {
             return;

--- a/src/main/java/org/opensearch/geospatial/action/upload/geojson/Uploader.java
+++ b/src/main/java/org/opensearch/geospatial/action/upload/geojson/Uploader.java
@@ -1,0 +1,300 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ *
+ * Modifications Copyright OpenSearch Contributors. See
+ * GitHub history for details.
+ */
+
+package org.opensearch.geospatial.action.upload.geojson;
+
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+import java.util.Objects;
+import java.util.Optional;
+import java.util.stream.Collectors;
+
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+import org.opensearch.action.ActionListener;
+import org.opensearch.action.StepListener;
+import org.opensearch.action.admin.indices.create.CreateIndexRequest;
+import org.opensearch.action.bulk.BulkItemResponse;
+import org.opensearch.action.bulk.BulkRequestBuilder;
+import org.opensearch.action.bulk.BulkResponse;
+import org.opensearch.action.index.IndexRequestBuilder;
+import org.opensearch.action.ingest.DeletePipelineRequest;
+import org.opensearch.action.ingest.PutPipelineRequest;
+import org.opensearch.action.support.WriteRequest;
+import org.opensearch.action.support.master.AcknowledgedResponse;
+import org.opensearch.client.Client;
+import org.opensearch.common.Strings;
+import org.opensearch.common.UUIDs;
+import org.opensearch.common.bytes.BytesReference;
+import org.opensearch.common.xcontent.XContentBuilder;
+import org.opensearch.common.xcontent.XContentFactory;
+import org.opensearch.common.xcontent.XContentType;
+import org.opensearch.geospatial.GeospatialParser;
+import org.opensearch.geospatial.processor.FeatureProcessor;
+import org.opensearch.ingest.Pipeline;
+
+/**
+ * Uploader will upload GeoJSON objects from UploadGeoJSONRequestContent as
+ * Documents to given index in three stage.
+ * At first stage (preUpload), resources like index, mapping, pipeline with
+ * GeoJSON Feature processors, will be created.
+ * At second stage (upload), Feature will be extracted from GeoJSON and indexed using
+ * BulkAction. This supports both Feature and FeatureCollection.
+ * At third stage (postUpload), previously created pipeline will be deleted and
+ * response will be added to the listener.
+ */
+public class Uploader {
+
+    public static final String FIELD_TYPE_KEY = "type";
+    public static final String MAPPING_PROPERTIES_KEY = "properties";
+    public static final String DOCUMENT_TYPE = "_doc";
+    public static final String ERROR_MESSAGE_DELIMITER = "\n";
+    public static final String SPACE = " ";
+    public static final String GEOJSON_FEATURE_ID_FIELD = "id";
+
+    private final Logger logger = LogManager.getLogger(Uploader.class);
+
+    private final Client client;
+    private final ActionListener<AcknowledgedResponse> flowListener;
+
+    public Uploader(Client client, ActionListener<AcknowledgedResponse> flowListener) {
+        this.client = Objects.requireNonNull(client, "client cannot be null");
+        this.flowListener = Objects.requireNonNull(flowListener, "listener cannot be null");
+    }
+
+    /**
+     * upload abstracts following operations from request
+     * 1. Create index if it doesn't exist ( preUpload)
+     * 2. Create pipeline ( preUpload)
+     * 3. Create BulkRequest, with every {@link UploadGeoJSONRequestContent#getData()} as {@link IndexRequestBuilder} (upload)
+     * 4. Execute {@link org.opensearch.action.bulk.BulkAction} (upload)
+     * 5. Delete pipeline (postUpload)
+     * @param content {@link UploadGeoJSONRequestContent} derived from {@link UploadGeoJSONRequest}
+     * @param isIndexAlreadyExists confirms whether the uploader should create the new index or not
+     * @throws IOException if upload fails to build mapping or pipeline body.
+     */
+    public void upload(UploadGeoJSONRequestContent content, boolean isIndexAlreadyExists) throws IOException {
+        StepListener<String> preUploadStepListener = new StepListener<>();
+        StepListener<Void> uploadListener = new StepListener<>();
+
+        preUploadStep(content, isIndexAlreadyExists, preUploadStepListener);
+
+        // index features as document after creating pipeline, delete pipeline if it fails
+        preUploadStepListener.whenComplete(
+            pipeline -> { upload(pipeline, content, uploadListener); },
+            uploadFailedException -> { postUploadStep(preUploadStepListener.result(), uploadFailedException); }
+        );
+
+        uploadListener.whenComplete(unUsed -> { postUploadStep(preUploadStepListener.result(), null); }, flowListener::onFailure);
+
+    }
+
+    private void preUploadStep(
+        UploadGeoJSONRequestContent content,
+        boolean isIndexAlreadyExists,
+        StepListener<String> preUploadActionListener
+    ) throws IOException {
+        StepListener<Void> createIndexActionListener = new StepListener<>();
+        if (!isIndexAlreadyExists) {
+            // create index
+            XContentBuilder newIndexMapping = buildMapping(content.getFieldName(), content.getFieldType());
+            createIndex(content.getIndexName(), newIndexMapping, createIndexActionListener);
+        } else {
+            createIndexActionListener.onResponse(null); // mark step 1 as completed, to continue to next steps.
+        }
+        // create pipeline after creating index
+        XContentBuilder processorConfig = buildProcessors(content.getFieldName());
+        createIndexActionListener.whenComplete(unUsed -> createPipeline(processorConfig, preUploadActionListener), flowListener::onFailure);
+    }
+
+    private void postUploadStep(String pipeline, Exception indexGeoJSONFailedException) {
+        deletePipeline(pipeline, indexGeoJSONFailedException);
+    }
+
+    private void deletePipeline(String pipeline, Exception indexGeoJSONFailedException) {
+        DeletePipelineRequest pipelineRequest = new DeletePipelineRequest(pipeline);
+        client.admin().cluster().deletePipeline(pipelineRequest, ActionListener.wrap(acknowledgedResponse -> {
+            StringBuilder message = new StringBuilder("Deleted pipeline: ").append(pipeline);
+            logger.info(message.toString());
+            if (indexGeoJSONFailedException != null) {
+                flowListener.onFailure(indexGeoJSONFailedException);
+                return;
+            }
+            flowListener.onResponse(new AcknowledgedResponse(true));
+        }, deletePipelineFailedException -> {
+            StringBuilder message = new StringBuilder("Failed to delete the pipeline: ").append(pipeline)
+                .append(SPACE)
+                .append("due to")
+                .append(SPACE)
+                .append(deletePipelineFailedException.getMessage());
+            flowListener.onFailure(new IllegalStateException(message.toString()));
+        }));
+    }
+
+    /* builds following content
+         {
+             "properties": {
+                "field_name": {
+                   "type": "geospatial_field_type"
+                 }
+             }
+          }
+    */
+    private XContentBuilder buildMapping(String geoSpatialFieldName, String geoSpatialFieldType) throws IOException {
+
+        return XContentFactory.jsonBuilder()
+            .startObject()
+            .startObject(MAPPING_PROPERTIES_KEY)
+            .startObject(geoSpatialFieldName)
+            .field(FIELD_TYPE_KEY, geoSpatialFieldType)
+            .endObject()
+            .endObject()
+            .endObject();
+    }
+
+    private void createIndex(String indexName, XContentBuilder mapping, StepListener<Void> createIndexStep) {
+        CreateIndexRequest request = new CreateIndexRequest(indexName).mapping(DOCUMENT_TYPE, mapping);
+        client.admin().indices().create(request, ActionListener.wrap(createIndexResponse -> {
+            StringBuilder message = new StringBuilder("Created index: ").append(indexName);
+            logger.info(message.toString());
+            // notify the listener to call next steps
+            createIndexStep.onResponse(null);
+        }, createIndexFailedException -> {
+            StringBuilder message = new StringBuilder("Failed to create the index: ").append(indexName)
+                .append(SPACE)
+                .append("due to")
+                .append(SPACE)
+                .append(createIndexFailedException.getMessage());
+            // notify the listener that failure happened and discard rest of the steps.
+            createIndexStep.onFailure(new IllegalStateException(message.toString()));
+        }));
+    }
+
+    /* builds following content
+     {
+         "description" : "Ingest GeoJSON into index",
+         "processors" : [
+           {
+               "geojson-feature" : {
+                  "field" : "geospatial_field_name"
+                }
+            }
+         ]
+      }
+     */
+    private XContentBuilder buildProcessors(String fieldName) throws IOException {
+
+        return XContentFactory.jsonBuilder()
+            .startObject()
+            .startArray(Pipeline.PROCESSORS_KEY)
+            .startObject()
+            .startObject(FeatureProcessor.TYPE)
+            .field(FeatureProcessor.FIELD_KEY, fieldName)
+            .endObject()
+            .endObject()
+            .endArray()
+            .endObject();
+    }
+
+    private void createPipeline(XContentBuilder pipelineRequestXContent, StepListener<String> createPipelineStep) {
+        BytesReference pipelineRequestBodyBytes = BytesReference.bytes(pipelineRequestXContent);
+        final String pipelineID = UUIDs.randomBase64UUID();
+        PutPipelineRequest pipelineRequest = new PutPipelineRequest(pipelineID, pipelineRequestBodyBytes, XContentType.JSON);
+        client.admin().cluster().putPipeline(pipelineRequest, ActionListener.wrap(acknowledgedResponse -> {
+            StringBuilder pipelineMessage = new StringBuilder("Created pipeline: ").append(pipelineID);
+            logger.info(pipelineMessage.toString());
+            createPipelineStep.onResponse(pipelineID);
+        }, createPipelineFailedException -> {
+            StringBuilder message = new StringBuilder("Failed to create the pipeline: ").append(pipelineID)
+                .append(SPACE)
+                .append("due to")
+                .append(SPACE)
+                .append(createPipelineFailedException.getMessage());
+            // notify the listener that failure happened and discard rest of the steps.
+            createPipelineStep.onFailure(new IllegalStateException(message.toString()));
+        }));
+    }
+
+    private IndexRequestBuilder createIndexRequestBuilder(Map<String, Object> source) {
+        final IndexRequestBuilder requestBuilder = client.prepareIndex().setSource(source);
+        String id = GeospatialParser.extractValueAsString(source, GEOJSON_FEATURE_ID_FIELD);
+        return Strings.hasText(id) ? requestBuilder.setId(id) : requestBuilder;
+    }
+
+    private BulkRequestBuilder getBulkRequestBuilder() {
+        return client.prepareBulk().setRefreshPolicy(WriteRequest.RefreshPolicy.WAIT_UNTIL);
+    }
+
+    /*
+        build BulkRequestBuilder, by, iterating, UploadGeoJSONRequestContent's data. This depends on
+        GeospatialParser.getFeatures to extract features from user input, create IndexRequestBuilder
+        with index name and pipeline.
+     */
+    private BulkRequestBuilder buildBulkRequestBuilder(UploadGeoJSONRequestContent content, String pipeline) {
+        BulkRequestBuilder builder = getBulkRequestBuilder();
+        List<Object> documents = (List<Object>) content.getData();
+        documents.stream()
+            .map(GeospatialParser::toStringObjectMap)
+            .map(GeospatialParser::getFeatures)
+            .filter(Optional::isPresent)
+            .map(Optional::get)
+            .flatMap(List::stream)
+            .map(documentSource -> createIndexRequestBuilder(documentSource))
+            .map(indexRequestBuilder -> indexRequestBuilder.setIndex(content.getIndexName()))
+            .map(indexRequestBuilder -> indexRequestBuilder.setPipeline(pipeline))
+            .map(indexRequestBuilder -> indexRequestBuilder.setType(DOCUMENT_TYPE))
+            .forEach(builder::add);
+        return builder;
+    }
+
+    /*
+        upload user input into index using pipeline for processing
+    */
+    private void upload(String pipeline, UploadGeoJSONRequestContent content, StepListener<Void> uploadStepListener) {
+        BulkRequestBuilder bulkRequestBuilder = buildBulkRequestBuilder(content, pipeline);
+
+        if (bulkRequestBuilder.numberOfActions() < 1) { // check any features to upload
+            // mark step as failed
+            uploadStepListener.onFailure(new IllegalArgumentException("No valid features are available to upload"));
+            return;
+        }
+
+        bulkRequestBuilder.execute(ActionListener.wrap(bulkResponse -> {
+            if (bulkResponse.hasFailures()) {
+                final String failureMessage = buildBulkRequestFailureMessage(bulkResponse);
+                throw new IllegalStateException(failureMessage);
+            }
+            logger.info("indexed " + bulkResponse.getItems().length + " features");
+            uploadStepListener.onResponse(null);
+
+        }, bulkRequestFailedException -> {
+            StringBuilder message = new StringBuilder("Failed to index document due to ").append(bulkRequestFailedException.getMessage());
+            // notify the listener that failure happened and discard rest of the steps.
+            uploadStepListener.onFailure(new IllegalStateException(message.toString()));
+        }));
+    }
+
+    /*
+      builds failure message from BulkItemResponse
+     */
+    private String buildBulkRequestFailureMessage(BulkResponse bulkResponse) {
+        List<BulkItemResponse> failedResponse = new ArrayList<>();
+        for (BulkItemResponse response : bulkResponse.getItems()) {
+            if (response.isFailed()) {
+                failedResponse.add(response);
+            }
+        }
+        return failedResponse.stream().map(BulkItemResponse::getFailureMessage).collect(Collectors.joining(ERROR_MESSAGE_DELIMITER));
+    }
+
+}

--- a/src/main/java/org/opensearch/geospatial/action/upload/geojson/Uploader.java
+++ b/src/main/java/org/opensearch/geospatial/action/upload/geojson/Uploader.java
@@ -11,37 +11,22 @@
 
 package org.opensearch.geospatial.action.upload.geojson;
 
-import java.io.IOException;
-import java.util.ArrayList;
-import java.util.List;
+import java.util.Collections;
+import java.util.HashMap;
 import java.util.Map;
 import java.util.Objects;
 import java.util.Optional;
 import java.util.stream.Collectors;
+import java.util.stream.Stream;
 
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.opensearch.action.ActionListener;
 import org.opensearch.action.StepListener;
-import org.opensearch.action.admin.indices.create.CreateIndexRequest;
 import org.opensearch.action.bulk.BulkItemResponse;
 import org.opensearch.action.bulk.BulkRequestBuilder;
 import org.opensearch.action.bulk.BulkResponse;
-import org.opensearch.action.index.IndexRequestBuilder;
-import org.opensearch.action.ingest.DeletePipelineRequest;
-import org.opensearch.action.ingest.PutPipelineRequest;
-import org.opensearch.action.support.WriteRequest;
 import org.opensearch.action.support.master.AcknowledgedResponse;
-import org.opensearch.client.Client;
-import org.opensearch.common.Strings;
-import org.opensearch.common.UUIDs;
-import org.opensearch.common.bytes.BytesReference;
-import org.opensearch.common.xcontent.XContentBuilder;
-import org.opensearch.common.xcontent.XContentFactory;
-import org.opensearch.common.xcontent.XContentType;
-import org.opensearch.geospatial.GeospatialParser;
-import org.opensearch.geospatial.processor.FeatureProcessor;
-import org.opensearch.ingest.Pipeline;
 
 /**
  * Uploader will upload GeoJSON objects from UploadGeoJSONRequestContent as
@@ -50,251 +35,114 @@ import org.opensearch.ingest.Pipeline;
  * GeoJSON Feature processors, will be created.
  * At second stage (upload), Feature will be extracted from GeoJSON and indexed using
  * BulkAction. This supports both Feature and FeatureCollection.
- * At third stage (postUpload), previously created pipeline will be deleted and
- * response will be added to the listener.
+ * At third stage (postUpload), previously created pipeline will be deleted
+ * At final stage response or failure will be added to the listener.
  */
 public class Uploader {
 
-    public static final String FIELD_TYPE_KEY = "type";
-    public static final String MAPPING_PROPERTIES_KEY = "properties";
-    public static final String DOCUMENT_TYPE = "_doc";
     public static final String ERROR_MESSAGE_DELIMITER = "\n";
-    public static final String SPACE = " ";
-    public static final String GEOJSON_FEATURE_ID_FIELD = "id";
 
-    private final Logger logger = LogManager.getLogger(Uploader.class);
+    private static final Logger LOGGER = LogManager.getLogger(Uploader.class);
 
-    private final Client client;
-    private final ActionListener<AcknowledgedResponse> flowListener;
+    private final IndexManager indexManager;
+    private final PipelineManager pipelineManager;
+    private final ContentBuilder contentBuilder;
 
-    public Uploader(Client client, ActionListener<AcknowledgedResponse> flowListener) {
-        this.client = Objects.requireNonNull(client, "client cannot be null");
-        this.flowListener = Objects.requireNonNull(flowListener, "listener cannot be null");
+    public Uploader(IndexManager indexManager, PipelineManager pipelineManager, ContentBuilder contentBuilder) {
+
+        this.indexManager = Objects.requireNonNull(indexManager, "IndexManager instance cannot be null");
+        this.pipelineManager = Objects.requireNonNull(pipelineManager, "PipelineManager instance cannot be null");
+        this.contentBuilder = Objects.requireNonNull(contentBuilder, "ContentBuilder instance cannot be null");
     }
 
     /**
      * upload abstracts following operations from request
-     * 1. Create index if it doesn't exist ( preUpload)
-     * 2. Create pipeline ( preUpload)
-     * 3. Create BulkRequest, with every {@link UploadGeoJSONRequestContent#getData()} as {@link IndexRequestBuilder} (upload)
-     * 4. Execute {@link org.opensearch.action.bulk.BulkAction} (upload)
-     * 5. Delete pipeline (postUpload)
+     * 1. Create index if it doesn't exist.
+     * 2. Create pipeline with {@link org.opensearch.geospatial.processor.FeatureProcessor}
+     * 3. Prepare Content from {@link UploadGeoJSONRequestContent#getData()}
+     * 4. Upload content
+     * 5. Delete pipeline
      * @param content {@link UploadGeoJSONRequestContent} derived from {@link UploadGeoJSONRequest}
      * @param isIndexAlreadyExists confirms whether the uploader should create the new index or not
-     * @throws IOException if upload fails to build mapping or pipeline body.
      */
-    public void upload(UploadGeoJSONRequestContent content, boolean isIndexAlreadyExists) throws IOException {
-        StepListener<String> preUploadStepListener = new StepListener<>();
-        StepListener<Void> uploadListener = new StepListener<>();
-
-        preUploadStep(content, isIndexAlreadyExists, preUploadStepListener);
-
-        // index features as document after creating pipeline, delete pipeline if it fails
-        preUploadStepListener.whenComplete(
-            pipeline -> { upload(pipeline, content, uploadListener); },
-            uploadFailedException -> { postUploadStep(preUploadStepListener.result(), uploadFailedException); }
-        );
-
-        uploadListener.whenComplete(unUsed -> { postUploadStep(preUploadStepListener.result(), null); }, flowListener::onFailure);
-
-    }
-
-    private void preUploadStep(
+    public void upload(
         UploadGeoJSONRequestContent content,
         boolean isIndexAlreadyExists,
-        StepListener<String> preUploadActionListener
-    ) throws IOException {
-        StepListener<Void> createIndexActionListener = new StepListener<>();
-        if (!isIndexAlreadyExists) {
-            // create index
-            XContentBuilder newIndexMapping = buildMapping(content.getFieldName(), content.getFieldType());
-            createIndex(content.getIndexName(), newIndexMapping, createIndexActionListener);
+        ActionListener<AcknowledgedResponse> flowListener
+    ) {
+        // validate input
+        Objects.requireNonNull(flowListener, "listener cannot be null");
+        Objects.requireNonNull(content, "content cannot be null");
+
+        // initialize step listeners to chain steps
+        StepListener<Void> createIndexStep = new StepListener<>();
+        StepListener<String> createPipelineStep = new StepListener<>();
+        StepListener<Void> indexFeatureStep = new StepListener<>();
+        StepListener<Exception> deletePipelineStep = new StepListener<>();
+
+        if (isIndexAlreadyExists) {
+            createIndexStep.onResponse(null); // mark create index step as completed, to continue to next steps.
         } else {
-            createIndexActionListener.onResponse(null); // mark step 1 as completed, to continue to next steps.
+            // create index
+            Map<String, String> fieldMap = new HashMap<>();
+            fieldMap.put(content.getFieldName(), content.getFieldType());
+            indexManager.create(content.getIndexName(), Collections.unmodifiableMap(fieldMap), createIndexStep);
         }
-        // create pipeline after creating index
-        XContentBuilder processorConfig = buildProcessors(content.getFieldName());
-        createIndexActionListener.whenComplete(unUsed -> createPipeline(processorConfig, preUploadActionListener), flowListener::onFailure);
-    }
+        // create a pipeline after creating index
+        createIndexStep.whenComplete(
+            notUsed -> pipelineManager.create(content.getFieldName(), createPipelineStep),
+            flowListener::onFailure
+        );
 
-    private void postUploadStep(String pipeline, Exception indexGeoJSONFailedException) {
-        deletePipeline(pipeline, indexGeoJSONFailedException);
-    }
+        // index features as document after creating pipeline
+        createPipelineStep.whenComplete(
+            pipeline -> { indexContentAsDocument(pipeline, content, indexFeatureStep); },
+            createPipelineFailedException -> { flowListener.onFailure(createPipelineFailedException); }
+        );
 
-    private void deletePipeline(String pipeline, Exception indexGeoJSONFailedException) {
-        DeletePipelineRequest pipelineRequest = new DeletePipelineRequest(pipeline);
-        client.admin().cluster().deletePipeline(pipelineRequest, ActionListener.wrap(acknowledgedResponse -> {
-            StringBuilder message = new StringBuilder("Deleted pipeline: ").append(pipeline);
-            logger.info(message.toString());
-            if (indexGeoJSONFailedException != null) {
-                flowListener.onFailure(indexGeoJSONFailedException);
-                return;
+        // delete pipeline
+        indexFeatureStep.whenComplete(notUsed -> {
+            String pipeline = createPipelineStep.result();
+            pipelineManager.delete(pipeline, deletePipelineStep, () -> null);
+        }, uploadFailed -> {
+            String pipeline = createPipelineStep.result();
+            pipelineManager.delete(pipeline, deletePipelineStep, () -> uploadFailed);
+        });
+
+        // set response or failure depending on previous steps status
+        deletePipelineStep.whenComplete(uploadFailedException -> {
+            if (uploadFailedException != null) {
+                throw uploadFailedException;
             }
             flowListener.onResponse(new AcknowledgedResponse(true));
-        }, deletePipelineFailedException -> {
-            StringBuilder message = new StringBuilder("Failed to delete the pipeline: ").append(pipeline)
-                .append(SPACE)
-                .append("due to")
-                .append(SPACE)
-                .append(deletePipelineFailedException.getMessage());
-            flowListener.onFailure(new IllegalStateException(message.toString()));
-        }));
+        }, flowListener::onFailure);
+
     }
 
-    /* builds following content
-         {
-             "properties": {
-                "field_name": {
-                   "type": "geospatial_field_type"
-                 }
-             }
-          }
-    */
-    private XContentBuilder buildMapping(String geoSpatialFieldName, String geoSpatialFieldType) throws IOException {
-
-        return XContentFactory.jsonBuilder()
-            .startObject()
-            .startObject(MAPPING_PROPERTIES_KEY)
-            .startObject(geoSpatialFieldName)
-            .field(FIELD_TYPE_KEY, geoSpatialFieldType)
-            .endObject()
-            .endObject()
-            .endObject();
-    }
-
-    private void createIndex(String indexName, XContentBuilder mapping, StepListener<Void> createIndexStep) {
-        CreateIndexRequest request = new CreateIndexRequest(indexName).mapping(DOCUMENT_TYPE, mapping);
-        client.admin().indices().create(request, ActionListener.wrap(createIndexResponse -> {
-            StringBuilder message = new StringBuilder("Created index: ").append(indexName);
-            logger.info(message.toString());
-            // notify the listener to call next steps
-            createIndexStep.onResponse(null);
-        }, createIndexFailedException -> {
-            StringBuilder message = new StringBuilder("Failed to create the index: ").append(indexName)
-                .append(SPACE)
-                .append("due to")
-                .append(SPACE)
-                .append(createIndexFailedException.getMessage());
-            // notify the listener that failure happened and discard rest of the steps.
-            createIndexStep.onFailure(new IllegalStateException(message.toString()));
-        }));
-    }
-
-    /* builds following content
-     {
-         "description" : "Ingest GeoJSON into index",
-         "processors" : [
-           {
-               "geojson-feature" : {
-                  "field" : "geospatial_field_name"
-                }
-            }
-         ]
-      }
-     */
-    private XContentBuilder buildProcessors(String fieldName) throws IOException {
-
-        return XContentFactory.jsonBuilder()
-            .startObject()
-            .startArray(Pipeline.PROCESSORS_KEY)
-            .startObject()
-            .startObject(FeatureProcessor.TYPE)
-            .field(FeatureProcessor.FIELD_KEY, fieldName)
-            .endObject()
-            .endObject()
-            .endArray()
-            .endObject();
-    }
-
-    private void createPipeline(XContentBuilder pipelineRequestXContent, StepListener<String> createPipelineStep) {
-        BytesReference pipelineRequestBodyBytes = BytesReference.bytes(pipelineRequestXContent);
-        final String pipelineID = UUIDs.randomBase64UUID();
-        PutPipelineRequest pipelineRequest = new PutPipelineRequest(pipelineID, pipelineRequestBodyBytes, XContentType.JSON);
-        client.admin().cluster().putPipeline(pipelineRequest, ActionListener.wrap(acknowledgedResponse -> {
-            StringBuilder pipelineMessage = new StringBuilder("Created pipeline: ").append(pipelineID);
-            logger.info(pipelineMessage.toString());
-            createPipelineStep.onResponse(pipelineID);
-        }, createPipelineFailedException -> {
-            StringBuilder message = new StringBuilder("Failed to create the pipeline: ").append(pipelineID)
-                .append(SPACE)
-                .append("due to")
-                .append(SPACE)
-                .append(createPipelineFailedException.getMessage());
-            // notify the listener that failure happened and discard rest of the steps.
-            createPipelineStep.onFailure(new IllegalStateException(message.toString()));
-        }));
-    }
-
-    private IndexRequestBuilder createIndexRequestBuilder(Map<String, Object> source) {
-        final IndexRequestBuilder requestBuilder = client.prepareIndex().setSource(source);
-        String id = GeospatialParser.extractValueAsString(source, GEOJSON_FEATURE_ID_FIELD);
-        return Strings.hasText(id) ? requestBuilder.setId(id) : requestBuilder;
-    }
-
-    private BulkRequestBuilder getBulkRequestBuilder() {
-        return client.prepareBulk().setRefreshPolicy(WriteRequest.RefreshPolicy.WAIT_UNTIL);
-    }
-
-    /*
-        build BulkRequestBuilder, by, iterating, UploadGeoJSONRequestContent's data. This depends on
-        GeospatialParser.getFeatures to extract features from user input, create IndexRequestBuilder
-        with index name and pipeline.
-     */
-    private BulkRequestBuilder buildBulkRequestBuilder(UploadGeoJSONRequestContent content, String pipeline) {
-        BulkRequestBuilder builder = getBulkRequestBuilder();
-        List<Object> documents = (List<Object>) content.getData();
-        documents.stream()
-            .map(GeospatialParser::toStringObjectMap)
-            .map(GeospatialParser::getFeatures)
-            .filter(Optional::isPresent)
-            .map(Optional::get)
-            .flatMap(List::stream)
-            .map(documentSource -> createIndexRequestBuilder(documentSource))
-            .map(indexRequestBuilder -> indexRequestBuilder.setIndex(content.getIndexName()))
-            .map(indexRequestBuilder -> indexRequestBuilder.setPipeline(pipeline))
-            .map(indexRequestBuilder -> indexRequestBuilder.setType(DOCUMENT_TYPE))
-            .forEach(builder::add);
-        return builder;
-    }
-
-    /*
-        upload user input into index using pipeline for processing
-    */
-    private void upload(String pipeline, UploadGeoJSONRequestContent content, StepListener<Void> uploadStepListener) {
-        BulkRequestBuilder bulkRequestBuilder = buildBulkRequestBuilder(content, pipeline);
-
-        if (bulkRequestBuilder.numberOfActions() < 1) { // check any features to upload
-            // mark step as failed
-            uploadStepListener.onFailure(new IllegalArgumentException("No valid features are available to upload"));
+    private void indexContentAsDocument(String pipeline, UploadGeoJSONRequestContent content, StepListener<Void> uploadStepListener) {
+        Optional<BulkRequestBuilder> contentRequestBuilder = contentBuilder.prepare(content, pipeline);
+        if (!contentRequestBuilder.isPresent()) {
+            uploadStepListener.onFailure(new IllegalStateException("No valid features are available to index"));
             return;
         }
-
-        bulkRequestBuilder.execute(ActionListener.wrap(bulkResponse -> {
+        contentRequestBuilder.get().execute(ActionListener.wrap(bulkResponse -> {
             if (bulkResponse.hasFailures()) {
-                final String failureMessage = buildBulkRequestFailureMessage(bulkResponse);
+                final String failureMessage = buildUploadFailureMessage(bulkResponse);
                 throw new IllegalStateException(failureMessage);
             }
-            logger.info("indexed " + bulkResponse.getItems().length + " features");
+            LOGGER.info("indexed " + bulkResponse.getItems().length + " features");
             uploadStepListener.onResponse(null);
 
         }, bulkRequestFailedException -> {
             StringBuilder message = new StringBuilder("Failed to index document due to ").append(bulkRequestFailedException.getMessage());
-            // notify the listener that failure happened and discard rest of the steps.
             uploadStepListener.onFailure(new IllegalStateException(message.toString()));
         }));
     }
 
-    /*
-      builds failure message from BulkItemResponse
-     */
-    private String buildBulkRequestFailureMessage(BulkResponse bulkResponse) {
-        List<BulkItemResponse> failedResponse = new ArrayList<>();
-        for (BulkItemResponse response : bulkResponse.getItems()) {
-            if (response.isFailed()) {
-                failedResponse.add(response);
-            }
-        }
-        return failedResponse.stream().map(BulkItemResponse::getFailureMessage).collect(Collectors.joining(ERROR_MESSAGE_DELIMITER));
+    private String buildUploadFailureMessage(BulkResponse bulkResponse) {
+        return Stream.of(bulkResponse.getItems())
+            .filter(BulkItemResponse::isFailed)
+            .map(BulkItemResponse::getFailureMessage)
+            .collect(Collectors.joining(ERROR_MESSAGE_DELIMITER));
     }
-
 }

--- a/src/main/java/org/opensearch/geospatial/action/upload/geojson/Uploader.java
+++ b/src/main/java/org/opensearch/geospatial/action/upload/geojson/Uploader.java
@@ -5,9 +5,6 @@
 
 package org.opensearch.geospatial.action.upload.geojson;
 
-import java.util.Collections;
-import java.util.HashMap;
-import java.util.Map;
 import java.util.Objects;
 import java.util.Optional;
 import java.util.stream.Collectors;
@@ -21,6 +18,7 @@ import org.opensearch.action.bulk.BulkItemResponse;
 import org.opensearch.action.bulk.BulkRequestBuilder;
 import org.opensearch.action.bulk.BulkResponse;
 import org.opensearch.action.support.master.AcknowledgedResponse;
+import org.opensearch.common.collect.MapBuilder;
 
 /**
  * Uploader will upload GeoJSON objects from UploadGeoJSONRequestContent as
@@ -42,7 +40,13 @@ public class Uploader {
     private final PipelineManager pipelineManager;
     private final ContentBuilder contentBuilder;
 
-    public Uploader(IndexManager indexManager, PipelineManager pipelineManager, ContentBuilder contentBuilder) {
+    /**
+     * Uploads {@link UploadGeoJSONRequestContent#getData()}
+     * @param indexManager {@link IndexManager} instance to perform index based operations
+     * @param pipelineManager {@link PipelineManager} instance to perform Pipeline operations
+     * @param contentBuilder {@link ContentBuilder} instance to prepare BulkRequest
+     */
+    public Uploader(final IndexManager indexManager, final PipelineManager pipelineManager, final ContentBuilder contentBuilder) {
 
         this.indexManager = Objects.requireNonNull(indexManager, "IndexManager instance cannot be null");
         this.pipelineManager = Objects.requireNonNull(pipelineManager, "PipelineManager instance cannot be null");
@@ -58,30 +62,31 @@ public class Uploader {
      * 5. Delete pipeline
      * @param content {@link UploadGeoJSONRequestContent} derived from {@link UploadGeoJSONRequest}
      * @param isIndexAlreadyExists confirms whether the uploader should create the new index or not
+     * @param flowListener action listener that contains the response of upload action.
      */
     public void upload(
-        UploadGeoJSONRequestContent content,
-        boolean isIndexAlreadyExists,
-        ActionListener<AcknowledgedResponse> flowListener
+        final UploadGeoJSONRequestContent content,
+        final boolean isIndexAlreadyExists,
+        final ActionListener<AcknowledgedResponse> flowListener
     ) {
         // validate input
         Objects.requireNonNull(flowListener, "listener cannot be null");
         Objects.requireNonNull(content, "content cannot be null");
 
         // initialize step listeners to chain steps
-        StepListener<Void> createIndexStep = new StepListener<>();
-        StepListener<String> createPipelineStep = new StepListener<>();
-        StepListener<Void> indexFeatureStep = new StepListener<>();
-        StepListener<Exception> deletePipelineStep = new StepListener<>();
+        final StepListener<Void> createIndexStep = new StepListener<>();
+        final StepListener<String> createPipelineStep = new StepListener<>();
+        final StepListener<Void> indexFeatureStep = new StepListener<>();
+        final StepListener<Exception> deletePipelineStep = new StepListener<>();
 
         if (isIndexAlreadyExists) {
             LOGGER.info("Index [ " + content.getIndexName() + " ] is already exists");
             createIndexStep.onResponse(null); // mark create index step as completed, to continue to next steps.
         } else {
             // create index
-            Map<String, String> fieldMap = new HashMap<>();
+            MapBuilder<String, String> fieldMap = new MapBuilder<>();
             fieldMap.put(content.getFieldName(), content.getFieldType());
-            indexManager.create(content.getIndexName(), Collections.unmodifiableMap(fieldMap), createIndexStep);
+            indexManager.create(content.getIndexName(), fieldMap.immutableMap(), createIndexStep);
         }
         // create a pipeline after creating index
         createIndexStep.whenComplete(

--- a/src/main/java/org/opensearch/geospatial/action/upload/geojson/Uploader.java
+++ b/src/main/java/org/opensearch/geospatial/action/upload/geojson/Uploader.java
@@ -75,6 +75,7 @@ public class Uploader {
         StepListener<Exception> deletePipelineStep = new StepListener<>();
 
         if (isIndexAlreadyExists) {
+            LOGGER.info("Index [ " + content.getIndexName() + " ] is already exists");
             createIndexStep.onResponse(null); // mark create index step as completed, to continue to next steps.
         } else {
             // create index

--- a/src/main/java/org/opensearch/geospatial/action/upload/geojson/Uploader.java
+++ b/src/main/java/org/opensearch/geospatial/action/upload/geojson/Uploader.java
@@ -1,12 +1,6 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
- * The OpenSearch Contributors require contributions made to
- * this file be licensed under the Apache-2.0 license or a
- * compatible open source license.
- *
- * Modifications Copyright OpenSearch Contributors. See
- * GitHub history for details.
  */
 
 package org.opensearch.geospatial.action.upload.geojson;

--- a/src/main/java/org/opensearch/geospatial/geojson/FeatureCollection.java
+++ b/src/main/java/org/opensearch/geospatial/geojson/FeatureCollection.java
@@ -6,11 +6,9 @@
 package org.opensearch.geospatial.geojson;
 
 import java.util.ArrayList;
-import java.util.Collections;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
-import java.util.stream.Stream;
 
 import org.opensearch.geospatial.GeospatialParser;
 
@@ -35,7 +33,7 @@ public final class FeatureCollection {
      * @return List of Feature as Map from the {@link FeatureCollection}
      */
     public List<Map<String, Object>> getFeatures() {
-        return Collections.unmodifiableList(features);
+        return features;
     }
 
     /**
@@ -74,13 +72,13 @@ public final class FeatureCollection {
         if (featureObject == null) { // empty features are valid based on definition
             return collection;
         }
-        if (!(featureObject instanceof Object[])) {
+        if (!(featureObject instanceof List)) {
             throw new IllegalArgumentException(
-                FEATURES_KEY + " is not an instance of type Object[], but of type [ " + featureObject.getClass().getName() + " ]"
+                FEATURES_KEY + " is not an instance of type List, but of type [ " + featureObject.getClass().getName() + " ]"
             );
         }
-        Object[] featureArray = (Object[]) featureObject;
-        Stream.of(featureArray).map(GeospatialParser::toStringObjectMap).forEach(collection::addFeature);
+        List<Object> featureArray = (List) featureObject;
+        featureArray.stream().map(GeospatialParser::toStringObjectMap).forEach(collection::addFeature);
         return collection;
     }
 

--- a/src/main/java/org/opensearch/geospatial/processor/FeatureProcessor.java
+++ b/src/main/java/org/opensearch/geospatial/processor/FeatureProcessor.java
@@ -36,7 +36,7 @@ public class FeatureProcessor extends AbstractProcessor {
         // 2. Remove field "type", since, we are not storing as geo-json
         // 3. Move properties.* as document's fields, since, we don't have to group it inside "properties"
         // 5. Move geojson's geometry object to geoshape field.
-        Feature feature = FeatureFactory.create(ingestDocument.getSourceAndMetadata());
+        final Feature feature = FeatureFactory.create(ingestDocument.getSourceAndMetadata());
         ingestDocument.removeField(Feature.TYPE_KEY);
         feature.getProperties().forEach((k, v) -> ingestDocument.setFieldValue(k, v));
         if (ingestDocument.hasField(Feature.PROPERTIES_KEY)) { // properties are optional in Feature

--- a/src/test/java/org/opensearch/geospatial/GeospatialObjectBuilder.java
+++ b/src/test/java/org/opensearch/geospatial/GeospatialObjectBuilder.java
@@ -74,7 +74,7 @@ public class GeospatialObjectBuilder {
     public static JSONObject buildGeoJSONFeatureCollection(JSONArray features) {
         JSONObject collection = new JSONObject();
         collection.put(FeatureCollection.TYPE_KEY, FeatureCollection.TYPE);
-        collection.put(FeatureCollection.FEATURES_KEY, features.toList().toArray());
+        collection.put(FeatureCollection.FEATURES_KEY, features.toList());
         return collection;
     }
 

--- a/src/test/java/org/opensearch/geospatial/GeospatialParserTests.java
+++ b/src/test/java/org/opensearch/geospatial/GeospatialParserTests.java
@@ -10,7 +10,6 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
-import java.util.stream.Collectors;
 
 import org.json.JSONArray;
 import org.json.JSONObject;
@@ -94,12 +93,6 @@ public class GeospatialParserTests extends OpenSearchTestCase {
         Optional<List<Map<String, Object>>> featureList = GeospatialParser.getFeatures(collection.toMap());
         assertTrue(featureList.isPresent());
         assertTrue(featureList.get().size() == features.length());
-        List<Map<String, Object>> expected = features.toList()
-            .stream()
-            .map(GeospatialParser::toStringObjectMap)
-            .collect(Collectors.toList());
-
-        assertArrayEquals("features are not equal", expected.toArray(), featureList.get().toArray());
     }
 
     public void testGetFeaturesWithUnSupportedType() {

--- a/src/test/java/org/opensearch/geospatial/GeospatialRestTestCase.java
+++ b/src/test/java/org/opensearch/geospatial/GeospatialRestTestCase.java
@@ -8,13 +8,13 @@ package org.opensearch.geospatial;
 import static java.util.stream.Collectors.joining;
 import static org.opensearch.geospatial.GeospatialObjectBuilder.buildProperties;
 import static org.opensearch.geospatial.GeospatialObjectBuilder.randomGeoJSONFeature;
+import static org.opensearch.geospatial.GeospatialTestHelper.*;
 import static org.opensearch.geospatial.action.upload.geojson.UploadGeoJSONRequestContent.FIELD_DATA;
 
 import java.io.IOException;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
-import java.util.Locale;
 import java.util.Map;
 import java.util.Optional;
 import java.util.stream.IntStream;
@@ -44,8 +44,6 @@ public abstract class GeospatialRestTestCase extends OpenSearchRestTestCase {
     public static final String URL_DELIMITER = "/";
     public static final String FIELD_TYPE_KEY = "type";
     public static final String MAPPING_PROPERTIES_KEY = "properties";
-    public static final int RANDOM_STRING_MIN_LENGTH = 2;
-    public static final int RANDOM_STRING_MAX_LENGTH = 16;
     public static final String MAPPING = "_mapping";
     public static final String FIELD_MAPPINGS_KEY = "mappings";
     public static final String COUNT = "_count";
@@ -132,14 +130,6 @@ public abstract class GeospatialRestTestCase extends OpenSearchRestTestCase {
         IntStream.range(0, totalGeoJSONObject).forEach(unUsed -> values.put(randomGeoJSONFeature(buildProperties(Collections.emptyMap()))));
         contents.put(FIELD_DATA.getPreferredName(), values);
         return contents;
-    }
-
-    private String randomString() {
-        return randomAlphaOfLengthBetween(RANDOM_STRING_MIN_LENGTH, RANDOM_STRING_MAX_LENGTH);
-    }
-
-    public String randomLowerCaseString() {
-        return randomString().toLowerCase(Locale.getDefault());
     }
 
     private RestStatus getIndexHeadRequestStatus(String indexName) throws IOException {

--- a/src/test/java/org/opensearch/geospatial/GeospatialTestHelper.java
+++ b/src/test/java/org/opensearch/geospatial/GeospatialTestHelper.java
@@ -1,0 +1,56 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ *
+ * Modifications Copyright OpenSearch Contributors. See
+ * GitHub history for details.
+ */
+
+package org.opensearch.geospatial;
+
+import static org.opensearch.geospatial.GeospatialObjectBuilder.buildProperties;
+import static org.opensearch.geospatial.GeospatialObjectBuilder.randomGeoJSONFeature;
+import static org.opensearch.geospatial.action.upload.geojson.UploadGeoJSONRequestContent.FIELD_DATA;
+
+import java.util.Collections;
+import java.util.Locale;
+import java.util.Map;
+import java.util.stream.IntStream;
+
+import org.json.JSONArray;
+import org.json.JSONObject;
+import org.opensearch.common.Randomness;
+import org.opensearch.geospatial.action.upload.geojson.ContentBuilder;
+import org.opensearch.geospatial.action.upload.geojson.UploadGeoJSONRequestContent;
+import org.opensearch.test.OpenSearchTestCase;
+
+public class GeospatialTestHelper {
+    public static final int RANDOM_STRING_MIN_LENGTH = 2;
+    public static final int RANDOM_STRING_MAX_LENGTH = 16;
+
+    public static Map<String, Object> buildRequestContent(int featureCount) {
+        JSONObject contents = new JSONObject();
+        if (Randomness.get().nextBoolean()) {
+            contents.put(ContentBuilder.GEOJSON_FEATURE_ID_FIELD, randomLowerCaseString());
+        }
+        contents.put(UploadGeoJSONRequestContent.FIELD_INDEX.getPreferredName(), randomLowerCaseString());
+        contents.put(UploadGeoJSONRequestContent.FIELD_GEOSPATIAL.getPreferredName(), randomLowerCaseString());
+        contents.put(UploadGeoJSONRequestContent.FIELD_GEOSPATIAL_TYPE.getPreferredName(), "geo_shape");
+        JSONArray values = new JSONArray();
+        IntStream.range(0, featureCount).forEach(notUsed -> { values.put(randomGeoJSONFeature(buildProperties(Collections.emptyMap()))); });
+        contents.put(FIELD_DATA.getPreferredName(), values);
+        return contents.toMap();
+    }
+
+    private static String randomString() {
+        return OpenSearchTestCase.randomAlphaOfLengthBetween(RANDOM_STRING_MIN_LENGTH, RANDOM_STRING_MAX_LENGTH);
+    }
+
+    public static String randomLowerCaseString() {
+        return randomString().toLowerCase(Locale.getDefault());
+    }
+
+}

--- a/src/test/java/org/opensearch/geospatial/action/upload/geojson/ContentBuilderTests.java
+++ b/src/test/java/org/opensearch/geospatial/action/upload/geojson/ContentBuilderTests.java
@@ -78,7 +78,7 @@ public class ContentBuilderTests extends OpenSearchTestCase {
         UploadGeoJSONRequestContent content = UploadGeoJSONRequestContent.create(contentMap);
         BulkRequestBuilder mockBulkRequestBuilder = mockBulkRequestBuilder(ZERO_ACTIONS);
         final Optional<BulkRequestBuilder> prepare = contentBuilder.prepare(content, randomLowerCaseString());
-        verify(mockClient).prepareBulk();
+        verify(mockClient, never()).prepareBulk();
         verify(mockClient, never()).prepareIndex();
         verify(mockBulkRequestBuilder, never()).add(any(IndexRequestBuilder.class));
         assertFalse("Feature count should be empty", prepare.isPresent());

--- a/src/test/java/org/opensearch/geospatial/action/upload/geojson/ContentBuilderTests.java
+++ b/src/test/java/org/opensearch/geospatial/action/upload/geojson/ContentBuilderTests.java
@@ -1,0 +1,93 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ *
+ * Modifications Copyright OpenSearch Contributors. See
+ * GitHub history for details.
+ */
+
+package org.opensearch.geospatial.action.upload.geojson;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+import static org.opensearch.geospatial.GeospatialTestHelper.randomLowerCaseString;
+
+import java.util.Map;
+import java.util.Optional;
+
+import org.opensearch.action.bulk.BulkRequestBuilder;
+import org.opensearch.action.index.IndexAction;
+import org.opensearch.action.index.IndexRequestBuilder;
+import org.opensearch.action.support.WriteRequest;
+import org.opensearch.client.Client;
+import org.opensearch.geospatial.GeospatialTestHelper;
+import org.opensearch.test.OpenSearchTestCase;
+import org.opensearch.test.client.NoOpClient;
+
+public class ContentBuilderTests extends OpenSearchTestCase {
+
+    public static final int MAX_NUM_ACTION = 5;
+    public static final int MAX_FEATURES_COUNT = 3;
+    public static final int ZERO_ACTIONS = 0;
+    public static final int ZERO_FEATURES = 0;
+    private Client mockClient;
+    private NoOpClient noOpClient;
+    private ContentBuilder contentBuilder;
+
+    @Override
+    public void setUp() throws Exception {
+        super.setUp();
+        noOpClient = new NoOpClient(getTestName());
+        mockClient = mock(Client.class);
+        contentBuilder = new ContentBuilder(mockClient);
+    }
+
+    @Override
+    public void tearDown() throws Exception {
+        super.tearDown();
+        noOpClient.close();
+    }
+
+    private BulkRequestBuilder mockBulkRequestBuilder(int noOfActions) {
+        // mock BulkRequest
+        BulkRequestBuilder mockBulkRequestBuilder = mock(BulkRequestBuilder.class);
+        when(mockClient.prepareBulk()).thenReturn(mockBulkRequestBuilder);
+        when(mockBulkRequestBuilder.setRefreshPolicy(WriteRequest.RefreshPolicy.WAIT_UNTIL)).thenReturn(mockBulkRequestBuilder);
+        when(mockBulkRequestBuilder.add(any(IndexRequestBuilder.class))).thenReturn(null);
+        when(mockBulkRequestBuilder.numberOfActions()).thenReturn(noOfActions);
+
+        IndexRequestBuilder indexRequestBuilder = new IndexRequestBuilder(noOpClient, IndexAction.INSTANCE);
+        when(mockClient.prepareIndex()).thenReturn(indexRequestBuilder);
+        return mockBulkRequestBuilder;
+    }
+
+    public void testContentBuilderSuccess() {
+        Map<String, Object> contentMap = GeospatialTestHelper.buildRequestContent(MAX_FEATURES_COUNT);
+        UploadGeoJSONRequestContent content = UploadGeoJSONRequestContent.create(contentMap);
+        BulkRequestBuilder mockBulkRequestBuilder = mockBulkRequestBuilder(MAX_NUM_ACTION);
+        final Optional<BulkRequestBuilder> prepare = contentBuilder.prepare(content, randomLowerCaseString());
+        verify(mockClient).prepareBulk();
+        verify(mockClient, times(MAX_FEATURES_COUNT)).prepareIndex();
+        verify(mockBulkRequestBuilder, times(MAX_FEATURES_COUNT)).add(any(IndexRequestBuilder.class));
+        assertTrue("failed to build request", prepare.isPresent());
+    }
+
+    public void testContentBuilderFailed() {
+        Map<String, Object> contentMap = GeospatialTestHelper.buildRequestContent(ZERO_FEATURES);
+        UploadGeoJSONRequestContent content = UploadGeoJSONRequestContent.create(contentMap);
+        BulkRequestBuilder mockBulkRequestBuilder = mockBulkRequestBuilder(ZERO_ACTIONS);
+        final Optional<BulkRequestBuilder> prepare = contentBuilder.prepare(content, randomLowerCaseString());
+        verify(mockClient).prepareBulk();
+        verify(mockClient, never()).prepareIndex();
+        verify(mockBulkRequestBuilder, never()).add(any(IndexRequestBuilder.class));
+        assertFalse("Feature count should be empty", prepare.isPresent());
+    }
+
+}

--- a/src/test/java/org/opensearch/geospatial/action/upload/geojson/ContentBuilderTests.java
+++ b/src/test/java/org/opensearch/geospatial/action/upload/geojson/ContentBuilderTests.java
@@ -1,12 +1,6 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
- * The OpenSearch Contributors require contributions made to
- * this file be licensed under the Apache-2.0 license or a
- * compatible open source license.
- *
- * Modifications Copyright OpenSearch Contributors. See
- * GitHub history for details.
  */
 
 package org.opensearch.geospatial.action.upload.geojson;

--- a/src/test/java/org/opensearch/geospatial/action/upload/geojson/IndexManagerTests.java
+++ b/src/test/java/org/opensearch/geospatial/action/upload/geojson/IndexManagerTests.java
@@ -1,0 +1,93 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ *
+ * Modifications Copyright OpenSearch Contributors. See
+ * GitHub history for details.
+ */
+
+package org.opensearch.geospatial.action.upload.geojson;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.doAnswer;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.opensearch.geospatial.GeospatialTestHelper.randomLowerCaseString;
+
+import java.util.HashMap;
+import java.util.Map;
+import java.util.stream.IntStream;
+
+import org.opensearch.ResourceAlreadyExistsException;
+import org.opensearch.action.ActionListener;
+import org.opensearch.action.StepListener;
+import org.opensearch.action.admin.indices.create.CreateIndexRequest;
+import org.opensearch.action.admin.indices.create.CreateIndexResponse;
+import org.opensearch.client.IndicesAdminClient;
+import org.opensearch.test.OpenSearchTestCase;
+
+public class IndexManagerTests extends OpenSearchTestCase {
+
+    public static final int INDEX_PROPERTIES_SIZE = 4;
+    private static final boolean FAIL = false;
+    private static final boolean SUCCEED = true;
+    private IndicesAdminClient mockClient;
+    private IndexManager manager;
+    private StepListener<Void> listener;
+
+    @Override
+    public void setUp() throws Exception {
+        super.setUp();
+        mockClient = mock(IndicesAdminClient.class);
+        manager = new IndexManager(mockClient);
+        listener = new StepListener<>();
+    }
+
+    @Override
+    public void tearDown() throws Exception {
+        super.tearDown();
+    }
+
+    private Map<String, String> randomFieldMap(int size) {
+        Map<String, String> fieldMap = new HashMap<>();
+        IntStream.range(0, size).forEach(unUsed -> fieldMap.put(randomLowerCaseString(), randomLowerCaseString()));
+        return fieldMap;
+    }
+
+    private void mockCreateAction(String indexName, boolean actionSucceeded) {
+        doAnswer(invocation -> {
+            Object[] args = invocation.getArguments();
+            assert args.length == 2;
+            CreateIndexRequest request = (CreateIndexRequest) args[0];
+            assertEquals("index name did not match", indexName, request.index());
+            ActionListener<CreateIndexResponse> createIndexAction = (ActionListener<CreateIndexResponse>) args[1];
+            if (actionSucceeded) {
+                // call onResponse flow
+                createIndexAction.onResponse(null);
+                return null;
+            }
+            createIndexAction.onFailure(new ResourceAlreadyExistsException(indexName));
+            return null;
+        }).when(mockClient).create(any(CreateIndexRequest.class), any(ActionListener.class));
+    }
+
+    public void testIndexCreationSucceeded() {
+        String indexName = randomLowerCaseString();
+        mockCreateAction(indexName, SUCCEED);
+        manager.create(indexName, randomFieldMap(INDEX_PROPERTIES_SIZE), listener);
+        verify(mockClient).create(any(CreateIndexRequest.class), any(ActionListener.class));
+        assertNull("create index failed", listener.result());
+
+    }
+
+    public void testIndexCreationFailed() {
+        String indexName = randomLowerCaseString();
+        mockCreateAction(indexName, FAIL);
+        manager.create(indexName, randomFieldMap(INDEX_PROPERTIES_SIZE), listener);
+        verify(mockClient).create(any(CreateIndexRequest.class), any(ActionListener.class));
+        expectThrows(ResourceAlreadyExistsException.class, listener::result);
+    }
+}

--- a/src/test/java/org/opensearch/geospatial/action/upload/geojson/IndexManagerTests.java
+++ b/src/test/java/org/opensearch/geospatial/action/upload/geojson/IndexManagerTests.java
@@ -1,12 +1,6 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
- * The OpenSearch Contributors require contributions made to
- * this file be licensed under the Apache-2.0 license or a
- * compatible open source license.
- *
- * Modifications Copyright OpenSearch Contributors. See
- * GitHub history for details.
  */
 
 package org.opensearch.geospatial.action.upload.geojson;

--- a/src/test/java/org/opensearch/geospatial/action/upload/geojson/PipelineManagerTests.java
+++ b/src/test/java/org/opensearch/geospatial/action/upload/geojson/PipelineManagerTests.java
@@ -1,0 +1,106 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ *
+ * Modifications Copyright OpenSearch Contributors. See
+ * GitHub history for details.
+ */
+
+package org.opensearch.geospatial.action.upload.geojson;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.doAnswer;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.opensearch.geospatial.GeospatialTestHelper.randomLowerCaseString;
+
+import org.opensearch.action.ActionListener;
+import org.opensearch.action.StepListener;
+import org.opensearch.action.ingest.DeletePipelineRequest;
+import org.opensearch.action.ingest.PutPipelineRequest;
+import org.opensearch.action.support.master.AcknowledgedResponse;
+import org.opensearch.client.ClusterAdminClient;
+import org.opensearch.test.OpenSearchTestCase;
+
+public class PipelineManagerTests extends OpenSearchTestCase {
+
+    public static final boolean ACTION_SUCCESS = true;
+    public static final boolean ACTION_FAILED = false;
+    private ClusterAdminClient mockClient;
+    private PipelineManager manager;
+
+    @Override
+    public void setUp() throws Exception {
+        super.setUp();
+        mockClient = mock(ClusterAdminClient.class);
+        manager = new PipelineManager(mockClient);
+    }
+
+    @Override
+    public void tearDown() throws Exception {
+        super.tearDown();
+    }
+
+    private void mockCreatePipelineAction(boolean actionSucceeded) {
+        doAnswer(invocation -> {
+            Object[] args = invocation.getArguments();
+            assert args.length == 2;
+            ActionListener<AcknowledgedResponse> createPipelineAction = (ActionListener<AcknowledgedResponse>) args[1];
+            if (actionSucceeded) {             // call onResponse flow
+                createPipelineAction.onResponse(new AcknowledgedResponse(true));
+                return null;
+            }
+            createPipelineAction.onFailure(new IllegalStateException(randomLowerCaseString()));
+            return null;
+        }).when(mockClient).putPipeline(any(PutPipelineRequest.class), any(ActionListener.class));
+    }
+
+    private void mockDeletePipelineAction(boolean status) {
+        doAnswer(invocation -> {
+            Object[] args = invocation.getArguments();
+            assert args.length == 2;
+            ActionListener<AcknowledgedResponse> createPipelineAction = (ActionListener<AcknowledgedResponse>) args[1];
+            if (status) {
+                createPipelineAction.onResponse(new AcknowledgedResponse(true));
+                return null;
+            }
+            createPipelineAction.onFailure(new IllegalStateException(randomLowerCaseString()));
+            return null;
+        }).when(mockClient).deletePipeline(any(DeletePipelineRequest.class), any(ActionListener.class));
+    }
+
+    public void testCreatePipelineSuccess() {
+        mockCreatePipelineAction(ACTION_SUCCESS);
+        StepListener<String> createPipelineListener = new StepListener<>();
+        manager.create(randomLowerCaseString(), createPipelineListener);
+        verify(mockClient).putPipeline(any(PutPipelineRequest.class), any(ActionListener.class));
+        assertNotNull("create pipeline failed", createPipelineListener.result());
+    }
+
+    public void testCreatePipelineFailed() {
+        mockCreatePipelineAction(ACTION_FAILED);
+        StepListener<String> createPipelineListener = new StepListener<>();
+        manager.create(randomLowerCaseString(), createPipelineListener);
+        verify(mockClient).putPipeline(any(PutPipelineRequest.class), any(ActionListener.class));
+        expectThrows(IllegalStateException.class, createPipelineListener::result);
+    }
+
+    public void testDeletePipelineSuccess() {
+        mockDeletePipelineAction(ACTION_SUCCESS);
+        StepListener<Exception> deletePipelineListener = new StepListener<>();
+        manager.delete(randomLowerCaseString(), deletePipelineListener, () -> null);
+        verify(mockClient).deletePipeline(any(DeletePipelineRequest.class), any(ActionListener.class));
+        assertNull("delete pipeline failed", deletePipelineListener.result());
+    }
+
+    public void testDeletePipelineFailed() {
+        mockDeletePipelineAction(ACTION_FAILED);
+        StepListener<Exception> deletePipelineListener = new StepListener<>();
+        manager.delete(randomLowerCaseString(), deletePipelineListener, () -> new IllegalStateException());
+        verify(mockClient).deletePipeline(any(DeletePipelineRequest.class), any(ActionListener.class));
+        expectThrows(IllegalStateException.class, deletePipelineListener::result);
+    }
+}

--- a/src/test/java/org/opensearch/geospatial/action/upload/geojson/PipelineManagerTests.java
+++ b/src/test/java/org/opensearch/geospatial/action/upload/geojson/PipelineManagerTests.java
@@ -1,12 +1,6 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
- * The OpenSearch Contributors require contributions made to
- * this file be licensed under the Apache-2.0 license or a
- * compatible open source license.
- *
- * Modifications Copyright OpenSearch Contributors. See
- * GitHub history for details.
  */
 
 package org.opensearch.geospatial.action.upload.geojson;

--- a/src/test/java/org/opensearch/geospatial/action/upload/geojson/UploadGeoJSONRequestTests.java
+++ b/src/test/java/org/opensearch/geospatial/action/upload/geojson/UploadGeoJSONRequestTests.java
@@ -1,12 +1,6 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
- * The OpenSearch Contributors require contributions made to
- * this file be licensed under the Apache-2.0 license or a
- * compatible open source license.
- *
- * Modifications Copyright OpenSearch Contributors. See
- * GitHub history for details.
  */
 
 package org.opensearch.geospatial.action.upload.geojson;

--- a/src/test/java/org/opensearch/geospatial/action/upload/geojson/UploaderTests.java
+++ b/src/test/java/org/opensearch/geospatial/action/upload/geojson/UploaderTests.java
@@ -1,12 +1,6 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
- * The OpenSearch Contributors require contributions made to
- * this file be licensed under the Apache-2.0 license or a
- * compatible open source license.
- *
- * Modifications Copyright OpenSearch Contributors. See
- * GitHub history for details.
  */
 
 package org.opensearch.geospatial.action.upload.geojson;

--- a/src/test/java/org/opensearch/geospatial/action/upload/geojson/UploaderTests.java
+++ b/src/test/java/org/opensearch/geospatial/action/upload/geojson/UploaderTests.java
@@ -1,0 +1,255 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ *
+ * Modifications Copyright OpenSearch Contributors. See
+ * GitHub history for details.
+ */
+
+package org.opensearch.geospatial.action.upload.geojson;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyMap;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.doAnswer;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.opensearch.geospatial.GeospatialTestHelper.randomLowerCaseString;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import java.util.function.Supplier;
+import java.util.stream.IntStream;
+
+import org.opensearch.OpenSearchException;
+import org.opensearch.action.ActionListener;
+import org.opensearch.action.DocWriteRequest;
+import org.opensearch.action.StepListener;
+import org.opensearch.action.bulk.BulkItemResponse;
+import org.opensearch.action.bulk.BulkRequestBuilder;
+import org.opensearch.action.bulk.BulkResponse;
+import org.opensearch.action.index.IndexResponse;
+import org.opensearch.action.support.replication.ReplicationResponse;
+import org.opensearch.common.UUIDs;
+import org.opensearch.common.collect.Tuple;
+import org.opensearch.geospatial.GeospatialTestHelper;
+import org.opensearch.index.shard.ShardId;
+import org.opensearch.test.OpenSearchTestCase;
+import org.opensearch.test.RandomObjects;
+
+public class UploaderTests extends OpenSearchTestCase {
+
+    public static final int MAX_NUM_ACTION = 5;
+    public static final boolean ACTION_SUCCESS = true;
+    public static final boolean BULK_REQUEST_SUCCESS = false;
+    public static final boolean BULK_REQUEST_FAILURE = true;
+    public static final boolean ACTION_FAILED = false;
+    public static final int MAX_SHARD_ID = 100;
+    public static final int MAX_SEQ_NO = 10000;
+    public static final int MAX_PRIMARY_TERM = 10000;
+    public static final int MAX_VERSION = 10000;
+    public static final boolean INDEX_ALREADY_EXIST = true;
+    public static final boolean INDEX_DOES_NOT_EXIST = false;
+    private Uploader uploader;
+    private UploadGeoJSONRequestContent content;
+    private ActionListener mockListener;
+    private IndexManager mockIndexManager;
+    private PipelineManager mockPipelineManager;
+    private ContentBuilder mockContentBuilder;
+    private BulkRequestBuilder mockBulkRequestBuilder;
+
+    @Override
+    public void setUp() throws Exception {
+        super.setUp();
+        mockListener = mock(ActionListener.class);
+        mockIndexManager = mock(IndexManager.class);
+        mockPipelineManager = mock(PipelineManager.class);
+        mockContentBuilder = mock(ContentBuilder.class);
+        mockBulkRequestBuilder = mock(BulkRequestBuilder.class);
+
+        uploader = new Uploader(mockIndexManager, mockPipelineManager, mockContentBuilder);
+        Map<String, Object> contentMap = GeospatialTestHelper.buildRequestContent(3);
+        content = UploadGeoJSONRequestContent.create(contentMap);
+    }
+
+    @Override
+    public void tearDown() throws Exception {
+        super.tearDown();
+    }
+
+    private void mockCreateIndexAction(boolean status) {
+        doAnswer(invocation -> {
+            Object[] args = invocation.getArguments();
+            assert args.length == 3;
+            StepListener<Void> createIndexListener = (StepListener<Void>) args[2];
+            if (status) {             // call onResponse flow
+                createIndexListener.onResponse(null);
+                return null;
+            }
+            createIndexListener.onFailure(new IllegalStateException(randomLowerCaseString()));
+            return null;
+        }).when(mockIndexManager).create(anyString(), anyMap(), any(StepListener.class));
+    }
+
+    private void mockCreatePipelineAction(boolean status) {
+        doAnswer(invocation -> {
+            Object[] args = invocation.getArguments();
+            assert args.length == 2;
+            StepListener<String> createPipelineListener = (StepListener<String>) args[1];
+            if (status) {             // call onResponse flow
+                createPipelineListener.onResponse(randomLowerCaseString());
+                return null;
+            }
+            createPipelineListener.onFailure(new IllegalStateException(randomLowerCaseString()));
+            return null;
+        }).when(mockPipelineManager).create(anyString(), any(StepListener.class));
+    }
+
+    private void mockDeletePipelineAction(boolean status, Supplier<Exception> supplier) {
+        doAnswer(invocation -> {
+            Object[] args = invocation.getArguments();
+            assert args.length == 3;
+            StepListener<Exception> createPipelineListener = (StepListener<Exception>) args[1];
+
+            if (status) {             // call onResponse flow
+                createPipelineListener.onResponse(supplier.get());
+                return null;
+            }
+            createPipelineListener.onFailure(new IllegalStateException(randomLowerCaseString()));
+            return null;
+        }).when(mockPipelineManager).delete(anyString(), any(StepListener.class), any(Supplier.class));
+    }
+
+    private void mockContentPreparation(boolean status) {
+        doAnswer(invocation -> {
+            Object[] args = invocation.getArguments();
+            assert args.length == 2;
+            if (status) {             // call onResponse flow
+                return Optional.of(mockBulkRequestBuilder);
+            }
+            return Optional.empty();
+        }).when(mockContentBuilder).prepare(any(UploadGeoJSONRequestContent.class), anyString());
+    }
+
+    public void testCreateIndexIsNotCalled() {
+        uploader.upload(content, INDEX_ALREADY_EXIST, mockListener);
+        verify(mockIndexManager, never()).create(anyString(), any(Map.class), any(StepListener.class));
+    }
+
+    public void testCreateIndexSuccess() {
+        mockCreateIndexAction(ACTION_SUCCESS);
+        uploader.upload(content, INDEX_DOES_NOT_EXIST, mockListener);
+        verify(mockIndexManager).create(any(String.class), anyMap(), any(StepListener.class));
+        // if create index is success, verify next step is called.
+        verify(mockPipelineManager).create(anyString(), any(StepListener.class));
+    }
+
+    public void testCreateIndexFailed() {
+        mockCreateIndexAction(ACTION_FAILED);
+        uploader.upload(content, INDEX_DOES_NOT_EXIST, mockListener);
+        verify(mockIndexManager).create(any(String.class), anyMap(), any(StepListener.class));
+        // if create index is success, verify, next step is not called.
+        verify(mockPipelineManager, never()).create(anyString(), any(StepListener.class));
+    }
+
+    public void testCreatePipelineSuccess() {
+        mockCreatePipelineAction(ACTION_SUCCESS);
+        uploader.upload(content, INDEX_ALREADY_EXIST, mockListener);
+        verify(mockPipelineManager).create(anyString(), any(StepListener.class));
+        // if create pipeline is success, verify next step is called.
+        verify(mockContentBuilder).prepare(any(UploadGeoJSONRequestContent.class), anyString());
+    }
+
+    public void testCreatePipelineFailed() {
+
+        mockCreatePipelineAction(ACTION_FAILED);
+        uploader.upload(content, INDEX_ALREADY_EXIST, mockListener);
+        // if create index is success, verify, next step is not called.
+        verify(mockContentBuilder, never()).prepare(any(UploadGeoJSONRequestContent.class), anyString());
+    }
+
+    public void testBulkActionWithoutFailures() {
+        mockCreatePipelineAction(ACTION_SUCCESS);
+        mockContentPreparation(ACTION_SUCCESS);
+        mockBulkRequestExecute(MAX_NUM_ACTION, BULK_REQUEST_SUCCESS);
+        mockDeletePipelineAction(ACTION_SUCCESS, () -> null);
+        uploader.upload(content, INDEX_ALREADY_EXIST, mockListener);
+        verify(mockBulkRequestBuilder).execute(any(ActionListener.class));
+        verify(mockPipelineManager).delete(anyString(), any(StepListener.class), any(Supplier.class));
+        verify(mockListener).onResponse(any());
+    }
+
+    //
+    public void testBulkActionWithFailedIndexRequest() {
+
+        mockCreatePipelineAction(ACTION_SUCCESS);
+        mockContentPreparation(ACTION_SUCCESS);
+        mockBulkRequestExecute(MAX_NUM_ACTION, BULK_REQUEST_FAILURE);
+        mockDeletePipelineAction(ACTION_SUCCESS, () -> new IllegalStateException(randomLowerCaseString()));
+        uploader.upload(content, INDEX_ALREADY_EXIST, mockListener);
+        verify(mockBulkRequestBuilder).execute(any(ActionListener.class));
+        verify(mockPipelineManager).delete(anyString(), any(StepListener.class), any(Supplier.class));
+        verify(mockListener).onFailure(any());
+    }
+
+    private void mockBulkRequestExecute(int noOfActions, boolean hasFailures) {
+        doAnswer(invocation -> {
+            Object[] args = invocation.getArguments();
+            assert args.length == 1;
+            ActionListener<BulkResponse> bulkRequestAction = (ActionListener<BulkResponse>) args[0];
+            bulkRequestAction.onResponse(generateRandomBulkResponse(noOfActions, hasFailures));
+            return null;
+        }).when(mockBulkRequestBuilder).execute(any(ActionListener.class));
+    }
+
+    private BulkResponse generateRandomBulkResponse(int noOfItems, boolean hasFailures) {
+        long took = randomNonNegativeLong();
+        long ingestTook = randomNonNegativeLong();
+        if (noOfItems < 1) {
+            return new BulkResponse(null, took, ingestTook);
+        }
+        List<BulkItemResponse> items = new ArrayList<>();
+        IntStream.range(0, noOfItems)
+            .forEach(shardId -> items.add(new BulkItemResponse(shardId, DocWriteRequest.OpType.CREATE, randomIndexResponse())));
+        if (hasFailures) {
+            final BulkItemResponse.Failure failedToIndex = new BulkItemResponse.Failure(
+                randomLowerCaseString(),
+                randomLowerCaseString(),
+                UUIDs.randomBase64UUID(),
+                new OpenSearchException(randomLowerCaseString())
+            );
+            items.add(new BulkItemResponse(randomIntBetween(0, MAX_SHARD_ID), DocWriteRequest.OpType.CREATE, failedToIndex));
+        }
+        return new BulkResponse(items.stream().toArray(BulkItemResponse[]::new), took, ingestTook);
+    }
+
+    /**
+     * Returns random @link IndexResponse}s by generating inputs using random functions.
+     * It is not guaranted to generate every possible values, and it is not required since
+     * it is used by the unit test and will not be validated by the cluster.
+     */
+    public static IndexResponse randomIndexResponse() {
+        String index = randomLowerCaseString();
+        String indexUUid = UUIDs.randomBase64UUID();
+        int shardId = randomIntBetween(0, MAX_SHARD_ID);
+        String type = randomLowerCaseString();
+        String id = UUIDs.randomBase64UUID();
+        long seqNo = randomIntBetween(0, MAX_SEQ_NO);
+        long primaryTerm = randomIntBetween(0, MAX_PRIMARY_TERM);
+        long version = randomIntBetween(0, MAX_VERSION);
+        boolean created = randomBoolean();
+        boolean forcedRefresh = randomBoolean();
+        Tuple<ReplicationResponse.ShardInfo, ReplicationResponse.ShardInfo> shardInfo = RandomObjects.randomShardInfo(random());
+        IndexResponse actual = new IndexResponse(new ShardId(index, indexUUid, shardId), type, id, seqNo, primaryTerm, version, created);
+        actual.setForcedRefresh(forcedRefresh);
+        actual.setShardInfo(shardInfo.v1());
+
+        return actual;
+    }
+}

--- a/src/test/java/org/opensearch/geospatial/geojson/FeatureCollectionTests.java
+++ b/src/test/java/org/opensearch/geospatial/geojson/FeatureCollectionTests.java
@@ -1,12 +1,6 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
- * The OpenSearch Contributors require contributions made to
- * this file be licensed under the Apache-2.0 license or a
- * compatible open source license.
- *
- * Modifications Copyright OpenSearch Contributors. See
- * GitHub history for details.
  */
 
 package org.opensearch.geospatial.geojson;

--- a/src/test/java/org/opensearch/geospatial/geojson/FeatureCollectionTests.java
+++ b/src/test/java/org/opensearch/geospatial/geojson/FeatureCollectionTests.java
@@ -16,13 +16,10 @@ import static org.opensearch.geospatial.GeospatialObjectBuilder.randomGeoJSONFea
 import static org.opensearch.geospatial.geojson.FeatureCollection.FEATURES_KEY;
 
 import java.util.HashMap;
-import java.util.List;
 import java.util.Map;
-import java.util.stream.Collectors;
 
 import org.json.JSONArray;
 import org.json.JSONObject;
-import org.opensearch.geospatial.GeospatialParser;
 import org.opensearch.test.OpenSearchTestCase;
 
 public class FeatureCollectionTests extends OpenSearchTestCase {
@@ -32,18 +29,11 @@ public class FeatureCollectionTests extends OpenSearchTestCase {
         features.put(randomGeoJSONFeature(new JSONObject()));
         features.put(randomGeoJSONFeature(new JSONObject()));
         features.put(randomGeoJSONFeature(new JSONObject()));
-        features.put(randomGeoJSONFeature(new JSONObject()));
+
         Map<String, Object> featureCollectionAsMap = buildGeoJSONFeatureCollection(features).toMap();
         FeatureCollection collection = FeatureCollection.create(featureCollectionAsMap);
         assertNotNull(collection);
         assertEquals(features.toList().size(), collection.getFeatures().size());
-
-        List<Map<String, Object>> expected = features.toList()
-            .stream()
-            .map(GeospatialParser::toStringObjectMap)
-            .collect(Collectors.toList());
-
-        assertArrayEquals("features are not equal", expected.toArray(), collection.getFeatures().toArray());
     }
 
     public void testCreateFeatureCollectionInvalidType() {
@@ -68,6 +58,6 @@ public class FeatureCollectionTests extends OpenSearchTestCase {
         featureCollectionAsMap.put(FeatureCollection.TYPE_KEY, FeatureCollection.TYPE);
         featureCollectionAsMap.put(FEATURES_KEY, "invalid");
         IllegalArgumentException ex = assertThrows(IllegalArgumentException.class, () -> FeatureCollection.create(featureCollectionAsMap));
-        assertTrue(ex.getMessage().contains(FEATURES_KEY + " is not an instance of type Object[]"));
+        assertTrue(ex.getMessage().contains(FEATURES_KEY + " is not an instance of type List"));
     }
 }

--- a/src/test/java/org/opensearch/geospatial/rest/action/upload/geojson/RestUploadGeoJSONActionIT.java
+++ b/src/test/java/org/opensearch/geospatial/rest/action/upload/geojson/RestUploadGeoJSONActionIT.java
@@ -11,6 +11,7 @@
 
 package org.opensearch.geospatial.rest.action.upload.geojson;
 
+import static org.opensearch.geospatial.GeospatialTestHelper.randomLowerCaseString;
 import static org.opensearch.geospatial.rest.action.upload.geojson.RestUploadGeoJSONAction.ACTION_OBJECT;
 import static org.opensearch.geospatial.rest.action.upload.geojson.RestUploadGeoJSONAction.ACTION_UPLOAD;
 

--- a/src/test/java/org/opensearch/geospatial/rest/action/upload/geojson/RestUploadGeoJSONActionIT.java
+++ b/src/test/java/org/opensearch/geospatial/rest/action/upload/geojson/RestUploadGeoJSONActionIT.java
@@ -54,6 +54,7 @@ public class RestUploadGeoJSONActionIT extends GeospatialRestTestCase {
         Map<String, String> geoFields = new HashMap<>();
         geoFields.put(geoFieldName, "geo_shape");
         createIndex(index, Settings.EMPTY, geoFields);
+        assertIndexExists(index);
         String path = String.join(GeospatialPlugin.URL_DELIMITER, GeospatialPlugin.getPluginURLPrefix(), ACTION_OBJECT, ACTION_UPLOAD);
         Request request = new Request("POST", path);
         final JSONObject requestBody = buildUploadGeoJSONRequestContent(NUMBER_OF_FEATURES_TO_ADD, index, geoFieldName);

--- a/src/test/java/org/opensearch/geospatial/rest/action/upload/geojson/RestUploadGeoJSONActionIT.java
+++ b/src/test/java/org/opensearch/geospatial/rest/action/upload/geojson/RestUploadGeoJSONActionIT.java
@@ -15,32 +15,83 @@ import static org.opensearch.geospatial.rest.action.upload.geojson.RestUploadGeo
 import static org.opensearch.geospatial.rest.action.upload.geojson.RestUploadGeoJSONAction.ACTION_UPLOAD;
 
 import java.io.IOException;
+import java.util.HashMap;
+import java.util.Map;
 
+import org.json.JSONObject;
 import org.opensearch.client.Request;
 import org.opensearch.client.Response;
+import org.opensearch.client.ResponseException;
+import org.opensearch.common.settings.Settings;
 import org.opensearch.geospatial.GeospatialRestTestCase;
+import org.opensearch.geospatial.action.upload.geojson.UploadGeoJSONRequestContent;
 import org.opensearch.geospatial.plugin.GeospatialPlugin;
 import org.opensearch.rest.RestStatus;
 
 public class RestUploadGeoJSONActionIT extends GeospatialRestTestCase {
 
+    public static final int NUMBER_OF_FEATURES_TO_ADD = 3;
+
     public void testGeoJSONUploadSuccessPostMethod() throws IOException {
 
         String path = String.join(GeospatialPlugin.URL_DELIMITER, GeospatialPlugin.getPluginURLPrefix(), ACTION_OBJECT, ACTION_UPLOAD);
         Request request = new Request("POST", path);
-        request.setJsonEntity(buildUploadGeoJSONRequestContent().toString());
+        final JSONObject requestBody = buildUploadGeoJSONRequestContent(NUMBER_OF_FEATURES_TO_ADD, null, null);
+        final String index = requestBody.getString(UploadGeoJSONRequestContent.FIELD_INDEX.getPreferredName());
+        assertIndexNotExists(index);
+        request.setJsonEntity(requestBody.toString());
         Response response = client().performRequest(request);
         assertEquals(RestStatus.OK, RestStatus.fromCode(response.getStatusLine().getStatusCode()));
+        assertIndexExists(index);
+        assertEquals("failed to index documents", NUMBER_OF_FEATURES_TO_ADD, getIndexDocumentCount(index));
+    }
 
+    public void testGeoJSONUploadFailIndexExists() throws IOException {
+
+        String index = randomLowerCaseString();
+        String geoFieldName = randomLowerCaseString();
+        Map<String, String> geoFields = new HashMap<>();
+        geoFields.put(geoFieldName, "geo_shape");
+        createIndex(index, Settings.EMPTY, geoFields);
+        String path = String.join(GeospatialPlugin.URL_DELIMITER, GeospatialPlugin.getPluginURLPrefix(), ACTION_OBJECT, ACTION_UPLOAD);
+        Request request = new Request("POST", path);
+        final JSONObject requestBody = buildUploadGeoJSONRequestContent(NUMBER_OF_FEATURES_TO_ADD, index, geoFieldName);
+        request.setJsonEntity(requestBody.toString());
+        final ResponseException responseException = assertThrows(ResponseException.class, () -> client().performRequest(request));
+        assertTrue("Not an expected exception", responseException.getMessage().contains("resource_already_exists_exception"));
     }
 
     public void testGeoJSONUploadSuccessPutMethod() throws IOException {
 
         String path = String.join(GeospatialPlugin.URL_DELIMITER, GeospatialPlugin.getPluginURLPrefix(), ACTION_OBJECT, ACTION_UPLOAD);
         Request request = new Request("PUT", path);
-        request.setJsonEntity(buildUploadGeoJSONRequestContent().toString());
+        final JSONObject requestBody = buildUploadGeoJSONRequestContent(NUMBER_OF_FEATURES_TO_ADD, null, null);
+        final String index = requestBody.getString(UploadGeoJSONRequestContent.FIELD_INDEX.getPreferredName());
+        assertIndexNotExists(index);
+        request.setJsonEntity(requestBody.toString());
         Response response = client().performRequest(request);
         assertEquals(RestStatus.OK, RestStatus.fromCode(response.getStatusLine().getStatusCode()));
+        assertIndexExists(index);
+        assertEquals("failed to index documents", NUMBER_OF_FEATURES_TO_ADD, getIndexDocumentCount(index));
+    }
 
+    public void testGeoJSONPutMethodUploadIndexExists() throws IOException {
+
+        String index = randomLowerCaseString();
+        String geoFieldName = randomLowerCaseString();
+        String path = String.join(GeospatialPlugin.URL_DELIMITER, GeospatialPlugin.getPluginURLPrefix(), ACTION_OBJECT, ACTION_UPLOAD);
+        Request request = new Request("PUT", path);
+        final JSONObject requestBody = buildUploadGeoJSONRequestContent(NUMBER_OF_FEATURES_TO_ADD, index, geoFieldName);
+        request.setJsonEntity(requestBody.toString());
+        Response response = client().performRequest(request);
+        assertEquals(RestStatus.OK, RestStatus.fromCode(response.getStatusLine().getStatusCode()));
+        int indexDocumentCount = getIndexDocumentCount(index);
+        // upload again
+        final JSONObject requestBodyUpload = buildUploadGeoJSONRequestContent(NUMBER_OF_FEATURES_TO_ADD, index, geoFieldName);
+        request.setJsonEntity(requestBodyUpload.toString());
+        Response uploadGeoJSONSecondTimeResponse = client().performRequest(request);
+        assertEquals(RestStatus.OK, RestStatus.fromCode(uploadGeoJSONSecondTimeResponse.getStatusLine().getStatusCode()));
+        int expectedDocCountAfterUpload = indexDocumentCount + NUMBER_OF_FEATURES_TO_ADD;
+        assertEquals("failed to index documents", expectedDocCountAfterUpload, getIndexDocumentCount(index));
     }
 }


### PR DESCRIPTION
Signed-off-by: Vijayan Balasubramanian <balasvij@amazon.com>

### Description
Uploader will upload GeoJSON objects from UploadGeoJSONRequestContent as Documents to given index in three stage.

- At first stage (preUpload), resources like index, mapping, pipeline with GeoJSON Feature processors, will be created.
- At second stage (upload), Feature will be extracted from GeoJSON and indexed using BulkAction. This supports both Feature and FeatureCollection.
- At third stage (postUpload), previously created pipeline will be deleted and
- response will be added to the listener.

### Check List
- [x] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
