### PR TITLE
Update upstream to use 2.1

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -27,7 +27,7 @@ jobs:
 
       - name: Run build
         run: |
-          ./gradlew build -Dopensearch.version=1.3.0-SNAPSHOT
+          ./gradlew build -Dopensearch.version=2.1.0-SNAPSHOT
 
       - name: Upload Coverage Report
         uses: codecov/codecov-action@v1

--- a/build.gradle
+++ b/build.gradle
@@ -70,6 +70,8 @@ allprojects {
     if (isSnapshot) {
         version += "-SNAPSHOT"
     }
+    targetCompatibility = JavaVersion.VERSION_11
+    sourceCompatibility = JavaVersion.VERSION_11
 }
 
 repositories {

--- a/build.gradle
+++ b/build.gradle
@@ -43,7 +43,7 @@ validateNebulaPom.enabled = false
 
 buildscript {
     ext {
-        opensearch_version = System.getProperty("opensearch.version", "1.3.0-SNAPSHOT")
+        opensearch_version = System.getProperty("opensearch.version", "2.1.0-SNAPSHOT")
         opensearch_group = "org.opensearch"
     }
 

--- a/src/main/java/org/opensearch/geospatial/action/upload/geojson/ContentBuilder.java
+++ b/src/main/java/org/opensearch/geospatial/action/upload/geojson/ContentBuilder.java
@@ -23,7 +23,6 @@ import org.opensearch.geospatial.GeospatialParser;
  */
 public class ContentBuilder {
     public static final String GEOJSON_FEATURE_ID_FIELD = "id";
-    private static final String DOCUMENT_TYPE = "_doc";
     private final Client client;
 
     public ContentBuilder(Client client) {
@@ -52,7 +51,6 @@ public class ContentBuilder {
             .map(documentSource -> createIndexRequestBuilder(documentSource))
             .map(indexRequestBuilder -> indexRequestBuilder.setIndex(content.getIndexName()))
             .map(indexRequestBuilder -> indexRequestBuilder.setPipeline(pipeline))
-            .map(indexRequestBuilder -> indexRequestBuilder.setType(DOCUMENT_TYPE))
             .forEach(builder::add);
         if (builder.numberOfActions() < 1) { // check any features to upload
             return Optional.empty();

--- a/src/main/java/org/opensearch/geospatial/action/upload/geojson/IndexManager.java
+++ b/src/main/java/org/opensearch/geospatial/action/upload/geojson/IndexManager.java
@@ -56,7 +56,7 @@ public class IndexManager {
     }
 
     private void createIndex(String indexName, XContentBuilder mapping, StepListener<Void> createIndexStep) {
-        CreateIndexRequest request = new CreateIndexRequest(indexName).mapping(DOCUMENT_TYPE, mapping);
+        CreateIndexRequest request = new CreateIndexRequest(indexName).mapping(mapping);
         client.create(request, ActionListener.wrap(createIndexResponse -> {
             StringBuilder message = new StringBuilder("Created index: ").append(indexName);
             LOGGER.info(message.toString());

--- a/src/test/java/org/opensearch/geospatial/action/upload/geojson/UploaderTests.java
+++ b/src/test/java/org/opensearch/geospatial/action/upload/geojson/UploaderTests.java
@@ -215,7 +215,6 @@ public class UploaderTests extends OpenSearchTestCase {
             final BulkItemResponse.Failure failedToIndex = new BulkItemResponse.Failure(
                 randomLowerCaseString(),
                 randomLowerCaseString(),
-                UUIDs.randomBase64UUID(),
                 new OpenSearchException(randomLowerCaseString())
             );
             items.add(new BulkItemResponse(randomIntBetween(0, MAX_SHARD_ID), DocWriteRequest.OpType.CREATE, failedToIndex));
@@ -232,7 +231,6 @@ public class UploaderTests extends OpenSearchTestCase {
         String index = randomLowerCaseString();
         String indexUUid = UUIDs.randomBase64UUID();
         int shardId = randomIntBetween(0, MAX_SHARD_ID);
-        String type = randomLowerCaseString();
         String id = UUIDs.randomBase64UUID();
         long seqNo = randomIntBetween(0, MAX_SEQ_NO);
         long primaryTerm = randomIntBetween(0, MAX_PRIMARY_TERM);
@@ -240,7 +238,7 @@ public class UploaderTests extends OpenSearchTestCase {
         boolean created = randomBoolean();
         boolean forcedRefresh = randomBoolean();
         Tuple<ReplicationResponse.ShardInfo, ReplicationResponse.ShardInfo> shardInfo = RandomObjects.randomShardInfo(random());
-        IndexResponse actual = new IndexResponse(new ShardId(index, indexUUid, shardId), type, id, seqNo, primaryTerm, version, created);
+        IndexResponse actual = new IndexResponse(new ShardId(index, indexUUid, shardId), id, seqNo, primaryTerm, version, created);
         actual.setForcedRefresh(forcedRefresh);
         actual.setShardInfo(shardInfo.v1());
 


### PR DESCRIPTION
### Description

- Update upstream to use 2.1 snapshot.
- Remove incompatible changes from 1.3 to 2.1
- Add min compatibility as java 11

 
 
### Check List
- [x] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
