### PR TITLE
Add support to Writeable interface

### DIFF
--- a/src/main/java/org/opensearch/geospatial/stats/upload/UploadMetric.java
+++ b/src/main/java/org/opensearch/geospatial/stats/upload/UploadMetric.java
@@ -10,13 +10,16 @@ import java.util.Locale;
 import java.util.Objects;
 
 import org.opensearch.common.Strings;
+import org.opensearch.common.io.stream.StreamInput;
+import org.opensearch.common.io.stream.StreamOutput;
+import org.opensearch.common.io.stream.Writeable;
 import org.opensearch.common.xcontent.ToXContentFragment;
 import org.opensearch.common.xcontent.XContentBuilder;
 
 /**
  * UploadMetric stores metric for an upload API
  */
-public final class UploadMetric implements ToXContentFragment {
+public final class UploadMetric implements ToXContentFragment, Writeable {
 
     public enum FIELDS {
         UPLOAD,
@@ -116,6 +119,16 @@ public final class UploadMetric implements ToXContentFragment {
         return builder;
     }
 
+    @Override
+    public void writeTo(StreamOutput output) throws IOException {
+        output.writeString(metricID);
+        output.writeString(type);
+        output.writeVLong(uploadCount);
+        output.writeVLong(successCount);
+        output.writeVLong(failedCount);
+        output.writeVLong(duration);
+    }
+
     /**
      * Builder to create {@link UploadMetric}
      */
@@ -164,6 +177,22 @@ public final class UploadMetric implements ToXContentFragment {
          */
         public UploadMetric build() {
             return new UploadMetric(this);
+        }
+
+        /**
+         * Deserialize {@link UploadMetric} from given {@link StreamInput}
+         * @param input StreamInput instance
+         * @return UploadMetric returns {@link UploadMetric} from {@link StreamInput}
+         * @throws IOException if unable to read from {@link StreamInput}
+         */
+        public static UploadMetric fromStreamInput(StreamInput input) throws IOException {
+            String metricId = input.readString();
+            String type = input.readString();
+            UploadMetricBuilder builder = new UploadMetricBuilder(metricId, type).uploadCount(input.readVLong())
+                .successCount(input.readVLong())
+                .failedCount(input.readVLong())
+                .duration(input.readVLong());
+            return builder.build();
         }
 
     }

--- a/src/main/java/org/opensearch/geospatial/stats/upload/UploadStats.java
+++ b/src/main/java/org/opensearch/geospatial/stats/upload/UploadStats.java
@@ -7,7 +7,6 @@ package org.opensearch.geospatial.stats.upload;
 
 import java.util.HashSet;
 import java.util.List;
-import java.util.Locale;
 import java.util.Objects;
 import java.util.Set;
 
@@ -17,18 +16,6 @@ import org.opensearch.common.metrics.CounterMetric;
  * Contains the total upload stats
  */
 public final class UploadStats {
-
-    public enum FIELDS {
-
-        METRICS,
-        TOTAL,
-        UPLOAD;
-
-        @Override
-        public String toString() {
-            return name().toLowerCase(Locale.getDefault());
-        }
-    }
 
     private static final UploadStats instance = new UploadStats();
 

--- a/src/test/java/org/opensearch/geospatial/stats/upload/UploadMetricTests.java
+++ b/src/test/java/org/opensearch/geospatial/stats/upload/UploadMetricTests.java
@@ -9,7 +9,11 @@ import static org.opensearch.geospatial.GeospatialTestHelper.GEOJSON;
 import static org.opensearch.geospatial.GeospatialTestHelper.buildFieldNameValuePair;
 import static org.opensearch.geospatial.GeospatialTestHelper.randomLowerCaseString;
 
+import java.io.IOException;
+
 import org.opensearch.common.Strings;
+import org.opensearch.common.io.stream.BytesStreamOutput;
+import org.opensearch.common.io.stream.StreamInput;
 import org.opensearch.geospatial.GeospatialTestHelper;
 import org.opensearch.test.OpenSearchTestCase;
 
@@ -73,4 +77,45 @@ public class UploadMetricTests extends OpenSearchTestCase {
         assertTrue(metricAsString.contains(buildFieldNameValuePair(UploadMetric.FIELDS.FAILED, actualMetric.getFailedCount())));
         assertTrue(metricAsString.contains(buildFieldNameValuePair(UploadMetric.FIELDS.SUCCESS, actualMetric.getSuccessCount())));
     }
+
+    public void testStreams() throws IOException {
+        UploadMetric actualMetric = GeospatialTestHelper.generateRandomUploadMetric();
+        BytesStreamOutput output = new BytesStreamOutput();
+        actualMetric.writeTo(output);
+        StreamInput in = StreamInput.wrap(output.bytes().toBytesRef().bytes);
+
+        UploadMetric serializedMetric = UploadMetric.UploadMetricBuilder.fromStreamInput(in);
+        assertNotNull("serialized metric cannot be null", serializedMetric);
+        assertEquals(
+            "upload count is not matching between serialized and deserialized",
+            actualMetric.getUploadCount(),
+            serializedMetric.getUploadCount()
+        );
+        assertEquals(
+            "success count is not matching between serialized and deserialized",
+            actualMetric.getSuccessCount(),
+            serializedMetric.getSuccessCount()
+        );
+        assertEquals(
+            "failed count is not matching between serialized and deserialized",
+            actualMetric.getFailedCount(),
+            serializedMetric.getFailedCount()
+        );
+        assertEquals(
+            "duration is not matching between serialized and deserialized",
+            actualMetric.getDuration(),
+            serializedMetric.getDuration()
+        );
+        assertEquals(
+            "metric id is not matching between serialized and deserialized",
+            actualMetric.getMetricID(),
+            serializedMetric.getMetricID()
+        );
+        assertEquals(
+            "geospatial type is not matching between serialized and deserialized",
+            actualMetric.getType(),
+            serializedMetric.getType()
+        );
+    }
+
 }


### PR DESCRIPTION
### Description
UploadStats and UploadMetric will be passed between Nodes during StatsRequest. This request will use
StreamInput/StreamOutput to read stats across each other.
 
 
### Check List
- [x] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
