### PR TITLE
Add tasks to publish generated plugin zips

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -8,6 +8,7 @@ import org.opensearch.gradle.test.RestIntegTestTask
 apply plugin: 'java'
 apply plugin: 'idea'
 apply plugin: 'opensearch.opensearchplugin'
+apply plugin: 'opensearch.pluginzip'
 apply plugin: 'opensearch.yaml-rest-test'
 apply plugin: 'jacoco'
 
@@ -88,6 +89,29 @@ repositories {
 test {
     include '**/*Tests.class'
     systemProperty 'tests.security.manager', 'false'
+}
+
+publishing {
+    publications {
+        pluginZip(MavenPublication) { publication ->
+            pom {
+                name = pluginName
+                description = pluginDescription
+                licenses {
+                    license {
+                        name = "The Apache License, Version 2.0"
+                        url = "http://www.apache.org/licenses/LICENSE-2.0.txt"
+                    }
+                }
+                developers {
+                    developer {
+                        name = "OpenSearch"
+                        url = "https://github.com/opensearch-project/geospatial"
+                    }
+                }
+            }
+        }
+    }
 }
 
 


### PR DESCRIPTION
Signed-off-by: Vijayan Balasubramanian <balasvij@amazon.com>

### Description
Along with plugin jars, plugin zips should also be published to
maven repo with right maven coordinates,
so user can download these plugins using dependancy model.
 
### Issues Resolved
#56 
 
### Check List
- [x] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
