### PR TITLE
Create Upload Stats Service to build response for stats API

### DIFF
--- a/src/main/java/org/opensearch/geospatial/stats/upload/TotalUploadStats.java
+++ b/src/main/java/org/opensearch/geospatial/stats/upload/TotalUploadStats.java
@@ -40,7 +40,6 @@ public final class TotalUploadStats implements ToXContentObject {
 
     @Override
     public XContentBuilder toXContent(XContentBuilder builder, Params params) throws IOException {
-
         builder.startObject(FIELDS.TOTAL.toString());
         if (isUploadStatsEmpty()) {
             return builder.endObject();

--- a/src/main/java/org/opensearch/geospatial/stats/upload/TotalUploadStats.java
+++ b/src/main/java/org/opensearch/geospatial/stats/upload/TotalUploadStats.java
@@ -1,0 +1,77 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package org.opensearch.geospatial.stats.upload;
+
+import java.io.IOException;
+import java.util.List;
+import java.util.Locale;
+import java.util.Objects;
+import java.util.function.Function;
+
+import org.opensearch.common.xcontent.ToXContentObject;
+import org.opensearch.common.xcontent.XContentBuilder;
+
+// Holder to construct summary of Upload API Stats across all Nodes
+public final class TotalUploadStats implements ToXContentObject {
+
+    // XContent field names
+    public enum FIELDS {
+        DURATION,
+        FAILED,
+        REQUEST_COUNT,
+        SUCCESS,
+        TOTAL,
+        UPLOAD;
+
+        @Override
+        public String toString() {
+            return this.name().toLowerCase(Locale.getDefault());
+        }
+    }
+
+    private final List<UploadStats> uploadStatsList;
+
+    public TotalUploadStats(final List<UploadStats> uploadStatsList) {
+        this.uploadStatsList = Objects.requireNonNull(uploadStatsList, "Upload stats list cannot be null");
+    }
+
+    @Override
+    public XContentBuilder toXContent(XContentBuilder builder, Params params) throws IOException {
+
+        builder.startObject(FIELDS.TOTAL.toString());
+        if (isUploadStatsEmpty()) {
+            return builder.endObject();
+        }
+        long totalRequestCount = uploadStatsList.stream().mapToLong(UploadStats::getTotalAPICount).sum();
+        builder.field(FIELDS.REQUEST_COUNT.toString(), totalRequestCount);
+
+        long totalUpload = sumMetricField(uploadStatsList, UploadMetric::getUploadCount);
+        builder.field(FIELDS.UPLOAD.toString(), totalUpload);
+
+        long totalSuccess = sumMetricField(uploadStatsList, UploadMetric::getSuccessCount);
+        builder.field(FIELDS.SUCCESS.toString(), totalSuccess);
+
+        long totalFailed = sumMetricField(uploadStatsList, UploadMetric::getFailedCount);
+        builder.field(FIELDS.FAILED.toString(), totalFailed);
+
+        long totalDuration = sumMetricField(uploadStatsList, UploadMetric::getDuration);
+        builder.field(FIELDS.DURATION.toString(), totalDuration);
+        return builder.endObject();
+    }
+
+    private long sumMetricField(List<UploadStats> stats, Function<UploadMetric, Long> mapper) {
+        return stats.stream().map(UploadStats::getMetrics).flatMap(List::stream).mapToLong(mapper::apply).sum();
+    }
+
+    /**
+     * Return whether any upload metrics are available or not
+     * @return true if no stats are available
+     */
+    public boolean isUploadStatsEmpty() {
+        return uploadStatsList.isEmpty();
+    }
+
+}

--- a/src/main/java/org/opensearch/geospatial/stats/upload/UploadStatsService.java
+++ b/src/main/java/org/opensearch/geospatial/stats/upload/UploadStatsService.java
@@ -1,0 +1,89 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package org.opensearch.geospatial.stats.upload;
+
+import java.io.IOException;
+import java.util.AbstractMap;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+import java.util.Objects;
+import java.util.stream.Collectors;
+
+import org.opensearch.common.xcontent.ToXContentFragment;
+import org.opensearch.common.xcontent.XContentBuilder;
+
+// Service to calculate summary of upload stats and generate XContent for StatsResponse
+public class UploadStatsService implements ToXContentFragment {
+
+    public static final String UPLOADS = "uploads";
+    public static final String TOTAL = "total";
+    public static final String METRICS = "metrics";
+    public static final String NODE_ID = "node_id";
+    private final Map<String, UploadStats> uploadStats;
+    private final TotalUploadStats totalUploadStats;
+
+    public UploadStatsService(Map<String, UploadStats> uploadStats) {
+        this.uploadStats = Objects.requireNonNull(uploadStats, "upload stats map cannot be null");
+        this.totalUploadStats = new TotalUploadStats(new ArrayList<>(uploadStats.values()));
+    }
+
+    @Override
+    public XContentBuilder toXContent(XContentBuilder builder, Params params) throws IOException {
+        /*
+        {
+          "uploads": {
+            "total": {
+                request_count : # of request,
+                "upload"       : sum of documents to upload across API,
+                "success"     : sum of successfully uploaded documents across API,
+                "failed"      : sum of failed to upload documents across API,
+                "duration"    : sum of duration in milliseconds to ingest document across API
+            },
+            "metrics" : [
+                {
+                    "id"       : <metric-id>,
+                    "node_id"  : node-id
+                    "upload"   : # of documents to upload,
+                    "success"  : # of successfully uploaded documents,
+                    "failed"   : # of failed to upload documents,
+                    "duration" : duration in milliseconds to ingest document
+                }, ......
+            ]
+          }
+        }
+         */
+        builder.startObject(UPLOADS);
+        totalUploadStats.toXContent(builder, params);
+        builder.startArray(METRICS);
+        if (totalUploadStats.isUploadStatsEmpty()) {
+            builder.endArray();
+            return builder.endObject();
+        }
+        final List<AbstractMap.SimpleEntry<String, UploadMetric>> metricsByNodeID = groupMetricsByNodeID(uploadStats);
+        for (AbstractMap.SimpleEntry<String, UploadMetric> entry : metricsByNodeID) {
+            addMetrics(builder, params, entry);
+        }
+        builder.endArray();
+        return builder.endObject();
+    }
+
+    private void addMetrics(XContentBuilder builder, Params params, AbstractMap.SimpleEntry<String, UploadMetric> entry)
+        throws IOException {
+        builder.startObject();
+        builder.field(NODE_ID, entry.getKey());
+        entry.getValue().toXContent(builder, params);
+        builder.endObject();
+    }
+
+    private List<AbstractMap.SimpleEntry<String, UploadMetric>> groupMetricsByNodeID(Map<String, UploadStats> uploadStats) {
+        return uploadStats.entrySet()
+            .stream()
+            .flatMap(stat -> stat.getValue().getMetrics().stream().map(metric -> new AbstractMap.SimpleEntry<>(stat.getKey(), metric)))
+            .collect(Collectors.toList());
+
+    }
+}

--- a/src/test/java/org/opensearch/geospatial/stats/upload/TotalUploadStatsTests.java
+++ b/src/test/java/org/opensearch/geospatial/stats/upload/TotalUploadStatsTests.java
@@ -12,19 +12,17 @@
 package org.opensearch.geospatial.stats.upload;
 
 import static org.opensearch.geospatial.GeospatialTestHelper.buildFieldNameValuePair;
+import static org.opensearch.geospatial.stats.upload.UploadStatsBuilder.randomUploadStats;
 
 import java.io.IOException;
-import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
-import java.util.stream.IntStream;
 
 import org.opensearch.common.Strings;
 import org.opensearch.common.xcontent.ToXContent;
 import org.opensearch.common.xcontent.XContentBuilder;
 import org.opensearch.common.xcontent.XContentFactory;
 import org.opensearch.common.xcontent.XContentType;
-import org.opensearch.geospatial.GeospatialTestHelper;
 import org.opensearch.test.OpenSearchTestCase;
 
 public class TotalUploadStatsTests extends OpenSearchTestCase {
@@ -34,19 +32,6 @@ public class TotalUploadStatsTests extends OpenSearchTestCase {
     private static final int MIN_STATS_COUNT = 2;
 
     private static final long INIT = 0L;
-
-    private UploadStats randomUploadStats() {
-        int randomMetricCount = randomIntBetween(MIN_METRIC_COUNT, MAX_METRIC_COUNT);
-        UploadStats stats = new UploadStats();
-        IntStream.range(0, randomMetricCount).forEach(unUsed -> stats.addMetric(GeospatialTestHelper.generateRandomUploadMetric()));
-        return stats;
-    }
-
-    private List<UploadStats> randomUploadStats(int max) {
-        List<UploadStats> stats = new ArrayList<>();
-        IntStream.range(0, max).forEach(unUsed -> stats.add(randomUploadStats()));
-        return stats;
-    }
 
     public void testInstanceCreation() {
         int randomStatsCount = randomIntBetween(MIN_STATS_COUNT, MAX_STATS_COUNT);

--- a/src/test/java/org/opensearch/geospatial/stats/upload/TotalUploadStatsTests.java
+++ b/src/test/java/org/opensearch/geospatial/stats/upload/TotalUploadStatsTests.java
@@ -1,0 +1,156 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ *
+ * Modifications Copyright OpenSearch Contributors. See
+ * GitHub history for details.
+ */
+
+package org.opensearch.geospatial.stats.upload;
+
+import static org.opensearch.geospatial.GeospatialTestHelper.buildFieldNameValuePair;
+
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+import java.util.stream.IntStream;
+
+import org.opensearch.common.Strings;
+import org.opensearch.common.xcontent.ToXContent;
+import org.opensearch.common.xcontent.XContentBuilder;
+import org.opensearch.common.xcontent.XContentFactory;
+import org.opensearch.common.xcontent.XContentType;
+import org.opensearch.geospatial.GeospatialTestHelper;
+import org.opensearch.test.OpenSearchTestCase;
+
+public class TotalUploadStatsTests extends OpenSearchTestCase {
+    private static final int MAX_METRIC_COUNT = 10;
+    private static final int MAX_STATS_COUNT = 5;
+    private static final int MIN_METRIC_COUNT = 2;
+    private static final int MIN_STATS_COUNT = 2;
+
+    private static final long INIT = 0L;
+
+    private UploadStats randomUploadStats() {
+        int randomMetricCount = randomIntBetween(MIN_METRIC_COUNT, MAX_METRIC_COUNT);
+        UploadStats stats = new UploadStats();
+        IntStream.range(0, randomMetricCount).forEach(unUsed -> stats.addMetric(GeospatialTestHelper.generateRandomUploadMetric()));
+        return stats;
+    }
+
+    private List<UploadStats> randomUploadStats(int max) {
+        List<UploadStats> stats = new ArrayList<>();
+        IntStream.range(0, max).forEach(unUsed -> stats.add(randomUploadStats()));
+        return stats;
+    }
+
+    public void testInstanceCreation() {
+        int randomStatsCount = randomIntBetween(MIN_STATS_COUNT, MAX_STATS_COUNT);
+        TotalUploadStats totalUploadStats = new TotalUploadStats(randomUploadStats(randomStatsCount));
+        assertNotNull("Failed to create TotalUploadStats", totalUploadStats);
+        assertFalse("Failed to add stats to list", totalUploadStats.isUploadStatsEmpty());
+    }
+
+    public void testInstanceCreationFails() {
+        assertThrows(NullPointerException.class, () -> new TotalUploadStats(null));
+    }
+
+    public void testEmptyUploadStats() {
+        TotalUploadStats totalUploadStats = new TotalUploadStats(Collections.emptyList());
+        assertTrue("stats should be empty", totalUploadStats.isUploadStatsEmpty());
+    }
+
+    public void testToXContentWithEmptyUploadStats() throws IOException {
+        TotalUploadStats totalUploadStats = new TotalUploadStats(Collections.emptyList());
+        XContentBuilder contentBuilder = XContentFactory.contentBuilder(XContentType.JSON);
+        contentBuilder.startObject();
+        totalUploadStats.toXContent(contentBuilder, ToXContent.EMPTY_PARAMS);
+        contentBuilder.endObject();
+        String summary = Strings.toString(contentBuilder);
+        assertNotNull(summary);
+        String expectedEmptyContent = "{\"total\":{}}";
+        assertEquals(expectedEmptyContent, summary);
+    }
+
+    public void testToXContentWithRequestAPICount() throws IOException {
+        List<UploadStats> randomUploadStats = randomUploadStats(MAX_STATS_COUNT);
+        long expectedSum = INIT;
+        expectedSum += randomUploadStats.stream().mapToLong(UploadStats::getTotalAPICount).sum();
+        TotalUploadStats totalUploadStats = new TotalUploadStats(randomUploadStats);
+        XContentBuilder contentBuilder = XContentFactory.contentBuilder(XContentType.JSON);
+        contentBuilder.startObject();
+        totalUploadStats.toXContent(contentBuilder, ToXContent.EMPTY_PARAMS);
+        contentBuilder.endObject();
+        String summary = Strings.toString(contentBuilder);
+        assertNotNull(summary);
+        assertTrue(summary.contains(buildFieldNameValuePair(TotalUploadStats.FIELDS.REQUEST_COUNT.toString(), expectedSum)));
+    }
+
+    public void testToXContentWithUploadCount() throws IOException {
+        List<UploadStats> randomUploadStats = randomUploadStats(MAX_STATS_COUNT);
+        long expectedSum = INIT;
+        for (UploadStats stats : randomUploadStats) {
+            expectedSum += stats.getMetrics().stream().mapToLong(UploadMetric::getUploadCount).sum();
+        }
+        TotalUploadStats totalUploadStats = new TotalUploadStats(randomUploadStats);
+        XContentBuilder contentBuilder = XContentFactory.contentBuilder(XContentType.JSON);
+        contentBuilder.startObject();
+        totalUploadStats.toXContent(contentBuilder, ToXContent.EMPTY_PARAMS);
+        contentBuilder.endObject();
+        String summary = Strings.toString(contentBuilder);
+        assertNotNull(summary);
+        assertTrue(summary.contains(buildFieldNameValuePair(TotalUploadStats.FIELDS.UPLOAD.toString(), expectedSum)));
+    }
+
+    public void testToXContentWithSuccessCount() throws IOException {
+        List<UploadStats> randomUploadStats = randomUploadStats(MAX_STATS_COUNT);
+        long expectedSum = INIT;
+        for (UploadStats stats : randomUploadStats) {
+            expectedSum += stats.getMetrics().stream().mapToLong(UploadMetric::getSuccessCount).sum();
+        }
+        TotalUploadStats totalUploadStats = new TotalUploadStats(randomUploadStats);
+        XContentBuilder contentBuilder = XContentFactory.contentBuilder(XContentType.JSON);
+        contentBuilder.startObject();
+        totalUploadStats.toXContent(contentBuilder, ToXContent.EMPTY_PARAMS);
+        contentBuilder.endObject();
+        String summary = Strings.toString(contentBuilder);
+        assertNotNull(summary);
+        assertTrue(summary.contains(buildFieldNameValuePair(TotalUploadStats.FIELDS.SUCCESS.toString(), expectedSum)));
+    }
+
+    public void testToXContentWithFailedCount() throws IOException {
+        List<UploadStats> randomUploadStats = randomUploadStats(MAX_STATS_COUNT);
+        long expectedSum = INIT;
+        for (UploadStats stats : randomUploadStats) {
+            expectedSum += stats.getMetrics().stream().mapToLong(UploadMetric::getFailedCount).sum();
+        }
+        TotalUploadStats totalUploadStats = new TotalUploadStats(randomUploadStats);
+        XContentBuilder contentBuilder = XContentFactory.contentBuilder(XContentType.JSON);
+        contentBuilder.startObject();
+        totalUploadStats.toXContent(contentBuilder, ToXContent.EMPTY_PARAMS);
+        contentBuilder.endObject();
+        String summary = Strings.toString(contentBuilder);
+        assertNotNull(summary);
+        assertTrue(summary.contains(buildFieldNameValuePair(TotalUploadStats.FIELDS.FAILED.toString(), expectedSum)));
+    }
+
+    public void testToXContentWithDuration() throws IOException {
+        List<UploadStats> randomUploadStats = randomUploadStats(MAX_STATS_COUNT);
+        long expectedSum = INIT;
+        for (UploadStats stats : randomUploadStats) {
+            expectedSum += stats.getMetrics().stream().mapToLong(UploadMetric::getDuration).sum();
+        }
+        TotalUploadStats totalUploadStats = new TotalUploadStats(randomUploadStats);
+        XContentBuilder contentBuilder = XContentFactory.contentBuilder(XContentType.JSON);
+        contentBuilder.startObject();
+        totalUploadStats.toXContent(contentBuilder, ToXContent.EMPTY_PARAMS);
+        contentBuilder.endObject();
+        String summary = Strings.toString(contentBuilder);
+        assertNotNull(summary);
+        assertTrue(summary.contains(buildFieldNameValuePair(TotalUploadStats.FIELDS.DURATION.toString(), expectedSum)));
+    }
+}

--- a/src/test/java/org/opensearch/geospatial/stats/upload/UploadStatsBuilder.java
+++ b/src/test/java/org/opensearch/geospatial/stats/upload/UploadStatsBuilder.java
@@ -1,0 +1,32 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package org.opensearch.geospatial.stats.upload;
+
+import static org.opensearch.test.OpenSearchTestCase.randomIntBetween;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.stream.IntStream;
+
+import org.opensearch.geospatial.GeospatialTestHelper;
+
+public class UploadStatsBuilder {
+    private static final int MAX_METRIC_COUNT = 10;
+    private static final int MIN_METRIC_COUNT = 2;
+
+    public static UploadStats randomUploadStats() {
+        int randomMetricCount = randomIntBetween(MIN_METRIC_COUNT, MAX_METRIC_COUNT);
+        UploadStats stats = new UploadStats();
+        IntStream.range(0, randomMetricCount).forEach(unUsed -> stats.addMetric(GeospatialTestHelper.generateRandomUploadMetric()));
+        return stats;
+    }
+
+    public static List<UploadStats> randomUploadStats(int max) {
+        List<UploadStats> stats = new ArrayList<>();
+        IntStream.range(0, max).forEach(unUsed -> stats.add(randomUploadStats()));
+        return stats;
+    }
+}

--- a/src/test/java/org/opensearch/geospatial/stats/upload/UploadStatsServiceTests.java
+++ b/src/test/java/org/opensearch/geospatial/stats/upload/UploadStatsServiceTests.java
@@ -1,0 +1,112 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package org.opensearch.geospatial.stats.upload;
+
+import static org.opensearch.common.xcontent.XContentFactory.jsonBuilder;
+import static org.opensearch.geospatial.GeospatialTestHelper.buildFieldNameValuePair;
+
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+import org.opensearch.common.Strings;
+import org.opensearch.common.xcontent.ToXContent;
+import org.opensearch.common.xcontent.XContentBuilder;
+import org.opensearch.geospatial.GeospatialTestHelper;
+import org.opensearch.test.OpenSearchTestCase;
+
+public class UploadStatsServiceTests extends OpenSearchTestCase {
+
+    private String removeStartAndEndObject(String content) {
+        assertNotNull(content);
+        assertTrue("content length should be at least 2", content.length() > 1);
+        return content.substring(1, content.length() - 1);
+    }
+
+    public void testInstanceCreation() {
+        Map<String, UploadStats> randomMap = new HashMap<>();
+        randomMap.put(GeospatialTestHelper.randomLowerCaseString(), UploadStatsBuilder.randomUploadStats());
+        randomMap.put(GeospatialTestHelper.randomLowerCaseString(), UploadStatsBuilder.randomUploadStats());
+
+        UploadStatsService service = new UploadStatsService(randomMap);
+        assertNotNull(service);
+    }
+
+    public void testInstanceCreationFails() {
+        assertThrows(NullPointerException.class, () -> new UploadStatsService(null));
+    }
+
+    public void testXContentWithNodeID() {
+        Map<String, UploadStats> randomMap = new HashMap<>();
+        randomMap.put(GeospatialTestHelper.randomLowerCaseString(), UploadStatsBuilder.randomUploadStats());
+        randomMap.put(GeospatialTestHelper.randomLowerCaseString(), UploadStatsBuilder.randomUploadStats());
+        UploadStatsService service = new UploadStatsService(randomMap);
+        String xContent = Strings.toString(service);
+        assertNotNull(xContent);
+        for (String nodeID : randomMap.keySet()) {
+            assertTrue(nodeID + " is missing", xContent.contains(buildFieldNameValuePair(UploadStatsService.NODE_ID, nodeID)));
+        }
+    }
+
+    public void testXContentWithEmptyStats() throws IOException {
+        UploadStatsService service = new UploadStatsService(new HashMap<>());
+        final XContentBuilder contentBuilder = jsonBuilder().startObject();
+        service.toXContent(contentBuilder, ToXContent.EMPTY_PARAMS);
+        contentBuilder.endObject();
+        String emptyContent = "{\"uploads\":{\"total\":{},\"metrics\":[]}}";
+        assertEquals(emptyContent, Strings.toString(contentBuilder));
+    }
+
+    public void testXContentWithTotalUploadStats() throws IOException {
+        Map<String, UploadStats> randomMap = new HashMap<>();
+        final List<UploadStats> uploadStats = List.of(UploadStatsBuilder.randomUploadStats(), UploadStatsBuilder.randomUploadStats());
+
+        for (UploadStats stats : uploadStats) {
+            randomMap.put(GeospatialTestHelper.randomLowerCaseString(), stats);
+        }
+        UploadStatsService service = new UploadStatsService(randomMap);
+        final XContentBuilder serviceContentBuilder = jsonBuilder().startObject();
+        service.toXContent(serviceContentBuilder, ToXContent.EMPTY_PARAMS);
+        serviceContentBuilder.endObject();
+        String content = Strings.toString(serviceContentBuilder);
+        assertNotNull(content);
+
+        final XContentBuilder summary = jsonBuilder().startObject();
+        TotalUploadStats expectedSummary = new TotalUploadStats(uploadStats);
+        expectedSummary.toXContent(summary, ToXContent.EMPTY_PARAMS);
+        summary.endObject();
+        final String totalUploadStatsSummary = Strings.toString(summary);
+        assertNotNull(totalUploadStatsSummary);
+        assertTrue(content.contains(removeStartAndEndObject(totalUploadStatsSummary)));
+    }
+
+    public void testXContentWithMetrics() throws IOException {
+        Map<String, UploadStats> randomMap = new HashMap<>();
+        List<UploadMetric> randomMetrics = new ArrayList<>();
+        final List<UploadStats> uploadStats = List.of(UploadStatsBuilder.randomUploadStats(), UploadStatsBuilder.randomUploadStats());
+        for (UploadStats stats : uploadStats) {
+            randomMap.put(GeospatialTestHelper.randomLowerCaseString(), stats);
+            randomMetrics.addAll(stats.getMetrics());
+        }
+        UploadStatsService service = new UploadStatsService(randomMap);
+        final XContentBuilder serviceContentBuilder = jsonBuilder().startObject();
+        service.toXContent(serviceContentBuilder, ToXContent.EMPTY_PARAMS);
+        serviceContentBuilder.endObject();
+        String content = Strings.toString(serviceContentBuilder);
+        assertNotNull(content);
+
+        for (UploadMetric metric : randomMetrics) {
+            XContentBuilder metricsAsContent = jsonBuilder().startObject();
+            metric.toXContent(metricsAsContent, ToXContent.EMPTY_PARAMS);
+            metricsAsContent.endObject();
+            final String metricsAsString = Strings.toString(metricsAsContent);
+            assertNotNull(metricsAsString);
+            assertTrue(content.contains(removeStartAndEndObject(metricsAsString)));
+        }
+    }
+}


### PR DESCRIPTION
### Description
Add upload stats service to build XContent for StatsNodesResponse. It generates following json as response body

```
        {
          "uploads": {
            "total": {
                request_count : #of request,
                "upload"       : sum of documents to upload across API,
                "success"     : sum of successfully uploaded documents across API,
                "failed"      : sum of failed to upload documents across API,
                "duration"    : sum of duration in milliseconds to ingest document across API
            },
            "metrics" : [
                {
                    "id"       : <metric-id>,
                    "node_id"  : node-id
                    "upload"   : # of documents to upload,
                    "success"  : # of successfully uploaded documents,
                    "failed"   : # of failed to upload documents,
                    "duration" : duration in milliseconds to ingest document
                }, ......
            ]
          }
        }
```
 
### Issues Resolved

 
### Check List
- [x] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
