### PR TITLE
Add dependency to spatial and locationtech

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -123,6 +123,8 @@ dependencies {
     testImplementation "org.hamcrest:hamcrest:${versions.hamcrest}"
     testImplementation 'org.json:json:20211205'
     implementation "org.apache.commons:commons-lang3:3.12.0"
+    implementation "org.locationtech.spatial4j:spatial4j:${versions.spatial4j}"
+    implementation "org.locationtech.jts:jts-core:${versions.jts}"
 }
 
 licenseHeaders.enabled = true


### PR DESCRIPTION
Signed-off-by: Vijayan Balasubramanian <balasvij@amazon.com>

### Description
These third party dependency is required for spatial plugin to work. Having direct dependency will help
plugin to download instead of transitive dependency from OpenSearch since it is optional dependency.
 
### Issues Resolved
 
### Check List
- [x] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
