### PR TITLE
Make field name as optional

### DIFF
--- a/src/main/java/org/opensearch/geospatial/action/upload/geojson/UploadGeoJSONRequestContent.java
+++ b/src/main/java/org/opensearch/geospatial/action/upload/geojson/UploadGeoJSONRequestContent.java
@@ -19,6 +19,7 @@ import org.opensearch.common.Strings;
  */
 public final class UploadGeoJSONRequestContent {
 
+    public static final String GEOSPATIAL_DEFAULT_FIELD_NAME = "location";
     public static final ParseField FIELD_INDEX = new ParseField("index", new String[0]);
     public static final ParseField FIELD_GEOSPATIAL = new ParseField("field", new String[0]);
     public static final ParseField FIELD_GEOSPATIAL_TYPE = new ParseField("type", new String[0]);
@@ -50,7 +51,7 @@ public final class UploadGeoJSONRequestContent {
         }
         String fieldName = extractValueAsString(input, FIELD_GEOSPATIAL.getPreferredName());
         if (!Strings.hasText(fieldName)) {
-            throw new IllegalArgumentException("field [ " + FIELD_GEOSPATIAL.getPreferredName() + " ] cannot be empty");
+            fieldName = GEOSPATIAL_DEFAULT_FIELD_NAME; // use default filed name, if field name is empty
         }
         String fieldType = extractValueAsString(input, FIELD_GEOSPATIAL_TYPE.getPreferredName());
         if (!Strings.hasText(fieldType)) {

--- a/src/test/java/org/opensearch/geospatial/action/upload/geojson/UploadGeoJSONRequestContentTests.java
+++ b/src/test/java/org/opensearch/geospatial/action/upload/geojson/UploadGeoJSONRequestContentTests.java
@@ -8,6 +8,7 @@ package org.opensearch.geospatial.action.upload.geojson;
 import static org.opensearch.geospatial.GeospatialObjectBuilder.buildProperties;
 import static org.opensearch.geospatial.GeospatialObjectBuilder.randomGeoJSONFeature;
 import static org.opensearch.geospatial.action.upload.geojson.UploadGeoJSONRequestContent.FIELD_DATA;
+import static org.opensearch.geospatial.action.upload.geojson.UploadGeoJSONRequestContent.GEOSPATIAL_DEFAULT_FIELD_NAME;
 
 import java.util.Collections;
 import java.util.Map;
@@ -51,11 +52,9 @@ public class UploadGeoJSONRequestContentTests extends OpenSearchTestCase {
     }
 
     public void testCreateEmptyGeospatialFieldName() {
-        IllegalArgumentException invalidIndexName = assertThrows(
-            IllegalArgumentException.class,
-            () -> UploadGeoJSONRequestContent.create(buildRequestContent("some-index", ""))
-        );
-        assertTrue(invalidIndexName.getMessage().contains("[ field ] cannot be empty"));
+        UploadGeoJSONRequestContent content = UploadGeoJSONRequestContent.create(buildRequestContent("some-index", ""));
+        assertNotNull(content);
+        assertEquals("wrong field name", GEOSPATIAL_DEFAULT_FIELD_NAME, content.getFieldName());
     }
 
     public void testCreateEmptyGeospatialFieldType() {


### PR DESCRIPTION
Signed-off-by: Vijayan Balasubramanian <balasvij@amazon.com>

### Description
Use default field name, if field is not explicitly provided.
 
### Check List
- [x] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
