### PR TITLE
Enable XContent for upload stats

### DIFF
--- a/src/main/java/org/opensearch/geospatial/stats/upload/TotalUploadStats.java
+++ b/src/main/java/org/opensearch/geospatial/stats/upload/TotalUploadStats.java
@@ -28,7 +28,7 @@ public final class TotalUploadStats implements ToXContentObject {
 
         @Override
         public String toString() {
-            return this.name().toLowerCase(Locale.getDefault());
+            return name().toLowerCase(Locale.getDefault());
         }
     }
 

--- a/src/test/java/org/opensearch/geospatial/stats/upload/TotalUploadStatsTests.java
+++ b/src/test/java/org/opensearch/geospatial/stats/upload/TotalUploadStatsTests.java
@@ -1,12 +1,6 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
- * The OpenSearch Contributors require contributions made to
- * this file be licensed under the Apache-2.0 license or a
- * compatible open source license.
- *
- * Modifications Copyright OpenSearch Contributors. See
- * GitHub history for details.
  */
 
 package org.opensearch.geospatial.stats.upload;
@@ -26,9 +20,7 @@ import org.opensearch.common.xcontent.XContentType;
 import org.opensearch.test.OpenSearchTestCase;
 
 public class TotalUploadStatsTests extends OpenSearchTestCase {
-    private static final int MAX_METRIC_COUNT = 10;
     private static final int MAX_STATS_COUNT = 5;
-    private static final int MIN_METRIC_COUNT = 2;
     private static final int MIN_STATS_COUNT = 2;
 
     private static final long INIT = 0L;

--- a/src/test/java/org/opensearch/geospatial/stats/upload/UploadStatsBuilder.java
+++ b/src/test/java/org/opensearch/geospatial/stats/upload/UploadStatsBuilder.java
@@ -5,6 +5,7 @@
 
 package org.opensearch.geospatial.stats.upload;
 
+import static org.opensearch.test.OpenSearchTestCase.randomBoolean;
 import static org.opensearch.test.OpenSearchTestCase.randomIntBetween;
 
 import java.util.ArrayList;
@@ -20,7 +21,14 @@ public class UploadStatsBuilder {
     public static UploadStats randomUploadStats() {
         int randomMetricCount = randomIntBetween(MIN_METRIC_COUNT, MAX_METRIC_COUNT);
         UploadStats stats = new UploadStats();
-        IntStream.range(0, randomMetricCount).forEach(unUsed -> stats.addMetric(GeospatialTestHelper.generateRandomUploadMetric()));
+        IntStream.range(0, randomMetricCount).forEach(unUsed -> {
+            stats.addMetric(GeospatialTestHelper.generateRandomUploadMetric());
+            stats.incrementAPICount();
+        });
+        // simulate failed upload by randomly increasing the api count
+        if (randomBoolean()) {
+            stats.incrementAPICount();
+        }
         return stats;
     }
 

--- a/src/test/java/org/opensearch/geospatial/stats/upload/UploadStatsTests.java
+++ b/src/test/java/org/opensearch/geospatial/stats/upload/UploadStatsTests.java
@@ -6,14 +6,19 @@
 package org.opensearch.geospatial.stats.upload;
 
 import static org.opensearch.geospatial.GeospatialTestHelper.GEOJSON;
+import static org.opensearch.geospatial.GeospatialTestHelper.buildFieldNameValuePair;
 
 import java.io.IOException;
 import java.util.HashSet;
 import java.util.Set;
 import java.util.stream.IntStream;
 
+import org.opensearch.common.Strings;
 import org.opensearch.common.io.stream.BytesStreamOutput;
 import org.opensearch.common.io.stream.StreamInput;
+import org.opensearch.common.xcontent.ToXContent;
+import org.opensearch.common.xcontent.XContentBuilder;
+import org.opensearch.common.xcontent.XContentFactory;
 import org.opensearch.geospatial.GeospatialTestHelper;
 import org.opensearch.test.OpenSearchTestCase;
 
@@ -81,5 +86,20 @@ public class UploadStatsTests extends OpenSearchTestCase {
         assertNotNull("serialized stats cannot be null", serializedStats);
         assertEquals("api count is ", stats.getTotalAPICount(), serializedStats.getTotalAPICount());
         assertEquals("failed to serialize metrics", stats.getMetrics().size(), serializedStats.getMetrics().size());
+    }
+
+    public void testToXContent() throws IOException {
+        UploadStats stats = UploadStatsBuilder.randomUploadStats();
+        XContentBuilder statsContent = XContentFactory.jsonBuilder().startObject();
+        String statsAsString = Strings.toString(stats.toXContent(statsContent, ToXContent.EMPTY_PARAMS).endObject());
+        assertNotNull(statsAsString);
+        assertTrue(statsAsString.contains(buildFieldNameValuePair(UploadStats.FIELDS.REQUEST_COUNT.toString(), stats.getTotalAPICount())));
+        stats.getMetrics().forEach(uploadMetric -> {
+            assertTrue(statsAsString.contains(buildFieldNameValuePair(UploadMetric.FIELDS.TYPE, GEOJSON)));
+            assertTrue(statsAsString.contains(buildFieldNameValuePair(UploadMetric.FIELDS.UPLOAD, uploadMetric.getUploadCount())));
+            assertTrue(statsAsString.contains(buildFieldNameValuePair(UploadMetric.FIELDS.DURATION, uploadMetric.getDuration())));
+            assertTrue(statsAsString.contains(buildFieldNameValuePair(UploadMetric.FIELDS.FAILED, uploadMetric.getFailedCount())));
+            assertTrue(statsAsString.contains(buildFieldNameValuePair(UploadMetric.FIELDS.SUCCESS, uploadMetric.getSuccessCount())));
+        });
     }
 }


### PR DESCRIPTION
### Description
UploadStats will contain request count and metrics as response. This will be part of StatsNodeResponse.

Example format:
```
{
            request_count : #of request,
            "metrics" : [
                {
                    "id"       : <metric-id>,
                    "upload"   : # of documents to upload,
                    "success"  : # of successfully uploaded documents,
                    "failed"   : # of failed to upload documents,
                    "duration" : duration in milliseconds to ingest document
                }, ......
            ]
}
```
 
### Issues Resolved
 
### Check List
- [x] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
