### PR TITLE
Update upload API response structure

### DIFF
--- a/src/main/java/org/opensearch/geospatial/action/upload/geojson/UploadGeoJSONAction.java
+++ b/src/main/java/org/opensearch/geospatial/action/upload/geojson/UploadGeoJSONAction.java
@@ -12,14 +12,13 @@
 package org.opensearch.geospatial.action.upload.geojson;
 
 import org.opensearch.action.ActionType;
-import org.opensearch.action.support.master.AcknowledgedResponse;
 
-public class UploadGeoJSONAction extends ActionType<AcknowledgedResponse> {
+public class UploadGeoJSONAction extends ActionType<UploadGeoJSONResponse> {
 
     public static UploadGeoJSONAction INSTANCE = new UploadGeoJSONAction();
     public static final String NAME = "cluster:admin/upload_geojson_action";
 
     private UploadGeoJSONAction() {
-        super(NAME, AcknowledgedResponse::new);
+        super(NAME, UploadGeoJSONResponse::new);
     }
 }

--- a/src/main/java/org/opensearch/geospatial/action/upload/geojson/UploadGeoJSONResponse.java
+++ b/src/main/java/org/opensearch/geospatial/action/upload/geojson/UploadGeoJSONResponse.java
@@ -1,0 +1,115 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package org.opensearch.geospatial.action.upload.geojson;
+
+import java.io.IOException;
+import java.util.Arrays;
+import java.util.Map;
+import java.util.stream.Collectors;
+
+import org.opensearch.action.ActionResponse;
+import org.opensearch.action.bulk.BulkItemResponse;
+import org.opensearch.action.bulk.BulkResponse;
+import org.opensearch.common.io.stream.StreamInput;
+import org.opensearch.common.io.stream.StreamOutput;
+import org.opensearch.common.xcontent.ToXContentObject;
+import org.opensearch.common.xcontent.XContentBuilder;
+
+//UploadGeoJSONResponse represents UploadGeoJSONRequest's Response
+public class UploadGeoJSONResponse extends ActionResponse implements ToXContentObject {
+    private static final String ERRORS = "errors";
+    private static final String FAILURE = "failure";
+    private static final String ID = "id";
+    private static final String FAILURES = "failures";
+    private static final String MESSAGE = "message";
+    private static final String SUCCESS = "success";
+    private static final String TOOK = "took";
+    private static final String TOTAL = "total";
+    private static final int NO_FAILURE = 0;
+    private final BulkResponse bulkResponse;
+
+    public UploadGeoJSONResponse(BulkResponse bulkResponse) {
+        super();
+        this.bulkResponse = bulkResponse;
+    }
+
+    public UploadGeoJSONResponse(StreamInput in) throws IOException {
+        super(in);
+        this.bulkResponse = new BulkResponse(in);
+    }
+
+    @Override
+    public void writeTo(StreamOutput streamOutput) throws IOException {
+        this.bulkResponse.writeTo(streamOutput);
+    }
+
+    @Override
+    public XContentBuilder toXContent(XContentBuilder builder, Params params) throws IOException {
+        /*
+        If BulkResponse has no failures:
+            {
+              "took": 100,
+              "errors": false,
+              "total": 5,
+              "success": 5,
+              "failure": 0
+            }
+        If BulkResponse has failures:
+            {
+              "took": 100,
+              "errors": true,
+              "total": 4,
+              "success": 2,
+              "failure": 2,
+              "failures": [
+                  {
+                    "id" : "DocId2",
+                    "message" : "failed to index due to ..."
+                  },
+                  {
+                    "id" : "DocId3",
+                    "message" : "failed to index due to ..."
+                  }
+             ]
+          }
+         */
+        builder.startObject();
+        builder.field(TOOK, bulkResponse.getTook().getMillis());
+        builder.field(ERRORS, bulkResponse.hasFailures());
+        builder.field(TOTAL, bulkResponse.getItems().length);
+        if (!bulkResponse.hasFailures()) {
+            buildSuccessXContent(builder);
+            return builder.endObject();
+        }
+        buildFailureXContent(builder);
+        return builder.endObject();
+    }
+
+    private void buildSuccessXContent(XContentBuilder builder) throws IOException {
+        buildResultXContent(builder, bulkResponse.getItems().length, NO_FAILURE);
+    }
+
+    private void buildResultXContent(XContentBuilder builder, int successCount, int failureCount) throws IOException {
+        builder.field(SUCCESS, successCount);
+        builder.field(FAILURE, failureCount);
+    }
+
+    private void buildFailureXContent(XContentBuilder builder) throws IOException {
+        final Map<String, String> failedResponses = Arrays.stream(bulkResponse.getItems())
+            .filter(BulkItemResponse::isFailed)
+            .collect(Collectors.toMap(BulkItemResponse::getId, BulkItemResponse::getFailureMessage));
+        int successCount = bulkResponse.getItems().length - failedResponses.size();
+        buildResultXContent(builder, successCount, failedResponses.size());
+        builder.startArray(FAILURES);
+        for (Map.Entry<String, String> entry : failedResponses.entrySet()) {
+            builder.startObject();
+            builder.field(ID, entry.getKey());
+            builder.field(MESSAGE, entry.getValue());
+            builder.endObject();
+        }
+        builder.endArray();
+    }
+}

--- a/src/main/java/org/opensearch/geospatial/action/upload/geojson/UploadGeoJSONTransportAction.java
+++ b/src/main/java/org/opensearch/geospatial/action/upload/geojson/UploadGeoJSONTransportAction.java
@@ -17,7 +17,6 @@ import org.opensearch.ResourceAlreadyExistsException;
 import org.opensearch.action.ActionListener;
 import org.opensearch.action.support.ActionFilters;
 import org.opensearch.action.support.HandledTransportAction;
-import org.opensearch.action.support.master.AcknowledgedResponse;
 import org.opensearch.client.Client;
 import org.opensearch.cluster.service.ClusterService;
 import org.opensearch.common.inject.Inject;
@@ -29,7 +28,7 @@ import org.opensearch.transport.TransportService;
 /**
  * TransportAction to handle import operation
  */
-public class UploadGeoJSONTransportAction extends HandledTransportAction<UploadGeoJSONRequest, AcknowledgedResponse> {
+public class UploadGeoJSONTransportAction extends HandledTransportAction<UploadGeoJSONRequest, UploadGeoJSONResponse> {
 
     private final ClusterService clusterService;
     private final Client client;
@@ -47,7 +46,7 @@ public class UploadGeoJSONTransportAction extends HandledTransportAction<UploadG
     }
 
     @Override
-    protected void doExecute(Task task, UploadGeoJSONRequest request, ActionListener<AcknowledgedResponse> actionListener) {
+    protected void doExecute(Task task, UploadGeoJSONRequest request, ActionListener<UploadGeoJSONResponse> actionListener) {
         final Map<String, Object> contentAsMap = GeospatialParser.convertToMap(request.getContent());
         // 1. parse request's data and extract into UploadGeoJSONRequestContent
         final UploadGeoJSONRequestContent content = UploadGeoJSONRequestContent.create(contentAsMap);

--- a/src/test/java/org/opensearch/geospatial/action/upload/geojson/UploadGeoJSONResponseTests.java
+++ b/src/test/java/org/opensearch/geospatial/action/upload/geojson/UploadGeoJSONResponseTests.java
@@ -1,0 +1,42 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package org.opensearch.geospatial.action.upload.geojson;
+
+import org.opensearch.action.bulk.BulkResponse;
+import org.opensearch.common.Strings;
+import org.opensearch.geospatial.GeospatialTestHelper;
+import org.opensearch.test.OpenSearchTestCase;
+
+public class UploadGeoJSONResponseTests extends OpenSearchTestCase {
+
+    private static final int MAX_SUCCESS_ITEM_COUNT = 5;
+    private static final int MIN_SUCCESS_ITEM_COUNT = 5;
+    private static final int FAILURE_ITEM_COUNT = 1;
+
+    public void testToXContentHasNoFailure() {
+        int successActionCount = randomIntBetween(MIN_SUCCESS_ITEM_COUNT, MAX_SUCCESS_ITEM_COUNT);
+        final BulkResponse bulkItemResponses = GeospatialTestHelper.generateRandomBulkResponse(successActionCount, false);
+        UploadGeoJSONResponse getResponse = new UploadGeoJSONResponse(bulkItemResponses);
+        String responseBody = Strings.toString(getResponse);
+        assertTrue(responseBody.contains("\"errors\":false"));
+        assertTrue(responseBody.contains("\"failure\":0"));
+        assertTrue(responseBody.contains("\"total\":" + successActionCount));
+        assertTrue(responseBody.contains("\"success\":" + successActionCount));
+
+    }
+
+    public void testToXContentHasFailure() {
+        int successActionCount = randomIntBetween(MIN_SUCCESS_ITEM_COUNT, MAX_SUCCESS_ITEM_COUNT);
+        int totalActionCount = successActionCount + FAILURE_ITEM_COUNT;
+        final BulkResponse bulkItemResponses = GeospatialTestHelper.generateRandomBulkResponse(successActionCount, true);
+        UploadGeoJSONResponse getResponse = new UploadGeoJSONResponse(bulkItemResponses);
+        String responseBody = Strings.toString(getResponse);
+        assertTrue(responseBody.contains("\"errors\":true"));
+        assertTrue(responseBody.contains("\"total\":" + totalActionCount));
+        assertTrue(responseBody.contains("\"success\":" + successActionCount));
+        assertTrue(responseBody.contains("\"failure\":" + FAILURE_ITEM_COUNT));
+    }
+}

--- a/src/test/java/org/opensearch/geospatial/action/upload/geojson/UploaderTests.java
+++ b/src/test/java/org/opensearch/geospatial/action/upload/geojson/UploaderTests.java
@@ -173,7 +173,7 @@ public class UploaderTests extends OpenSearchTestCase {
         uploader.upload(content, INDEX_ALREADY_EXIST, mockListener);
         verify(mockBulkRequestBuilder).execute(any(ActionListener.class));
         verify(mockPipelineManager).delete(anyString(), any(StepListener.class), any(Supplier.class));
-        verify(mockListener).onFailure(any());
+        verify(mockListener).onResponse(any());
     }
 
     private void mockBulkRequestExecute(int noOfActions, boolean hasFailures) {


### PR DESCRIPTION
### Description
Include following information about upload API results
1. errors, with values either true or false
2. total, with values as total number of documents
3. success, with values as number of documents that are indexed
4. failure, with values as number of documents that are failed
5. failures, json array,  contains additional information about the failed operation.
 
### Issues Resolved
#49 
 
### Check List
- [x] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
