### PR TITLE
Add shape field mapper

### DIFF
--- a/src/main/java/org/opensearch/geospatial/index/mapper/xyshape/XYShapeFieldMapper.java
+++ b/src/main/java/org/opensearch/geospatial/index/mapper/xyshape/XYShapeFieldMapper.java
@@ -1,0 +1,146 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package org.opensearch.geospatial.index.mapper.xyshape;
+
+import java.util.List;
+import java.util.Map;
+
+import org.apache.lucene.document.FieldType;
+import org.apache.lucene.index.IndexOptions;
+import org.apache.lucene.index.IndexableField;
+import org.opensearch.common.Explicit;
+import org.opensearch.common.geo.GeometryParser;
+import org.opensearch.geometry.Geometry;
+import org.opensearch.geometry.GeometryVisitor;
+import org.opensearch.index.mapper.AbstractShapeGeometryFieldMapper;
+import org.opensearch.index.mapper.GeoShapeParser;
+import org.opensearch.index.mapper.MappedFieldType;
+import org.opensearch.index.mapper.ParseContext;
+
+/**
+ *  FieldMapper for indexing {@link org.apache.lucene.document.XYShape}s.
+ */
+public class XYShapeFieldMapper extends AbstractShapeGeometryFieldMapper<Geometry, Geometry> {
+
+    public static final String CONTENT_TYPE = "xy_shape";
+    private static final FieldType FIELD_TYPE = new FieldType();
+    // Similar to geo_shape, this field is indexed by encoding it as triangular mesh
+    // and index each traingle as 7 dimension point in BKD Tree
+    static {
+        FIELD_TYPE.setDimensions(7, 4, Integer.BYTES);
+        FIELD_TYPE.setIndexOptions(IndexOptions.DOCS);
+        FIELD_TYPE.setOmitNorms(true);
+        FIELD_TYPE.freeze();
+    }
+
+    private XYShapeFieldMapper(
+        String simpleName,
+        FieldType fieldType,
+        MappedFieldType mappedFieldType,
+        Explicit ignoreMalformed,
+        Explicit coerce,
+        Explicit ignoreZValue,
+        Explicit orientation,
+        MultiFields multiFields,
+        CopyTo copyTo
+    ) {
+        super(simpleName, fieldType, mappedFieldType, ignoreMalformed, coerce, ignoreZValue, orientation, multiFields, copyTo);
+    }
+
+    @Override
+    public XYShapeFieldType fieldType() {
+        return (XYShapeFieldType) super.fieldType();
+    }
+
+    @Override
+    protected boolean docValuesByDefault() {
+        return false;
+    }
+
+    @Override
+    protected void mergeGeoOptions(AbstractShapeGeometryFieldMapper mergeWith, List conflicts) {
+        // Cartesian plane don't have to support this feature
+    }
+
+    @Override
+    protected String contentType() {
+        return CONTENT_TYPE;
+    }
+
+    @Override
+    protected void addStoredFields(ParseContext context, Geometry geometry) {
+        // No stored fields will be added
+    }
+
+    @Override
+    protected void addDocValuesFields(String name, Geometry geometry, List<IndexableField> fields, ParseContext context) {
+        // doc values are not supported
+    }
+
+    @Override
+    protected void addMultiFields(ParseContext context, Geometry geometry) {
+        // No other fields will be added
+    }
+
+    /**
+     * Builder class to create an instance of {@link XYShapeFieldMapper}
+     */
+    public static class XYShapeFieldMapperBuilder extends AbstractShapeGeometryFieldMapper.Builder<
+        XYShapeFieldMapperBuilder,
+        XYShapeFieldType> {
+
+        public XYShapeFieldMapperBuilder(String fieldName) {
+            super(fieldName, FIELD_TYPE);
+            this.hasDocValues = false;
+        }
+
+        @Override
+        public XYShapeFieldMapper build(BuilderContext context) {
+            return new XYShapeFieldMapper(
+                name,
+                fieldType,
+                buildShapeFieldType(context),
+                ignoreMalformed(context),
+                coerce(context),
+                ignoreZValue(),
+                orientation(),
+                multiFieldsBuilder.build(this, context),
+                copyTo
+            );
+        }
+
+        private XYShapeFieldType buildShapeFieldType(BuilderContext context) {
+            XYShapeFieldType fieldType = new XYShapeFieldType(buildFullName(context), indexed, this.fieldType.stored(), hasDocValues, meta);
+            GeometryParser geometryParser = new GeometryParser(
+                orientation().value().getAsBoolean(),
+                coerce().value(),
+                ignoreZValue().value()
+            );
+            fieldType.setGeometryParser(new GeoShapeParser(geometryParser));
+            GeometryVisitor<IndexableField[], RuntimeException> xyShapeIndexableVisitor = new XYShapeIndexableFieldsVisitor(
+                fieldType.name()
+            );
+            GeometryVisitor<Geometry, RuntimeException> xyShapeSupportVisitor = new XYShapeSupportVisitor();
+            fieldType.setGeometryIndexer(new XYShapeIndexer(xyShapeSupportVisitor, xyShapeIndexableVisitor));
+            fieldType.setOrientation(orientation().value());
+            return fieldType;
+        }
+    }
+
+    public static class XYShapeFieldType extends AbstractShapeGeometryFieldType<Geometry, Geometry> {
+
+        public XYShapeFieldType(String name, boolean indexed, boolean stored, boolean hasDocValues, Map<String, String> meta) {
+            super(name, indexed, stored, hasDocValues, false, meta);
+        }
+
+        @Override
+        public String typeName() {
+            return CONTENT_TYPE;
+        }
+
+    }
+
+}

