### PR TITLE
Add shape processor

### DIFF
--- a/src/main/java/org/opensearch/geospatial/index/common/xyshape/XYShapeConverter.java
+++ b/src/main/java/org/opensearch/geospatial/index/common/xyshape/XYShapeConverter.java
@@ -13,9 +13,14 @@ import java.util.stream.Collectors;
 import java.util.stream.DoubleStream;
 import java.util.stream.IntStream;
 
+import org.apache.lucene.geo.XYCircle;
 import org.apache.lucene.geo.XYLine;
+import org.apache.lucene.geo.XYPoint;
 import org.apache.lucene.geo.XYPolygon;
+import org.apache.lucene.geo.XYRectangle;
+import org.opensearch.geometry.Circle;
 import org.opensearch.geometry.Line;
+import org.opensearch.geometry.Point;
 import org.opensearch.geometry.Polygon;
 import org.opensearch.geometry.Rectangle;
 import org.opensearch.geometry.ShapeType;
@@ -25,6 +30,11 @@ import org.opensearch.geometry.ShapeType;
  */
 public class XYShapeConverter {
 
+    /**
+     * Convert from {@link Line} to {@link XYLine}
+     * @param line of type {@link Line}
+     * @return {@link XYLine} instance
+     */
     public static XYLine toXYLine(Line line) {
         Objects.requireNonNull(line, String.format(Locale.getDefault(), "%s cannot be null", ShapeType.LINESTRING));
         float[] x = toFloatArray(line.getX());
@@ -32,6 +42,11 @@ public class XYShapeConverter {
         return new XYLine(x, y);
     }
 
+    /**
+     * Convert from {@link Rectangle} to {@link XYPolygon}
+     * @param rectangle of type {@link Rectangle}
+     * @return {@link XYPolygon} instance
+     */
     public static XYPolygon toXYPolygon(Rectangle rectangle) {
         Objects.requireNonNull(rectangle, "Rectangle cannot be null");
         // build polygon by assigning points in Counter Clock Wise direction (default for polygon) and end at where
@@ -52,12 +67,54 @@ public class XYShapeConverter {
         return new XYPolygon(toFloatArray(x), toFloatArray(y));
     }
 
+    /**
+     * Convert from {@link Polygon} to {@link XYPolygon}
+     * @param polygon of type {@link Polygon}
+     * @return {@link XYPolygon} instance
+     */
     public static XYPolygon toXYPolygon(Polygon polygon) {
         Objects.requireNonNull(polygon, String.format(Locale.getDefault(), "%s cannot be null", ShapeType.POLYGON));
         XYPolygon[] holes = extractXYPolygonsFromHoles(polygon);
         Line line = polygon.getPolygon();
         XYLine polygonLine = toXYLine(line);
         return new XYPolygon(polygonLine.getX(), polygonLine.getY(), holes);
+    }
+
+    /**
+     * Convert from {@link Circle} to {@link XYCircle}
+     * @param circle of type {@link Circle}
+     * @return {@link XYCircle} instance
+     */
+    public static XYCircle toXYCircle(Circle circle) {
+        return new XYCircle(
+            Double.valueOf(circle.getX()).floatValue(),
+            Double.valueOf(circle.getY()).floatValue(),
+            Double.valueOf(circle.getRadiusMeters()).floatValue()
+        );
+    }
+
+    /**
+     * Convert from {@link Point} to {@link XYPoint}
+     * @param point of type {@link Point}
+     * @return {@link XYPoint} instance
+     */
+    public static XYPoint toXYPoint(Point point) {
+        float x = Double.valueOf(point.getX()).floatValue();
+        float y = Double.valueOf(point.getY()).floatValue();
+        return new XYPoint(x, y);
+    }
+
+    /**
+     * Convert from {@link Rectangle} to {@link XYRectangle}
+     * @param rectangle of type {@link Rectangle}
+     * @return {@link XYRectangle} instance
+     */
+    public static XYRectangle toXYRectangle(Rectangle rectangle) {
+        float minX = Double.valueOf(rectangle.getMinX()).floatValue();
+        float maxX = Double.valueOf(rectangle.getMaxX()).floatValue();
+        float minY = Double.valueOf(rectangle.getMinY()).floatValue();
+        float maxY = Double.valueOf(rectangle.getMaxY()).floatValue();
+        return new XYRectangle(minX, maxX, minY, maxY);
     }
 
     // Each hole inside a polygon is just a polygon inside the polygon itself. This method will

--- a/src/main/java/org/opensearch/geospatial/index/mapper/xyshape/XYShapeIndexableFieldsVisitor.java
+++ b/src/main/java/org/opensearch/geospatial/index/mapper/xyshape/XYShapeIndexableFieldsVisitor.java
@@ -7,6 +7,7 @@ package org.opensearch.geospatial.index.mapper.xyshape;
 
 import static org.opensearch.geometry.ShapeType.CIRCLE;
 import static org.opensearch.geometry.ShapeType.LINEARRING;
+import static org.opensearch.geospatial.index.common.xyshape.XYShapeConverter.toXYPoint;
 
 import java.util.ArrayList;
 import java.util.Arrays;
@@ -16,6 +17,7 @@ import java.util.Objects;
 
 import org.apache.lucene.document.XYShape;
 import org.apache.lucene.geo.XYLine;
+import org.apache.lucene.geo.XYPoint;
 import org.apache.lucene.geo.XYPolygon;
 import org.apache.lucene.index.IndexableField;
 import org.opensearch.geometry.Circle;
@@ -89,9 +91,8 @@ public final class XYShapeIndexableFieldsVisitor implements GeometryVisitor<Inde
     @Override
     public IndexableField[] visit(Point point) {
         Objects.requireNonNull(point, String.format(Locale.getDefault(), "%s cannot be null", ShapeType.POINT));
-        float x = Double.valueOf(point.getX()).floatValue();
-        float y = Double.valueOf(point.getY()).floatValue();
-        return XYShape.createIndexableFields(fieldName, x, y);
+        XYPoint xyPoint = toXYPoint(point);
+        return XYShape.createIndexableFields(fieldName, xyPoint.getX(), xyPoint.getY());
     }
 
     @Override

--- a/src/main/java/org/opensearch/geospatial/index/query/xyshape/XYShapeQueryProcessor.java
+++ b/src/main/java/org/opensearch/geospatial/index/query/xyshape/XYShapeQueryProcessor.java
@@ -1,0 +1,89 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package org.opensearch.geospatial.index.query.xyshape;
+
+import java.util.List;
+import java.util.Locale;
+import java.util.Objects;
+
+import org.apache.lucene.document.ShapeField;
+import org.apache.lucene.document.XYShape;
+import org.apache.lucene.geo.XYGeometry;
+import org.apache.lucene.search.MatchNoDocsQuery;
+import org.apache.lucene.search.Query;
+import org.opensearch.common.geo.ShapeRelation;
+import org.opensearch.geometry.Geometry;
+import org.opensearch.geometry.GeometryVisitor;
+import org.opensearch.geospatial.index.mapper.xyshape.XYShapeFieldMapper;
+import org.opensearch.index.mapper.MappedFieldType;
+import org.opensearch.index.query.QueryShardContext;
+import org.opensearch.index.query.QueryShardException;
+
+/**
+ * Query Processor to convert given Geometry into Lucene query
+ */
+public class XYShapeQueryProcessor {
+
+    /**
+     * Creates a {@link Query} that matches all indexed shapes to the provided {@link Geometry}  based on {@link ShapeRelation}
+     * @param geometry OpenSearch {@link Geometry} as an input
+     * @param fieldName Lucene field of type {@link XYShape}
+     * @param relation Relation to be used to get all shapes from given Geometry
+     * @param context QueryShardContext instance
+     * @return {@link Query} instance from XYShape.newGeometryQuery
+     */
+    public Query shapeQuery(
+        Geometry geometry,
+        String fieldName,
+        ShapeRelation relation,
+        GeometryVisitor<List<XYGeometry>, RuntimeException> visitor,
+        QueryShardContext context
+    ) {
+        // if no input is parsed from input, return no documents should be matched from index,
+        // this is similar to geo_shape field type
+        if (geometry == null || geometry.isEmpty()) {
+            return new MatchNoDocsQuery();
+        }
+
+        Objects.requireNonNull(fieldName, "Field name cannot be null");
+        Objects.requireNonNull(context, "QueryShardContext cannot be null");
+        validateIsXYShapeFieldType(fieldName, context);
+
+        Objects.requireNonNull(relation, "ShapeRelation cannot be null");
+        return getQueryFromGeometry(geometry, fieldName, relation.getLuceneRelation(), visitor);
+    }
+
+    private Query getQueryFromGeometry(
+        Geometry geometry,
+        String fieldName,
+        ShapeField.QueryRelation queryRelation,
+        GeometryVisitor<List<XYGeometry>, RuntimeException> visitor
+    ) {
+        final List<XYGeometry> collections = geometry.visit(visitor);
+        // if no valid geometries are found from input shape, return No documents matched query as fallback
+        if (collections == null || collections.isEmpty()) {
+            return new MatchNoDocsQuery();
+        }
+        return XYShape.newGeometryQuery(fieldName, queryRelation, collections.toArray(new XYGeometry[0]));
+    }
+
+    private void validateIsXYShapeFieldType(String fieldName, QueryShardContext context) {
+        MappedFieldType fieldType = context.fieldMapper(fieldName);
+        if (fieldType instanceof XYShapeFieldMapper.XYShapeFieldType) {
+            return;
+        }
+        throw new QueryShardException(
+            context,
+            String.format(
+                Locale.getDefault(),
+                "Expected %s field type for Field [ %s ] but found %s",
+                XYShapeFieldMapper.CONTENT_TYPE,
+                fieldName,
+                fieldType.typeName()
+            )
+        );
+    }
+}

--- a/src/main/java/org/opensearch/geospatial/index/query/xyshape/XYShapeQueryVisitor.java
+++ b/src/main/java/org/opensearch/geospatial/index/query/xyshape/XYShapeQueryVisitor.java
@@ -14,6 +14,7 @@ import static org.opensearch.geospatial.index.common.xyshape.XYShapeConverter.to
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
+import java.util.Locale;
 import java.util.Objects;
 
 import org.apache.lucene.geo.XYGeometry;
@@ -29,12 +30,11 @@ import org.opensearch.geometry.MultiPolygon;
 import org.opensearch.geometry.Point;
 import org.opensearch.geometry.Polygon;
 import org.opensearch.geometry.Rectangle;
-import org.opensearch.geometry.ShapeType;
 import org.opensearch.index.query.QueryShardContext;
 import org.opensearch.index.query.QueryShardException;
 
 /**
- * Geomtery Visitor to create a query to find all cartesian XYShapes
+ * Geometry Visitor to create a query to find all cartesian XYShapes
  * that comply ShapeRelation with all other XYShapes objects
  */
 public class XYShapeQueryVisitor implements GeometryVisitor<List<XYGeometry>, RuntimeException> {
@@ -49,7 +49,7 @@ public class XYShapeQueryVisitor implements GeometryVisitor<List<XYGeometry>, Ru
 
     @Override
     public List<XYGeometry> visit(Circle circle) throws RuntimeException {
-        Objects.requireNonNull(circle, ShapeType.CIRCLE + " cannot be null");
+        Objects.requireNonNull(circle, "Circle cannot be null");
         // XYShape don't support indexing Circle, but, can perform query to identify list of shapes
         // that interact with a provided circle
         return List.of(toXYCircle(circle));
@@ -57,7 +57,7 @@ public class XYShapeQueryVisitor implements GeometryVisitor<List<XYGeometry>, Ru
 
     @Override
     public List<XYGeometry> visit(GeometryCollection<?> geometryCollection) throws RuntimeException {
-        Objects.requireNonNull(geometryCollection, " Geometry collection cannot be null");
+        Objects.requireNonNull(geometryCollection, "Geometry collection cannot be null");
         return visitCollection(geometryCollection);
     }
 
@@ -69,12 +69,15 @@ public class XYShapeQueryVisitor implements GeometryVisitor<List<XYGeometry>, Ru
 
     @Override
     public List<XYGeometry> visit(LinearRing linearRing) throws RuntimeException {
-        throw new QueryShardException(this.context, "Field [" + this.name + "] found an unsupported shape LinearRing");
+        throw new QueryShardException(
+            this.context,
+            String.format(Locale.getDefault(), "Field [%s] found an unsupported shape LinearRing", this.name)
+        );
     }
 
     @Override
     public List<XYGeometry> visit(MultiLine multiLine) throws RuntimeException {
-        Objects.requireNonNull(multiLine, "Multi line cannot be null");
+        Objects.requireNonNull(multiLine, "Multi Line cannot be null");
         return visitCollection(multiLine);
     }
 

--- a/src/main/java/org/opensearch/geospatial/index/query/xyshape/XYShapeQueryVisitor.java
+++ b/src/main/java/org/opensearch/geospatial/index/query/xyshape/XYShapeQueryVisitor.java
@@ -1,0 +1,121 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package org.opensearch.geospatial.index.query.xyshape;
+
+import static org.opensearch.geospatial.index.common.xyshape.XYShapeConverter.toXYCircle;
+import static org.opensearch.geospatial.index.common.xyshape.XYShapeConverter.toXYLine;
+import static org.opensearch.geospatial.index.common.xyshape.XYShapeConverter.toXYPoint;
+import static org.opensearch.geospatial.index.common.xyshape.XYShapeConverter.toXYPolygon;
+import static org.opensearch.geospatial.index.common.xyshape.XYShapeConverter.toXYRectangle;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+import java.util.Objects;
+
+import org.apache.lucene.geo.XYGeometry;
+import org.opensearch.geometry.Circle;
+import org.opensearch.geometry.Geometry;
+import org.opensearch.geometry.GeometryCollection;
+import org.opensearch.geometry.GeometryVisitor;
+import org.opensearch.geometry.Line;
+import org.opensearch.geometry.LinearRing;
+import org.opensearch.geometry.MultiLine;
+import org.opensearch.geometry.MultiPoint;
+import org.opensearch.geometry.MultiPolygon;
+import org.opensearch.geometry.Point;
+import org.opensearch.geometry.Polygon;
+import org.opensearch.geometry.Rectangle;
+import org.opensearch.geometry.ShapeType;
+import org.opensearch.index.query.QueryShardContext;
+import org.opensearch.index.query.QueryShardException;
+
+/**
+ * Geomtery Visitor to create a query to find all cartesian XYShapes
+ * that comply ShapeRelation with all other XYShapes objects
+ */
+public class XYShapeQueryVisitor implements GeometryVisitor<List<XYGeometry>, RuntimeException> {
+
+    private final String name;
+    private final QueryShardContext context;
+
+    public XYShapeQueryVisitor(String name, QueryShardContext context) {
+        this.name = name;
+        this.context = context;
+    }
+
+    @Override
+    public List<XYGeometry> visit(Circle circle) throws RuntimeException {
+        Objects.requireNonNull(circle, ShapeType.CIRCLE + " cannot be null");
+        // XYShape don't support indexing Circle, but, can perform query to identify list of shapes
+        // that interact with a provided circle
+        return List.of(toXYCircle(circle));
+    }
+
+    @Override
+    public List<XYGeometry> visit(GeometryCollection<?> geometryCollection) throws RuntimeException {
+        Objects.requireNonNull(geometryCollection, " Geometry collection cannot be null");
+        return visitCollection(geometryCollection);
+    }
+
+    @Override
+    public List<XYGeometry> visit(Line line) throws RuntimeException {
+        Objects.requireNonNull(line, "Line cannot be null");
+        return List.of(toXYLine(line));
+    }
+
+    @Override
+    public List<XYGeometry> visit(LinearRing linearRing) throws RuntimeException {
+        throw new QueryShardException(this.context, "Field [" + this.name + "] found an unsupported shape LinearRing");
+    }
+
+    @Override
+    public List<XYGeometry> visit(MultiLine multiLine) throws RuntimeException {
+        Objects.requireNonNull(multiLine, "Multi line cannot be null");
+        return visitCollection(multiLine);
+    }
+
+    @Override
+    public List<XYGeometry> visit(MultiPoint multiPoint) throws RuntimeException {
+        Objects.requireNonNull(multiPoint, "Multi Point cannot be null");
+        return visitCollection(multiPoint);
+    }
+
+    @Override
+    public List<XYGeometry> visit(MultiPolygon multiPolygon) throws RuntimeException {
+        Objects.requireNonNull(multiPolygon, "Multi Polygon cannot be null");
+        return visitCollection(multiPolygon);
+    }
+
+    @Override
+    public List<XYGeometry> visit(Point point) throws RuntimeException {
+        Objects.requireNonNull(point, "Point cannot be null");
+        return List.of(toXYPoint(point));
+    }
+
+    @Override
+    public List<XYGeometry> visit(Polygon polygon) throws RuntimeException {
+        Objects.requireNonNull(polygon, "Polygon cannot be null");
+        return List.of(toXYPolygon(polygon));
+    }
+
+    @Override
+    public List<XYGeometry> visit(Rectangle rectangle) throws RuntimeException {
+        Objects.requireNonNull(rectangle, "Rectangle cannot be null");
+        return List.of(toXYRectangle(rectangle));
+    }
+
+    private List<XYGeometry> visitCollection(GeometryCollection<?> collection) {
+        if (collection.isEmpty()) {
+            return List.of();
+        }
+        List<XYGeometry> xyGeometryCollection = new ArrayList<>();
+        for (Geometry geometry : collection) {
+            xyGeometryCollection.addAll(geometry.visit(this));
+        }
+        return Collections.unmodifiableList(xyGeometryCollection);
+    }
+}

--- a/src/test/java/org/opensearch/geospatial/index/common/xyshape/ShapeObjectBuilder.java
+++ b/src/test/java/org/opensearch/geospatial/index/common/xyshape/ShapeObjectBuilder.java
@@ -16,6 +16,7 @@ import java.util.stream.Collectors;
 import java.util.stream.IntStream;
 
 import org.opensearch.common.Randomness;
+import org.opensearch.common.geo.ShapeRelation;
 import org.opensearch.geo.GeometryTestUtils;
 import org.opensearch.geometry.Circle;
 import org.opensearch.geometry.Geometry;
@@ -93,6 +94,13 @@ public class ShapeObjectBuilder {
         return (MultiPolygon) RandomPicks.randomFrom(
             Randomness.get(),
             List.of(getMultiPolygon(), GeometryTestUtils.randomMultiPolygon(randomBoolean()))
+        );
+    }
+
+    public static ShapeRelation randomShapeRelation() {
+        return RandomPicks.randomFrom(
+            Randomness.get(),
+            List.of(ShapeRelation.CONTAINS, ShapeRelation.WITHIN, ShapeRelation.DISJOINT, ShapeRelation.INTERSECTS)
         );
     }
 

--- a/src/test/java/org/opensearch/geospatial/index/common/xyshape/XYShapeConverterTests.java
+++ b/src/test/java/org/opensearch/geospatial/index/common/xyshape/XYShapeConverterTests.java
@@ -7,6 +7,7 @@ package org.opensearch.geospatial.index.common.xyshape;
 
 import static org.opensearch.geospatial.GeospatialTestHelper.toDoubleArray;
 import static org.opensearch.geospatial.index.common.xyshape.ShapeObjectBuilder.randomLine;
+import static org.opensearch.geospatial.index.common.xyshape.ShapeObjectBuilder.randomPoint;
 import static org.opensearch.geospatial.index.common.xyshape.ShapeObjectBuilder.randomPolygon;
 import static org.opensearch.geospatial.index.common.xyshape.ShapeObjectBuilder.randomRectangle;
 
@@ -16,8 +17,11 @@ import java.util.Arrays;
 
 import org.apache.commons.lang3.ArrayUtils;
 import org.apache.lucene.geo.XYLine;
+import org.apache.lucene.geo.XYPoint;
 import org.apache.lucene.geo.XYPolygon;
+import org.apache.lucene.geo.XYRectangle;
 import org.opensearch.geometry.Line;
+import org.opensearch.geometry.Point;
 import org.opensearch.geometry.Polygon;
 import org.opensearch.geometry.Rectangle;
 import org.opensearch.test.OpenSearchTestCase;
@@ -68,5 +72,28 @@ public class XYShapeConverterTests extends OpenSearchTestCase {
         assertArrayEquals(polygon.getPolygon().getX(), toDoubleArray(xyPolygon.getPolyX()), DELTA_ERROR);
         assertArrayEquals(polygon.getPolygon().getY(), toDoubleArray(xyPolygon.getPolyY()), DELTA_ERROR);
         assertEquals("number of holes are  differnt", polygon.getNumberOfHoles(), xyPolygon.numHoles());
+    }
+
+    public void testRectangleToXYRectangle() {
+        Rectangle rectangle = randomRectangle();
+        final XYRectangle xyRectangle = XYShapeConverter.toXYRectangle(rectangle);
+        assertNotNull("failed to convert to XYRectangle", xyRectangle);
+        assertArrayEquals(
+            "Vertices didn't match between Rectangle and XYRectangle",
+            new double[] { rectangle.getMaxX(), rectangle.getMaxY(), rectangle.getMinX(), rectangle.getMinY() },
+            toDoubleArray(new float[] { xyRectangle.maxX, xyRectangle.maxY, xyRectangle.minX, xyRectangle.minY }),
+            DELTA_ERROR
+        );
+    }
+
+    public void testXYPoint() {
+        Point point = randomPoint();
+        final XYPoint xyPoint = XYShapeConverter.toXYPoint(point);
+        assertArrayEquals(
+            "Coordinates didn't match",
+            new double[] { point.getX(), point.getY() },
+            toDoubleArray(new float[] { xyPoint.getX(), xyPoint.getY() }),
+            DELTA_ERROR
+        );
     }
 }

--- a/src/test/java/org/opensearch/geospatial/index/query/xyshape/XYShapeQueryProcessorTests.java
+++ b/src/test/java/org/opensearch/geospatial/index/query/xyshape/XYShapeQueryProcessorTests.java
@@ -1,0 +1,262 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package org.opensearch.geospatial.index.query.xyshape;
+
+import static java.util.Collections.emptyMap;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+import static org.opensearch.geospatial.index.common.xyshape.ShapeObjectBuilder.randomCircle;
+import static org.opensearch.geospatial.index.common.xyshape.ShapeObjectBuilder.randomGeometryCollection;
+import static org.opensearch.geospatial.index.common.xyshape.ShapeObjectBuilder.randomLine;
+import static org.opensearch.geospatial.index.common.xyshape.ShapeObjectBuilder.randomLinearRing;
+import static org.opensearch.geospatial.index.common.xyshape.ShapeObjectBuilder.randomMultiLine;
+import static org.opensearch.geospatial.index.common.xyshape.ShapeObjectBuilder.randomMultiPoint;
+import static org.opensearch.geospatial.index.common.xyshape.ShapeObjectBuilder.randomMultiPolygon;
+import static org.opensearch.geospatial.index.common.xyshape.ShapeObjectBuilder.randomPoint;
+import static org.opensearch.geospatial.index.common.xyshape.ShapeObjectBuilder.randomPolygon;
+import static org.opensearch.geospatial.index.common.xyshape.ShapeObjectBuilder.randomRectangle;
+import static org.opensearch.geospatial.index.common.xyshape.ShapeObjectBuilder.randomShapeRelation;
+
+import java.io.IOException;
+import java.text.ParseException;
+import java.util.List;
+
+import org.apache.lucene.geo.XYGeometry;
+import org.apache.lucene.search.MatchNoDocsQuery;
+import org.apache.lucene.search.Query;
+import org.opensearch.common.geo.ShapeRelation;
+import org.opensearch.geometry.Circle;
+import org.opensearch.geometry.Geometry;
+import org.opensearch.geometry.GeometryCollection;
+import org.opensearch.geometry.GeometryVisitor;
+import org.opensearch.geometry.Line;
+import org.opensearch.geometry.LinearRing;
+import org.opensearch.geometry.MultiLine;
+import org.opensearch.geometry.MultiPoint;
+import org.opensearch.geometry.MultiPolygon;
+import org.opensearch.geometry.Point;
+import org.opensearch.geometry.Polygon;
+import org.opensearch.geometry.Rectangle;
+import org.opensearch.geospatial.GeospatialTestHelper;
+import org.opensearch.geospatial.index.mapper.xyshape.XYShapeFieldMapper;
+import org.opensearch.index.mapper.GeoPointFieldMapper;
+import org.opensearch.index.query.QueryShardContext;
+import org.opensearch.index.query.QueryShardException;
+import org.opensearch.test.OpenSearchTestCase;
+
+public class XYShapeQueryProcessorTests extends OpenSearchTestCase {
+
+    public static final boolean VALID_FIELD_TYPE = true;
+    public static final boolean INVALID_FIELD_TYPE = false;
+    private final static Integer MAX_NUMBER_OF_VERTICES = 100;
+    private final static Integer MIN_NUMBER_OF_VERTICES = 2;
+    private final static Integer MIN_NUMBER_OF_GEOMETRY_OBJECTS = 10;
+    private GeometryVisitor<List<XYGeometry>, RuntimeException> mockQueryVisitor;
+    private GeometryVisitor<Geometry, RuntimeException> mockSupportVisitor;
+    private XYShapeQueryProcessor queryProcessor;
+    private QueryShardContext mockQueryShardContext;
+    private String fieldName;
+    private ShapeRelation relation;
+
+    @Override
+    public void setUp() throws Exception {
+        super.setUp();
+        mockQueryShardContext = mock(QueryShardContext.class);
+        mockQueryVisitor = mock(GeometryVisitor.class);
+        queryProcessor = new XYShapeQueryProcessor();
+        fieldName = GeospatialTestHelper.randomLowerCaseString();
+        relation = randomShapeRelation();
+    }
+
+    public void testQueryingNullGeometry() {
+        mockFieldType(VALID_FIELD_TYPE);
+        final Query query = queryProcessor.shapeQuery(null, fieldName, relation, mockQueryVisitor, mockQueryShardContext);
+        assertEquals("No match found query should be returned", new MatchNoDocsQuery(), query);
+    }
+
+    public void testQueryingNullFieldName() {
+        NullPointerException exception = assertThrows(
+            NullPointerException.class,
+            () -> queryProcessor.shapeQuery(randomPolygon(), null, relation, mockQueryVisitor, mockQueryShardContext)
+        );
+        assertEquals("Unexpected error message", "Field name cannot be null", exception.getMessage());
+    }
+
+    public void testQueryingNullQueryContext() {
+        NullPointerException exception = assertThrows(
+            NullPointerException.class,
+            () -> queryProcessor.shapeQuery(randomPolygon(), fieldName, relation, mockQueryVisitor, null)
+        );
+        assertEquals("Unexpected error message", "QueryShardContext cannot be null", exception.getMessage());
+    }
+
+    public void testQueryingNullShapeRelation() {
+        mockFieldType(VALID_FIELD_TYPE);
+        NullPointerException exception = assertThrows(
+            NullPointerException.class,
+            () -> queryProcessor.shapeQuery(randomPolygon(), fieldName, null, mockQueryVisitor, mockQueryShardContext)
+        );
+        assertEquals("Unexpected error message", "ShapeRelation cannot be null", exception.getMessage());
+    }
+
+    public void testQueryingEmptyGeometry() {
+        mockFieldType(VALID_FIELD_TYPE);
+        final Query query = queryProcessor.shapeQuery(
+            new GeometryCollection<>(),
+            fieldName,
+            relation,
+            mockQueryVisitor,
+            mockQueryShardContext
+        );
+        assertEquals("No match found query should be returned", new MatchNoDocsQuery(), query);
+    }
+
+    public void testQueryingInvalidFieldTypeGeometry() {
+        mockFieldType(INVALID_FIELD_TYPE);
+        final QueryShardException exception = expectThrows(
+            QueryShardException.class,
+            () -> queryProcessor.shapeQuery(randomPolygon(), fieldName, relation, mockQueryVisitor, mockQueryShardContext)
+        );
+        assertEquals(
+            "wrong exception message",
+            "Expected xy_shape field type for Field [ " + fieldName + " ] but found geo_point",
+            exception.getMessage()
+        );
+    }
+
+    public void testQueryingCircle() {
+        mockFieldType(VALID_FIELD_TYPE);
+        Circle circle = randomCircle();
+        when(mockQueryVisitor.visit(circle)).thenReturn(List.of(mock(XYGeometry.class)));
+        assertNotNull(
+            "failed to convert to Query",
+            queryProcessor.shapeQuery(circle, fieldName, relation, mockQueryVisitor, mockQueryShardContext)
+        );
+        verify(mockQueryVisitor).visit(circle);
+    }
+
+    public void testQueryingLinearRing() {
+        LinearRing ring = randomLinearRing(randomIntBetween(MIN_NUMBER_OF_VERTICES, MAX_NUMBER_OF_VERTICES));
+        expectThrows(
+            NullPointerException.class,
+            () -> queryProcessor.shapeQuery(ring, fieldName, relation, mockQueryVisitor, mockQueryShardContext)
+        );
+    }
+
+    public void testQueryingLine() {
+        mockFieldType(VALID_FIELD_TYPE);
+        int verticesLimit = randomIntBetween(MIN_NUMBER_OF_VERTICES, MAX_NUMBER_OF_VERTICES);
+        Line geometry = randomLine(verticesLimit);
+        when(mockQueryVisitor.visit(geometry)).thenReturn(List.of(mock(XYGeometry.class)));
+        assertNotNull(
+            "failed to convert to Query",
+            queryProcessor.shapeQuery(geometry, fieldName, relation, mockQueryVisitor, mockQueryShardContext)
+        );
+        verify(mockQueryVisitor).visit(geometry);
+    }
+
+    public void testQueryingMultiLine() {
+        mockFieldType(VALID_FIELD_TYPE);
+        int verticesLimit = randomIntBetween(MIN_NUMBER_OF_VERTICES, MAX_NUMBER_OF_VERTICES);
+        final int linesLimit = atLeast(MIN_NUMBER_OF_GEOMETRY_OBJECTS);
+        MultiLine geometry = randomMultiLine(verticesLimit, linesLimit);
+        when(mockQueryVisitor.visit(geometry)).thenReturn(List.of(mock(XYGeometry.class)));
+        assertNotNull(
+            "failed to convert to Query",
+            queryProcessor.shapeQuery(geometry, fieldName, relation, mockQueryVisitor, mockQueryShardContext)
+        );
+        verify(mockQueryVisitor).visit(geometry);
+    }
+
+    public void testQueryingPoint() {
+        mockFieldType(VALID_FIELD_TYPE);
+        Point geometry = randomPoint();
+        when(mockQueryVisitor.visit(geometry)).thenReturn(List.of(mock(XYGeometry.class)));
+        assertNotNull(
+            "failed to convert to Query",
+            queryProcessor.shapeQuery(geometry, fieldName, relation, mockQueryVisitor, mockQueryShardContext)
+        );
+        verify(mockQueryVisitor).visit(geometry);
+    }
+
+    public void testQueryingMultiPoint() {
+        mockFieldType(VALID_FIELD_TYPE);
+        int pointLimit = atLeast(MIN_NUMBER_OF_GEOMETRY_OBJECTS);
+        MultiPoint geometry = randomMultiPoint(pointLimit);
+        when(mockQueryVisitor.visit(geometry)).thenReturn(List.of(mock(XYGeometry.class)));
+        assertNotNull(
+            "failed to convert to Query",
+            queryProcessor.shapeQuery(geometry, fieldName, relation, mockQueryVisitor, mockQueryShardContext)
+        );
+        verify(mockQueryVisitor).visit(geometry);
+    }
+
+    public void testQueryingPolygon() throws IOException, ParseException {
+        mockFieldType(VALID_FIELD_TYPE);
+        Polygon geometry = randomPolygon();
+        when(mockQueryVisitor.visit(geometry)).thenReturn(List.of(mock(XYGeometry.class)));
+        assertNotNull(
+            "failed to convert to Query",
+            queryProcessor.shapeQuery(geometry, fieldName, relation, mockQueryVisitor, mockQueryShardContext)
+        );
+        verify(mockQueryVisitor).visit(geometry);
+    }
+
+    public void testQueryingMultiPolygon() throws IOException, ParseException {
+        mockFieldType(VALID_FIELD_TYPE);
+        MultiPolygon geometry = randomMultiPolygon();
+        when(mockQueryVisitor.visit(geometry)).thenReturn(List.of(mock(XYGeometry.class)));
+        assertNotNull(
+            "failed to convert to Query",
+            queryProcessor.shapeQuery(geometry, fieldName, relation, mockQueryVisitor, mockQueryShardContext)
+        );
+        verify(mockQueryVisitor).visit(geometry);
+    }
+
+    public void testQueryingGeometryCollection() throws IOException, ParseException {
+        mockFieldType(VALID_FIELD_TYPE);
+        GeometryCollection geometry = randomGeometryCollection(MIN_NUMBER_OF_GEOMETRY_OBJECTS);
+        when(mockQueryVisitor.visit(geometry)).thenReturn(List.of(mock(XYGeometry.class)));
+        assertNotNull(
+            "failed to convert to Query",
+            queryProcessor.shapeQuery(geometry, fieldName, relation, mockQueryVisitor, mockQueryShardContext)
+        );
+        verify(mockQueryVisitor).visit(geometry);
+    }
+
+    public void testQueryingEmptyGeometryCollection() throws IOException, ParseException {
+        mockFieldType(VALID_FIELD_TYPE);
+        GeometryCollection geometry = randomGeometryCollection(MIN_NUMBER_OF_GEOMETRY_OBJECTS);
+        when(mockQueryVisitor.visit(geometry)).thenReturn(List.of());
+        final Query actualQuery = queryProcessor.shapeQuery(geometry, fieldName, relation, mockQueryVisitor, mockQueryShardContext);
+        assertNotNull("failed to convert to Query", actualQuery);
+        verify(mockQueryVisitor).visit(geometry);
+        assertEquals("MatchNoDocs query should be returned", new MatchNoDocsQuery(), actualQuery);
+    }
+
+    public void testQueryingRectangle() {
+        mockFieldType(VALID_FIELD_TYPE);
+        Rectangle geometry = randomRectangle();
+        when(mockQueryVisitor.visit(geometry)).thenReturn(List.of(mock(XYGeometry.class)));
+        assertNotNull(
+            "failed to convert to Query",
+            queryProcessor.shapeQuery(geometry, fieldName, relation, mockQueryVisitor, mockQueryShardContext)
+        );
+        verify(mockQueryVisitor).visit(geometry);
+    }
+
+    private void mockFieldType(boolean success) {
+        if (success) {
+            when(mockQueryShardContext.fieldMapper(fieldName)).thenReturn(
+                new XYShapeFieldMapper.XYShapeFieldType(fieldName, randomBoolean(), randomBoolean(), randomBoolean(), emptyMap())
+            );
+            return;
+        }
+        when(mockQueryShardContext.fieldMapper(fieldName)).thenReturn(new GeoPointFieldMapper.GeoPointFieldType(fieldName));
+    }
+
+}

--- a/src/test/java/org/opensearch/geospatial/index/query/xyshape/XYShapeQueryVisitorTests.java
+++ b/src/test/java/org/opensearch/geospatial/index/query/xyshape/XYShapeQueryVisitorTests.java
@@ -1,0 +1,151 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package org.opensearch.geospatial.index.query.xyshape;
+
+import static org.mockito.Mockito.mock;
+import static org.opensearch.geospatial.index.common.xyshape.ShapeObjectBuilder.randomCircle;
+import static org.opensearch.geospatial.index.common.xyshape.ShapeObjectBuilder.randomGeometryCollection;
+import static org.opensearch.geospatial.index.common.xyshape.ShapeObjectBuilder.randomLine;
+import static org.opensearch.geospatial.index.common.xyshape.ShapeObjectBuilder.randomLinearRing;
+import static org.opensearch.geospatial.index.common.xyshape.ShapeObjectBuilder.randomMultiLine;
+import static org.opensearch.geospatial.index.common.xyshape.ShapeObjectBuilder.randomMultiPoint;
+import static org.opensearch.geospatial.index.common.xyshape.ShapeObjectBuilder.randomMultiPolygon;
+import static org.opensearch.geospatial.index.common.xyshape.ShapeObjectBuilder.randomPoint;
+import static org.opensearch.geospatial.index.common.xyshape.ShapeObjectBuilder.randomPolygon;
+import static org.opensearch.geospatial.index.common.xyshape.ShapeObjectBuilder.randomRectangle;
+
+import java.io.IOException;
+import java.text.ParseException;
+import java.util.List;
+
+import org.apache.lucene.geo.XYCircle;
+import org.apache.lucene.geo.XYGeometry;
+import org.apache.lucene.geo.XYLine;
+import org.apache.lucene.geo.XYPoint;
+import org.apache.lucene.geo.XYPolygon;
+import org.apache.lucene.geo.XYRectangle;
+import org.opensearch.geometry.Circle;
+import org.opensearch.geometry.GeometryCollection;
+import org.opensearch.geometry.GeometryVisitor;
+import org.opensearch.geometry.Line;
+import org.opensearch.geometry.LinearRing;
+import org.opensearch.geometry.MultiLine;
+import org.opensearch.geometry.MultiPoint;
+import org.opensearch.geometry.MultiPolygon;
+import org.opensearch.geometry.Point;
+import org.opensearch.geometry.Polygon;
+import org.opensearch.geometry.Rectangle;
+import org.opensearch.geospatial.GeospatialTestHelper;
+import org.opensearch.index.query.QueryShardContext;
+import org.opensearch.index.query.QueryShardException;
+import org.opensearch.test.OpenSearchTestCase;
+
+public class XYShapeQueryVisitorTests extends OpenSearchTestCase {
+
+    private final static Integer MAX_NUMBER_OF_VERTICES = 100;
+    private final static Integer MIN_NUMBER_OF_VERTICES = 2;
+    private final static Integer MIN_NUMBER_OF_GEOMETRY_OBJECTS = 10;
+    public static final int FIRST_GEOMETRY = 0;
+    public static final int SIZE = 1;
+    private GeometryVisitor<List<XYGeometry>, RuntimeException> queryVisitor;
+    private String fieldName;
+
+    @Override
+    public void setUp() throws Exception {
+        super.setUp();
+        QueryShardContext context = mock(QueryShardContext.class);
+        fieldName = GeospatialTestHelper.randomLowerCaseString();
+        queryVisitor = new XYShapeQueryVisitor(fieldName, context);
+    }
+
+    public void testQueryingCircle() {
+        Circle circle = randomCircle();
+        final List<XYGeometry> geometries = queryVisitor.visit(circle);
+        assertNotNull("failed to convert to XYCircle", geometries);
+        assertEquals("Unexpected number of geomteries found", SIZE, geometries.size());
+        assertTrue("invalid object found", geometries.get(FIRST_GEOMETRY) instanceof XYCircle);
+    }
+
+    public void testQueryingLinearRing() {
+        LinearRing ring = randomLinearRing(randomIntBetween(MIN_NUMBER_OF_VERTICES, MAX_NUMBER_OF_VERTICES));
+        QueryShardException exception = expectThrows(QueryShardException.class, () -> queryVisitor.visit(ring));
+        assertEquals("Field [" + fieldName + "] found an unsupported shape LinearRing", exception.getMessage());
+    }
+
+    public void testQueryingLine() {
+        int verticesLimit = randomIntBetween(MIN_NUMBER_OF_VERTICES, MAX_NUMBER_OF_VERTICES);
+        Line geometry = randomLine(verticesLimit);
+        final List<XYGeometry> geometries = queryVisitor.visit(geometry);
+        assertNotNull("Query geometries cannot be null", geometries);
+        assertEquals("Unexpected number of geomteries found", SIZE, geometries.size());
+        assertTrue("invalid object found ", geometries.get(FIRST_GEOMETRY) instanceof XYLine);
+    }
+
+    public void testQueryingMultiLine() {
+        int verticesLimit = randomIntBetween(MIN_NUMBER_OF_VERTICES, MAX_NUMBER_OF_VERTICES);
+        final int linesLimit = atLeast(MIN_NUMBER_OF_GEOMETRY_OBJECTS);
+        MultiLine multiLine = randomMultiLine(verticesLimit, linesLimit);
+        final List<XYGeometry> geometries = queryVisitor.visit(multiLine);
+        assertNotNull("Query geometries cannot be null", geometries);
+        assertEquals("Unexpected number of geomteries found", geometries.size(), multiLine.size());
+        for (XYGeometry geometry : geometries) {
+            assertTrue("invalid object found", geometry instanceof XYLine);
+        }
+    }
+
+    public void testQueryingPoint() {
+        Point geometry = randomPoint();
+        final List<XYGeometry> geometries = queryVisitor.visit(geometry);
+        assertNotNull("Query geometries cannot be null", geometries);
+        assertEquals("Unexpected number of geomteries found", SIZE, geometries.size());
+        assertTrue("invalid object found", geometries.get(FIRST_GEOMETRY) instanceof XYPoint);
+
+    }
+
+    public void testQueryingMultiPoint() {
+        int pointLimit = atLeast(MIN_NUMBER_OF_GEOMETRY_OBJECTS);
+        MultiPoint multiPoint = randomMultiPoint(pointLimit);
+        final List<XYGeometry> geometries = queryVisitor.visit(multiPoint);
+        assertNotNull("Query geometries cannot be null", geometries);
+        assertEquals("Unexpected number of geomteries found", geometries.size(), multiPoint.size());
+        for (XYGeometry geometry : geometries) {
+            assertTrue("invalid object found", geometry instanceof XYPoint);
+        }
+    }
+
+    public void testQueryingPolygon() throws IOException, ParseException {
+        Polygon geometry = randomPolygon();
+        final List<XYGeometry> geometries = queryVisitor.visit(geometry);
+        assertNotNull("Query geometries cannot be null", geometries);
+        assertEquals("Unexpected number of geomteries found", SIZE, geometries.size());
+        assertTrue("invalid object found", geometries.get(FIRST_GEOMETRY) instanceof XYPolygon);
+    }
+
+    public void testQueryingMultiPolygon() throws IOException, ParseException {
+        MultiPolygon multiPolygon = randomMultiPolygon();
+        final List<XYGeometry> geometries = queryVisitor.visit(multiPolygon);
+        assertNotNull("Query geometries cannot be null", geometries);
+        assertEquals("Unexpected number of geomteries found", geometries.size(), multiPolygon.size());
+        for (XYGeometry geometry : geometries) {
+            assertTrue("invalid object found", geometry instanceof XYPolygon);
+        }
+    }
+
+    public void testQueryingGeometryCollection() throws IOException, ParseException {
+        GeometryCollection<?> collection = randomGeometryCollection(MIN_NUMBER_OF_GEOMETRY_OBJECTS);
+        final List<XYGeometry> geometries = queryVisitor.visit(collection);
+        assertNotNull("Query geometries cannot be null", geometries);
+        assertTrue("Some geometries are not processed", geometries.size() >= collection.size());
+    }
+
+    public void testQueryingRectangle() {
+        Rectangle geometry = randomRectangle();
+        final List<XYGeometry> geometries = queryVisitor.visit(geometry);
+        assertNotNull("Query geometries cannot be null", geometries);
+        assertEquals("Unexpected number of geomteries found", SIZE, geometries.size());
+        assertTrue("invalid object found", geometries.get(FIRST_GEOMETRY) instanceof XYRectangle);
+    }
+}


### PR DESCRIPTION
### Description

- Create Geometry Visitor pattern to create Lucene XYGeometry objects based on OpenSearch Geometry. This geometry will be either from user defined shape or doc id referrenced from index which contains xy_shape field.
- Processor to accept user input as Geometry and convert it into Lucene Query based on XYShapeVisitor


 
### Issues Resolved
#67 
 
### Check List
- [x] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