--- a/src/main/java/org/opensearch/geospatial/index/mapper/xyshape/XYShapeFieldTypeParser.java
+++ b/src/main/java/org/opensearch/geospatial/index/mapper/xyshape/XYShapeFieldTypeParser.java
@@ -1,0 +1,20 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package org.opensearch.geospatial.index.mapper.xyshape;
+
+import java.util.Map;
+
+import org.opensearch.index.mapper.AbstractShapeGeometryFieldMapper;
+
+/**
+ * XYShapeFieldTypeParser to parse and validate mapping parameters
+ */
+public final class XYShapeFieldTypeParser extends AbstractShapeGeometryFieldMapper.TypeParser {
+    @Override
+    protected AbstractShapeGeometryFieldMapper.Builder newBuilder(String name, Map<String, Object> params) {
+        return new XYShapeFieldMapper.XYShapeFieldMapperBuilder(name);
+    }
+}

--- a/src/main/java/org/opensearch/geospatial/plugin/GeospatialPlugin.java
+++ b/src/main/java/org/opensearch/geospatial/plugin/GeospatialPlugin.java
@@ -27,15 +27,19 @@ import org.opensearch.env.Environment;
 import org.opensearch.env.NodeEnvironment;
 import org.opensearch.geospatial.action.upload.geojson.UploadGeoJSONAction;
 import org.opensearch.geospatial.action.upload.geojson.UploadGeoJSONTransportAction;
+import org.opensearch.geospatial.index.mapper.xyshape.XYShapeFieldMapper;
+import org.opensearch.geospatial.index.mapper.xyshape.XYShapeFieldTypeParser;
 import org.opensearch.geospatial.processor.FeatureProcessor;
 import org.opensearch.geospatial.rest.action.upload.geojson.RestUploadGeoJSONAction;
 import org.opensearch.geospatial.stats.upload.RestUploadStatsAction;
 import org.opensearch.geospatial.stats.upload.UploadStats;
 import org.opensearch.geospatial.stats.upload.UploadStatsAction;
 import org.opensearch.geospatial.stats.upload.UploadStatsTransportAction;
+import org.opensearch.index.mapper.Mapper;
 import org.opensearch.ingest.Processor;
 import org.opensearch.plugins.ActionPlugin;
 import org.opensearch.plugins.IngestPlugin;
+import org.opensearch.plugins.MapperPlugin;
 import org.opensearch.plugins.Plugin;
 import org.opensearch.repositories.RepositoriesService;
 import org.opensearch.rest.RestController;
@@ -48,7 +52,7 @@ import org.opensearch.watcher.ResourceWatcherService;
  * Entry point for Geospatial features. It provides additional Processors, Actions
  * to interact with Cluster.
  */
-public class GeospatialPlugin extends Plugin implements IngestPlugin, ActionPlugin {
+public class GeospatialPlugin extends Plugin implements IngestPlugin, ActionPlugin, MapperPlugin {
 
     @Override
     public Map<String, Processor.Factory> getProcessors(Processor.Parameters parameters) {
@@ -95,5 +99,10 @@ public class GeospatialPlugin extends Plugin implements IngestPlugin, ActionPlug
             new ActionHandler<>(UploadGeoJSONAction.INSTANCE, UploadGeoJSONTransportAction.class),
             new ActionHandler<>(UploadStatsAction.INSTANCE, UploadStatsTransportAction.class)
         );
+    }
+
+    @Override
+    public Map<String, Mapper.TypeParser> getMappers() {
+        return Map.of(XYShapeFieldMapper.CONTENT_TYPE, new XYShapeFieldTypeParser());
     }
 }

--- a/src/test/java/org/opensearch/geospatial/index/mapper/xyshape/XYShapeFieldMapperIT.java
+++ b/src/test/java/org/opensearch/geospatial/index/mapper/xyshape/XYShapeFieldMapperIT.java
@@ -1,0 +1,74 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package org.opensearch.geospatial.index.mapper.xyshape;
+
+import java.io.IOException;
+import java.util.Map;
+
+import org.opensearch.common.geo.GeoJson;
+import org.opensearch.common.settings.Settings;
+import org.opensearch.geometry.Geometry;
+import org.opensearch.geometry.Point;
+import org.opensearch.geospatial.GeospatialRestTestCase;
+import org.opensearch.geospatial.GeospatialTestHelper;
+import org.opensearch.geospatial.index.common.xyshape.ShapeObjectBuilder;
+
+public class XYShapeFieldMapperIT extends GeospatialRestTestCase {
+
+    private static final String FIELD_COORDINATES_KEY = "coordinates";
+
+    private String getDocumentWithGeoJSONValueForXYShape(String fieldName, Point point) throws IOException {
+        return indexContentAsString(build -> {
+            build.startObject(fieldName);
+            build.field(FIELD_TYPE_KEY, GeoJson.getGeoJsonName(point));
+            build.field(FIELD_COORDINATES_KEY, new double[] { point.getX(), point.getY() });
+            build.endObject();
+        });
+    }
+
+    private String getDocumentWithWKTValueForXYShape(String fieldName, Geometry geometry) throws IOException {
+        return indexContentAsString(build -> { build.field(fieldName, geometry.toString()); });
+    }
+
+    public void testMappingWithXYShapeField() throws IOException {
+        String indexName = GeospatialTestHelper.randomLowerCaseString();
+        String fieldName = GeospatialTestHelper.randomLowerCaseString();
+        createIndex(indexName, Settings.EMPTY, Map.of(fieldName, XYShapeFieldMapper.CONTENT_TYPE));
+        final Map<String, Object> fieldNameTypeMap = getIndexProperties(indexName);
+        assertTrue("field name is not found inside mapping", fieldName.contains(fieldName));
+        final Map<String, Object> fieldType = (Map<String, Object>) fieldNameTypeMap.get(fieldName);
+        assertEquals("invalid field type", XYShapeFieldMapper.CONTENT_TYPE, fieldType.get(FIELD_TYPE_KEY));
+        deleteIndex(indexName);
+    }
+
+    public void testIndexWithXYShapeFieldAsWKTFormat() throws IOException {
+        String indexName = GeospatialTestHelper.randomLowerCaseString();
+        String fieldName = GeospatialTestHelper.randomLowerCaseString();
+        createIndex(indexName, Settings.EMPTY, Map.of(fieldName, XYShapeFieldMapper.CONTENT_TYPE));
+        final Point point = ShapeObjectBuilder.randomPoint();
+        String docID = indexDocument(indexName, getDocumentWithWKTValueForXYShape(fieldName, point));
+        assertTrue("failed to index document", getIndexDocumentCount(indexName) > 0);
+        final Map<String, Object> document = getDocument(docID, indexName);
+        assertNotNull("failed to get indexed document", document);
+        assertEquals("failed to index xy_shape", point.toString(), document.get(fieldName));
+        deleteIndex(indexName);
+    }
+
+    public void testIndexWithXYShapeFieldAsGeoJSONFormat() throws IOException {
+        String indexName = GeospatialTestHelper.randomLowerCaseString();
+        String fieldName = GeospatialTestHelper.randomLowerCaseString();
+        createIndex(indexName, Settings.EMPTY, Map.of(fieldName, XYShapeFieldMapper.CONTENT_TYPE));
+        final Point point = ShapeObjectBuilder.randomPoint();
+        String docID = indexDocument(indexName, getDocumentWithGeoJSONValueForXYShape(fieldName, point));
+        assertTrue("failed to index document", getIndexDocumentCount(indexName) > 0);
+        final Map<String, Object> document = getDocument(docID, indexName);
+        assertNotNull("failed to get indexed document", document);
+        // remove z value since Shape will always ignore z value
+        final Map<String, Object> geoJSON = GeoJson.toMap(new Point(point.getX(), point.getY()));
+        assertEquals("failed to index xy_shape", geoJSON, document.get(fieldName));
+        deleteIndex(indexName);
+    }
+}

--- a/src/test/java/org/opensearch/geospatial/index/mapper/xyshape/XYShapeFieldMapperTests.java
+++ b/src/test/java/org/opensearch/geospatial/index/mapper/xyshape/XYShapeFieldMapperTests.java
@@ -1,0 +1,154 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package org.opensearch.geospatial.index.mapper.xyshape;
+
+import java.io.IOException;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.Set;
+
+import org.apache.lucene.document.ShapeField;
+import org.apache.lucene.index.IndexableField;
+import org.opensearch.common.geo.GeoShapeType;
+import org.opensearch.common.geo.builders.ShapeBuilder;
+import org.opensearch.common.xcontent.XContentBuilder;
+import org.opensearch.geospatial.GeospatialTestHelper;
+import org.opensearch.geospatial.plugin.GeospatialPlugin;
+import org.opensearch.index.mapper.AbstractShapeGeometryFieldMapper;
+import org.opensearch.index.mapper.DocumentMapper;
+import org.opensearch.index.mapper.FieldMapperTestCase2;
+import org.opensearch.index.mapper.Mapper;
+import org.opensearch.index.mapper.ParsedDocument;
+import org.opensearch.plugins.Plugin;
+
+public class XYShapeFieldMapperTests extends FieldMapperTestCase2<XYShapeFieldMapper.XYShapeFieldMapperBuilder> {
+
+    public static final String FIELD_TYPE_NAME = "type";
+    public static final String FIELD_NAME = "field";
+    public static final String COORDINATES_KEY = "coordinates";
+
+    @Override
+    protected Set<String> unsupportedProperties() {
+        return Set.of("analyzer", "similarity", "doc_values", "store");
+    }
+
+    @Override
+    protected void minimalMapping(XContentBuilder builder) throws IOException {
+        builder.field(FIELD_TYPE_NAME, XYShapeFieldMapper.CONTENT_TYPE);
+    }
+
+    @Override
+    protected void writeFieldValue(XContentBuilder xContentBuilder) throws IOException {
+        xContentBuilder.value("POINT (14.0 15.0)");
+    }
+
+    @Override
+    protected void registerParameters(ParameterChecker parameterChecker) throws IOException {
+        parameterChecker.registerUpdateCheck(
+            builder -> builder.field(
+                AbstractShapeGeometryFieldMapper.Names.ORIENTATION.getPreferredName(),
+                ShapeBuilder.Orientation.CLOCKWISE.name()
+            ),
+            mapper -> {
+                assertTrue("invalid mapper retrieved", mapper instanceof XYShapeFieldMapper);
+                XYShapeFieldMapper XYShapeFieldMapper = (XYShapeFieldMapper) mapper;
+                assertEquals("param [ orientation ] is not updated", ShapeBuilder.Orientation.CLOCKWISE, XYShapeFieldMapper.orientation());
+            }
+        );
+        parameterChecker.registerUpdateCheck(
+            b -> b.field(AbstractShapeGeometryFieldMapper.Names.IGNORE_MALFORMED.getPreferredName(), true),
+            mapper -> {
+                assertTrue("invalid mapper retrieved", mapper instanceof XYShapeFieldMapper);
+                XYShapeFieldMapper XYShapeFieldMapper = (XYShapeFieldMapper) mapper;
+                assertTrue("param [ ignore_malformed ] is not updated", XYShapeFieldMapper.ignoreMalformed().value());
+            }
+        );
+        parameterChecker.registerUpdateCheck(
+            b -> b.field(AbstractShapeGeometryFieldMapper.Names.IGNORE_Z_VALUE.getPreferredName(), false),
+            mapper -> {
+                assertTrue("invalid mapper retrieved", mapper instanceof XYShapeFieldMapper);
+                XYShapeFieldMapper XYShapeFieldMapper = (XYShapeFieldMapper) mapper;
+                assertFalse("param [ ignore_z_value ] is not updated", XYShapeFieldMapper.ignoreZValue().value());
+            }
+        );
+        parameterChecker.registerUpdateCheck(
+            b -> b.field(AbstractShapeGeometryFieldMapper.Names.COERCE.getPreferredName(), true),
+            mapper -> {
+                assertTrue("invalid mapper retrieved", mapper instanceof XYShapeFieldMapper);
+                XYShapeFieldMapper XYShapeFieldMapper = (XYShapeFieldMapper) mapper;
+                assertTrue("param [ coerce ] is not updated", XYShapeFieldMapper.coerce().value());
+            }
+        );
+    }
+
+    @Override
+    protected Collection<Plugin> getPlugins() {
+        return Collections.singletonList(new GeospatialPlugin());
+    }
+
+    @Override
+    protected boolean supportsMeta() {
+        return false;
+    }
+
+    @Override
+    protected boolean supportsOrIgnoresBoost() {
+        return false;
+    }
+
+    public void testIndexGeoJSONPointAsShapeValue() throws IOException {
+        float[] coordinates = new float[] { randomFloat(), randomFloat() };
+        DocumentMapper mapper = createDocumentMapper(fieldMapping(this::minimalMapping));
+        ParsedDocument doc = mapper.parse(
+            source(
+                builder -> builder.startObject(FIELD_NAME)
+                    .field(COORDINATES_KEY, coordinates)
+                    .field(FIELD_TYPE_NAME, GeoShapeType.POINT.shapeName())
+                    .endObject()
+            )
+        );
+        final IndexableField actualFieldValue = doc.rootDoc().getField(FIELD_NAME);
+        assertNotNull(actualFieldValue);
+        assertTrue("Invalid indexable field is found", actualFieldValue instanceof ShapeField.Triangle);
+    }
+
+    public void testWKTPointAsShapeValue() throws IOException {
+        DocumentMapper mapper = createDocumentMapper(fieldMapping(this::minimalMapping));
+        ParsedDocument doc = mapper.parse(source(builder -> builder.field(FIELD_NAME, "POINT (100.0 -180.10)")));
+        final IndexableField actualFieldValue = doc.rootDoc().getField(FIELD_NAME);
+        assertNotNull(actualFieldValue);
+        assertTrue("Invalid indexable field is found", actualFieldValue instanceof ShapeField.Triangle);
+    }
+
+    public void testDefaultConfiguration() throws IOException {
+        DocumentMapper mapper = createDocumentMapper(fieldMapping(this::minimalMapping));
+        Mapper fieldMapper = mapper.mappers().getMapper(FIELD_NAME);
+        assertTrue("invalid mapper retrieved", fieldMapper instanceof XYShapeFieldMapper);
+        XYShapeFieldMapper XYShapeFieldMapper = (XYShapeFieldMapper) fieldMapper;
+        assertEquals(
+            "param [ orientation ] default value should be CCW",
+            XYShapeFieldMapper.fieldType().orientation(),
+            AbstractShapeGeometryFieldMapper.Defaults.ORIENTATION.value()
+        );
+        assertEquals("param [ docs_value ] default value should be false", XYShapeFieldMapper.fieldType().hasDocValues(), false);
+        assertEquals("param [ ignore_malformed ] default value should be false", XYShapeFieldMapper.ignoreMalformed().value(), false);
+        assertEquals("param [ ignore_z_value ] default value should be true", XYShapeFieldMapper.ignoreZValue().value(), true);
+        assertEquals("param [ coerce ] default value should be false", XYShapeFieldMapper.coerce().value(), false);
+    }
+
+    public void testFieldTypeContentType() throws IOException {
+        DocumentMapper mapper = createDocumentMapper(fieldMapping(this::minimalMapping));
+        Mapper fieldMapper = mapper.mappers().getMapper(FIELD_NAME);
+        assertTrue(fieldMapper instanceof XYShapeFieldMapper);
+        final XYShapeFieldMapper.XYShapeFieldType fieldType = ((XYShapeFieldMapper) fieldMapper).fieldType();
+        assertEquals("invalid field type name", fieldType.typeName(), XYShapeFieldMapper.CONTENT_TYPE);
+    }
+
+    @Override
+    protected XYShapeFieldMapper.XYShapeFieldMapperBuilder newBuilder() {
+        return new XYShapeFieldMapper.XYShapeFieldMapperBuilder(GeospatialTestHelper.randomLowerCaseString());
+    }
+}


### PR DESCRIPTION
### Description
Added new content type "xy_shape" to index document with
field of type "xy_shape". This is similar to geo_shape. It accepts
value as either GeoJSON format or WKT format.
This has same parameters as geo_shape like ignore_malformed,
ignore_z_value, coerce, orientation.
 
### Issues Resolved

 
### Check List
- [x] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
