### PR TITLE
Add parameter to randomly include z coordinates to geometry

### DIFF
--- a/src/test/java/org/opensearch/geospatial/index/common/xyshape/XYShapeConverterTests.java
+++ b/src/test/java/org/opensearch/geospatial/index/common/xyshape/XYShapeConverterTests.java
@@ -34,7 +34,7 @@ public class XYShapeConverterTests extends OpenSearchTestCase {
 
     public void testXYLine() {
         int verticesLimit = randomIntBetween(MIN_NUMBER_OF_VERTICES, MAX_NUMBER_OF_VERTICES);
-        Line line = randomLine(verticesLimit);
+        Line line = randomLine(verticesLimit, randomBoolean());
         final XYLine xyLine = XYShapeConverter.toXYLine(line);
         assertArrayEquals("not matching x coords", line.getX(), toDoubleArray(xyLine.getX()), DELTA_ERROR);
         assertArrayEquals("not matching y coords", line.getY(), toDoubleArray(xyLine.getY()), DELTA_ERROR);
@@ -87,7 +87,7 @@ public class XYShapeConverterTests extends OpenSearchTestCase {
     }
 
     public void testXYPoint() {
-        Point point = randomPoint();
+        Point point = randomPoint(randomBoolean());
         final XYPoint xyPoint = XYShapeConverter.toXYPoint(point);
         assertArrayEquals(
             "Coordinates didn't match",

--- a/src/test/java/org/opensearch/geospatial/index/mapper/xyshape/XYShapeFieldMapperIT.java
+++ b/src/test/java/org/opensearch/geospatial/index/mapper/xyshape/XYShapeFieldMapperIT.java
@@ -48,7 +48,7 @@ public class XYShapeFieldMapperIT extends GeospatialRestTestCase {
         String indexName = GeospatialTestHelper.randomLowerCaseString();
         String fieldName = GeospatialTestHelper.randomLowerCaseString();
         createIndex(indexName, Settings.EMPTY, Map.of(fieldName, XYShapeFieldMapper.CONTENT_TYPE));
-        final Point point = ShapeObjectBuilder.randomPoint();
+        final Point point = ShapeObjectBuilder.randomPoint(randomBoolean());
         String docID = indexDocument(indexName, getDocumentWithWKTValueForXYShape(fieldName, point));
         assertTrue("failed to index document", getIndexDocumentCount(indexName) > 0);
         final Map<String, Object> document = getDocument(docID, indexName);
@@ -61,7 +61,7 @@ public class XYShapeFieldMapperIT extends GeospatialRestTestCase {
         String indexName = GeospatialTestHelper.randomLowerCaseString();
         String fieldName = GeospatialTestHelper.randomLowerCaseString();
         createIndex(indexName, Settings.EMPTY, Map.of(fieldName, XYShapeFieldMapper.CONTENT_TYPE));
-        final Point point = ShapeObjectBuilder.randomPoint();
+        final Point point = ShapeObjectBuilder.randomPoint(randomBoolean());
         String docID = indexDocument(indexName, getDocumentWithGeoJSONValueForXYShape(fieldName, point));
         assertTrue("failed to index document", getIndexDocumentCount(indexName) > 0);
         final Map<String, Object> document = getDocument(docID, indexName);

--- a/src/test/java/org/opensearch/geospatial/index/mapper/xyshape/XYShapeIndexableFieldsVisitorTests.java
+++ b/src/test/java/org/opensearch/geospatial/index/mapper/xyshape/XYShapeIndexableFieldsVisitorTests.java
@@ -63,20 +63,20 @@ public class XYShapeIndexableFieldsVisitorTests extends OpenSearchTestCase {
     }
 
     public void testIndexingCircle() {
-        Circle circle = randomCircle();
+        Circle circle = randomCircle(randomBoolean());
         IllegalArgumentException exception = expectThrows(IllegalArgumentException.class, () -> visitor.visit(circle));
         assertEquals("invalid shape type found [ CIRCLE ] while indexing shape", exception.getMessage());
     }
 
     public void testIndexingLinearRing() {
-        LinearRing ring = randomLinearRing(randomIntBetween(MIN_NUMBER_OF_VERTICES, MAX_NUMBER_OF_VERTICES));
+        LinearRing ring = randomLinearRing(randomIntBetween(MIN_NUMBER_OF_VERTICES, MAX_NUMBER_OF_VERTICES), randomBoolean());
         IllegalArgumentException exception = expectThrows(IllegalArgumentException.class, () -> visitor.visit(ring));
         assertEquals("invalid shape type found [ LINEARRING ] while indexing shape", exception.getMessage());
     }
 
     public void testIndexingLine() {
         int verticesLimit = randomIntBetween(MIN_NUMBER_OF_VERTICES, MAX_NUMBER_OF_VERTICES);
-        Line geometry = randomLine(verticesLimit);
+        Line geometry = randomLine(verticesLimit, randomBoolean());
         final IndexableField[] indexableFields = visitor.visit(geometry);
         assertNotNull("indexable field cannot be null", indexableFields);
         int expectedTrianglesSize = numberOfTrianglesFromLine(verticesLimit);
@@ -86,7 +86,7 @@ public class XYShapeIndexableFieldsVisitorTests extends OpenSearchTestCase {
     public void testIndexingMultiLine() {
         int verticesLimit = randomIntBetween(MIN_NUMBER_OF_VERTICES, MAX_NUMBER_OF_VERTICES);
         final int linesLimit = atLeast(MIN_NUMBER_OF_GEOMETRY_OBJECTS);
-        MultiLine geometry = randomMultiLine(verticesLimit, linesLimit);
+        MultiLine geometry = randomMultiLine(verticesLimit, linesLimit, randomBoolean());
         final IndexableField[] indexableFields = visitor.visit(geometry);
         assertNotNull("indexable field cannot be null", indexableFields);
         int expectedTrianglesSize = linesLimit * numberOfTrianglesFromLine(verticesLimit);
@@ -94,7 +94,7 @@ public class XYShapeIndexableFieldsVisitorTests extends OpenSearchTestCase {
     }
 
     public void testIndexingPoint() {
-        Point geometry = randomPoint();
+        Point geometry = randomPoint(randomBoolean());
         final IndexableField[] indexableFields = visitor.visit(geometry);
         assertNotNull("indexable field cannot be null", indexableFields);
         assertEquals("indexing is incomplete", numberOfTrianglesFromPoint(), indexableFields.length);
@@ -102,7 +102,7 @@ public class XYShapeIndexableFieldsVisitorTests extends OpenSearchTestCase {
 
     public void testIndexingMultiPoint() {
         int pointLimit = atLeast(MIN_NUMBER_OF_GEOMETRY_OBJECTS);
-        MultiPoint geometry = randomMultiPoint(pointLimit);
+        MultiPoint geometry = randomMultiPoint(pointLimit, randomBoolean());
         final IndexableField[] indexableFields = visitor.visit(geometry);
         assertNotNull("indexable field cannot be null", indexableFields);
         int expectedTrianglesSize = pointLimit * numberOfTrianglesFromPoint();
@@ -124,7 +124,7 @@ public class XYShapeIndexableFieldsVisitorTests extends OpenSearchTestCase {
     }
 
     public void testIndexingGeometryCollection() {
-        GeometryCollection<Geometry> geometry = randomGeometryCollection(MIN_NUMBER_OF_GEOMETRY_OBJECTS);
+        GeometryCollection<Geometry> geometry = randomGeometryCollection(MIN_NUMBER_OF_GEOMETRY_OBJECTS, randomBoolean());
         final IndexableField[] indexableFields = visitor.visit(geometry);
         assertNotNull("indexable field cannot be null", indexableFields);
         assertTrue("indexing is incomplete", indexableFields.length >= geometry.size());

--- a/src/test/java/org/opensearch/geospatial/index/mapper/xyshape/XYShapeIndexerTests.java
+++ b/src/test/java/org/opensearch/geospatial/index/mapper/xyshape/XYShapeIndexerTests.java
@@ -62,14 +62,14 @@ public class XYShapeIndexerTests extends OpenSearchTestCase {
     }
 
     public void testIndexingCircle() {
-        Circle circle = randomCircle();
+        Circle circle = randomCircle(randomBoolean());
         when(mockIndexableFieldVisitor.visit(circle)).thenReturn(new IndexableField[0]);
         assertNotNull("failed to index geometry", indexer.indexShape(parseContext, circle));
         verify(mockIndexableFieldVisitor).visit(circle);
     }
 
     public void testIndexingLinearRing() {
-        LinearRing ring = randomLinearRing(randomIntBetween(MIN_NUMBER_OF_VERTICES, MAX_NUMBER_OF_VERTICES));
+        LinearRing ring = randomLinearRing(randomIntBetween(MIN_NUMBER_OF_VERTICES, MAX_NUMBER_OF_VERTICES), randomBoolean());
         when(mockIndexableFieldVisitor.visit(ring)).thenReturn(new IndexableField[0]);
         assertNotNull("failed to index geometry", indexer.indexShape(parseContext, ring));
         verify(mockIndexableFieldVisitor).visit(ring);
@@ -77,7 +77,7 @@ public class XYShapeIndexerTests extends OpenSearchTestCase {
 
     public void testIndexingLine() {
         int verticesLimit = randomIntBetween(MIN_NUMBER_OF_VERTICES, MAX_NUMBER_OF_VERTICES);
-        Line geometry = randomLine(verticesLimit);
+        Line geometry = randomLine(verticesLimit, randomBoolean());
         when(mockIndexableFieldVisitor.visit(geometry)).thenReturn(new IndexableField[0]);
         assertNotNull("failed to index geometry", indexer.indexShape(parseContext, geometry));
         verify(mockIndexableFieldVisitor).visit(geometry);
@@ -86,14 +86,14 @@ public class XYShapeIndexerTests extends OpenSearchTestCase {
     public void testIndexingMultiLine() {
         int verticesLimit = randomIntBetween(MIN_NUMBER_OF_VERTICES, MAX_NUMBER_OF_VERTICES);
         final int linesLimit = atLeast(MIN_NUMBER_OF_GEOMETRY_OBJECTS);
-        MultiLine geometry = randomMultiLine(verticesLimit, linesLimit);
+        MultiLine geometry = randomMultiLine(verticesLimit, linesLimit, randomBoolean());
         when(mockIndexableFieldVisitor.visit(geometry)).thenReturn(new IndexableField[0]);
         assertNotNull("failed to index geometry", indexer.indexShape(parseContext, geometry));
         verify(mockIndexableFieldVisitor).visit(geometry);
     }
 
     public void testIndexingPoint() {
-        Point geometry = randomPoint();
+        Point geometry = randomPoint(randomBoolean());
         when(mockIndexableFieldVisitor.visit(geometry)).thenReturn(new IndexableField[0]);
         assertNotNull("failed to index geometry", indexer.indexShape(parseContext, geometry));
         verify(mockIndexableFieldVisitor).visit(geometry);
@@ -101,7 +101,7 @@ public class XYShapeIndexerTests extends OpenSearchTestCase {
 
     public void testIndexingMultiPoint() {
         int pointLimit = atLeast(MIN_NUMBER_OF_GEOMETRY_OBJECTS);
-        MultiPoint geometry = randomMultiPoint(pointLimit);
+        MultiPoint geometry = randomMultiPoint(pointLimit, randomBoolean());
         when(mockIndexableFieldVisitor.visit(geometry)).thenReturn(new IndexableField[0]);
         assertNotNull("failed to index geometry", indexer.indexShape(parseContext, geometry));
         verify(mockIndexableFieldVisitor).visit(geometry);
@@ -122,7 +122,7 @@ public class XYShapeIndexerTests extends OpenSearchTestCase {
     }
 
     public void testIndexingGeometryCollection() {
-        GeometryCollection<Geometry> geometry = randomGeometryCollection(MIN_NUMBER_OF_GEOMETRY_OBJECTS);
+        GeometryCollection<Geometry> geometry = randomGeometryCollection(MIN_NUMBER_OF_GEOMETRY_OBJECTS, randomBoolean());
         when(mockIndexableFieldVisitor.visit(geometry)).thenReturn(new IndexableField[0]);
         assertNotNull("failed to index geometry", indexer.indexShape(parseContext, geometry));
         verify(mockIndexableFieldVisitor).visit(geometry);
@@ -136,20 +136,20 @@ public class XYShapeIndexerTests extends OpenSearchTestCase {
     }
 
     public void testPrepareIndexingCircle() {
-        Circle circle = randomCircle();
+        Circle circle = randomCircle(randomBoolean());
         indexer.prepareForIndexing(circle);
         verify(mockSupportVisitor).visit(circle);
     }
 
     public void testPrepareIndexingLinearRing() {
-        LinearRing ring = randomLinearRing(randomIntBetween(MIN_NUMBER_OF_VERTICES, MAX_NUMBER_OF_VERTICES));
+        LinearRing ring = randomLinearRing(randomIntBetween(MIN_NUMBER_OF_VERTICES, MAX_NUMBER_OF_VERTICES), randomBoolean());
         indexer.prepareForIndexing(ring);
         verify(mockSupportVisitor).visit(ring);
     }
 
     public void testPrepareIndexingLine() {
         int verticesLimit = randomIntBetween(MIN_NUMBER_OF_VERTICES, MAX_NUMBER_OF_VERTICES);
-        Line geometry = randomLine(verticesLimit);
+        Line geometry = randomLine(verticesLimit, randomBoolean());
         indexer.prepareForIndexing(geometry);
         verify(mockSupportVisitor).visit(geometry);
     }
@@ -157,20 +157,20 @@ public class XYShapeIndexerTests extends OpenSearchTestCase {
     public void testPrepareIndexingMultiLine() {
         int verticesLimit = randomIntBetween(MIN_NUMBER_OF_VERTICES, MAX_NUMBER_OF_VERTICES);
         final int linesLimit = atLeast(MIN_NUMBER_OF_GEOMETRY_OBJECTS);
-        MultiLine geometry = randomMultiLine(verticesLimit, linesLimit);
+        MultiLine geometry = randomMultiLine(verticesLimit, linesLimit, randomBoolean());
         indexer.prepareForIndexing(geometry);
         verify(mockSupportVisitor).visit(geometry);
     }
 
     public void testPrepareIndexingPoint() {
-        Point geometry = randomPoint();
+        Point geometry = randomPoint(randomBoolean());
         indexer.prepareForIndexing(geometry);
         verify(mockSupportVisitor).visit(geometry);
     }
 
     public void testPrepareIndexingMultiPoint() {
         int pointLimit = atLeast(MIN_NUMBER_OF_GEOMETRY_OBJECTS);
-        MultiPoint geometry = randomMultiPoint(pointLimit);
+        MultiPoint geometry = randomMultiPoint(pointLimit, randomBoolean());
         indexer.prepareForIndexing(geometry);
         verify(mockSupportVisitor).visit(geometry);
     }
@@ -188,7 +188,7 @@ public class XYShapeIndexerTests extends OpenSearchTestCase {
     }
 
     public void testPrepareIndexingGeometryCollection() {
-        GeometryCollection<Geometry> geometry = randomGeometryCollection(MIN_NUMBER_OF_GEOMETRY_OBJECTS);
+        GeometryCollection<Geometry> geometry = randomGeometryCollection(MIN_NUMBER_OF_GEOMETRY_OBJECTS, randomBoolean());
         indexer.prepareForIndexing(geometry);
         verify(mockSupportVisitor).visit(geometry);
     }

--- a/src/test/java/org/opensearch/geospatial/index/mapper/xyshape/XYShapeSupportVisitorTests.java
+++ b/src/test/java/org/opensearch/geospatial/index/mapper/xyshape/XYShapeSupportVisitorTests.java
@@ -46,37 +46,40 @@ public class XYShapeSupportVisitorTests extends OpenSearchTestCase {
     }
 
     public void testPrepareForIndexingCircle() {
-        UnsupportedOperationException exception = expectThrows(UnsupportedOperationException.class, () -> visitor.visit(randomCircle()));
+        UnsupportedOperationException exception = expectThrows(
+            UnsupportedOperationException.class,
+            () -> visitor.visit(randomCircle(randomBoolean()))
+        );
         assertEquals("CIRCLE is not supported", exception.getMessage());
     }
 
     public void testPrepareForIndexingLinearRing() {
-        LinearRing ring = randomLinearRing(randomIntBetween(MIN_NUMBER_OF_VERTICES, MAX_NUMBER_OF_VERTICES));
+        LinearRing ring = randomLinearRing(randomIntBetween(MIN_NUMBER_OF_VERTICES, MAX_NUMBER_OF_VERTICES), randomBoolean());
         UnsupportedOperationException exception = expectThrows(UnsupportedOperationException.class, () -> visitor.visit(ring));
         assertEquals("cannot index LINEARRING [ " + ring + " ] directly", exception.getMessage());
     }
 
     public void testPrepareForIndexingLine() {
         int verticesLimit = randomIntBetween(MIN_NUMBER_OF_VERTICES, MAX_NUMBER_OF_VERTICES);
-        Line geometry = randomLine(verticesLimit);
+        Line geometry = randomLine(verticesLimit, randomBoolean());
         assertEquals(geometry, visitor.visit(geometry));
     }
 
     public void testPrepareForIndexingMultiLine() {
         int verticesLimit = randomIntBetween(MIN_NUMBER_OF_VERTICES, MAX_NUMBER_OF_VERTICES);
         final int linesLimit = atLeast(MIN_NUMBER_OF_GEOMETRY_OBJECTS);
-        MultiLine geometry = randomMultiLine(verticesLimit, linesLimit);
+        MultiLine geometry = randomMultiLine(verticesLimit, linesLimit, randomBoolean());
         assertEquals(geometry, visitor.visit(geometry));
     }
 
     public void testPrepareForIndexingPoint() {
-        Point geometry = randomPoint();
+        Point geometry = randomPoint(randomBoolean());
         assertEquals(geometry, visitor.visit(geometry));
     }
 
     public void testPrepareForIndexingMultiPoint() {
         int pointLimit = atLeast(MIN_NUMBER_OF_GEOMETRY_OBJECTS);
-        MultiPoint geometry = randomMultiPoint(pointLimit);
+        MultiPoint geometry = randomMultiPoint(pointLimit, randomBoolean());
         assertEquals(geometry, visitor.visit(geometry));
     }
 
@@ -91,7 +94,7 @@ public class XYShapeSupportVisitorTests extends OpenSearchTestCase {
     }
 
     public void testPrepareForIndexingGeometryCollection() {
-        GeometryCollection<Geometry> collection = randomGeometryCollection(MIN_NUMBER_OF_GEOMETRY_OBJECTS);
+        GeometryCollection<Geometry> collection = randomGeometryCollection(MIN_NUMBER_OF_GEOMETRY_OBJECTS, randomBoolean());
         assertEquals(collection, visitor.visit(collection));
     }
 

--- a/src/test/java/org/opensearch/geospatial/index/query/xyshape/XYShapeQueryProcessorTests.java
+++ b/src/test/java/org/opensearch/geospatial/index/query/xyshape/XYShapeQueryProcessorTests.java
@@ -130,7 +130,7 @@ public class XYShapeQueryProcessorTests extends OpenSearchTestCase {
 
     public void testQueryingCircle() {
         mockFieldType(VALID_FIELD_TYPE);
-        Circle circle = randomCircle();
+        Circle circle = randomCircle(randomBoolean());
         when(mockQueryVisitor.visit(circle)).thenReturn(List.of(mock(XYGeometry.class)));
         assertNotNull(
             "failed to convert to Query",
@@ -140,7 +140,7 @@ public class XYShapeQueryProcessorTests extends OpenSearchTestCase {
     }
 
     public void testQueryingLinearRing() {
-        LinearRing ring = randomLinearRing(randomIntBetween(MIN_NUMBER_OF_VERTICES, MAX_NUMBER_OF_VERTICES));
+        LinearRing ring = randomLinearRing(randomIntBetween(MIN_NUMBER_OF_VERTICES, MAX_NUMBER_OF_VERTICES), randomBoolean());
         expectThrows(
             NullPointerException.class,
             () -> queryProcessor.shapeQuery(ring, fieldName, relation, mockQueryVisitor, mockQueryShardContext)
@@ -150,7 +150,7 @@ public class XYShapeQueryProcessorTests extends OpenSearchTestCase {
     public void testQueryingLine() {
         mockFieldType(VALID_FIELD_TYPE);
         int verticesLimit = randomIntBetween(MIN_NUMBER_OF_VERTICES, MAX_NUMBER_OF_VERTICES);
-        Line geometry = randomLine(verticesLimit);
+        Line geometry = randomLine(verticesLimit, randomBoolean());
         when(mockQueryVisitor.visit(geometry)).thenReturn(List.of(mock(XYGeometry.class)));
         assertNotNull(
             "failed to convert to Query",
@@ -163,7 +163,7 @@ public class XYShapeQueryProcessorTests extends OpenSearchTestCase {
         mockFieldType(VALID_FIELD_TYPE);
         int verticesLimit = randomIntBetween(MIN_NUMBER_OF_VERTICES, MAX_NUMBER_OF_VERTICES);
         final int linesLimit = atLeast(MIN_NUMBER_OF_GEOMETRY_OBJECTS);
-        MultiLine geometry = randomMultiLine(verticesLimit, linesLimit);
+        MultiLine geometry = randomMultiLine(verticesLimit, linesLimit, randomBoolean());
         when(mockQueryVisitor.visit(geometry)).thenReturn(List.of(mock(XYGeometry.class)));
         assertNotNull(
             "failed to convert to Query",
@@ -174,7 +174,7 @@ public class XYShapeQueryProcessorTests extends OpenSearchTestCase {
 
     public void testQueryingPoint() {
         mockFieldType(VALID_FIELD_TYPE);
-        Point geometry = randomPoint();
+        Point geometry = randomPoint(randomBoolean());
         when(mockQueryVisitor.visit(geometry)).thenReturn(List.of(mock(XYGeometry.class)));
         assertNotNull(
             "failed to convert to Query",
@@ -186,7 +186,7 @@ public class XYShapeQueryProcessorTests extends OpenSearchTestCase {
     public void testQueryingMultiPoint() {
         mockFieldType(VALID_FIELD_TYPE);
         int pointLimit = atLeast(MIN_NUMBER_OF_GEOMETRY_OBJECTS);
-        MultiPoint geometry = randomMultiPoint(pointLimit);
+        MultiPoint geometry = randomMultiPoint(pointLimit, randomBoolean());
         when(mockQueryVisitor.visit(geometry)).thenReturn(List.of(mock(XYGeometry.class)));
         assertNotNull(
             "failed to convert to Query",
@@ -219,7 +219,7 @@ public class XYShapeQueryProcessorTests extends OpenSearchTestCase {
 
     public void testQueryingGeometryCollection() throws IOException, ParseException {
         mockFieldType(VALID_FIELD_TYPE);
-        GeometryCollection geometry = randomGeometryCollection(MIN_NUMBER_OF_GEOMETRY_OBJECTS);
+        GeometryCollection geometry = randomGeometryCollection(MIN_NUMBER_OF_GEOMETRY_OBJECTS, randomBoolean());
         when(mockQueryVisitor.visit(geometry)).thenReturn(List.of(mock(XYGeometry.class)));
         assertNotNull(
             "failed to convert to Query",
@@ -230,7 +230,7 @@ public class XYShapeQueryProcessorTests extends OpenSearchTestCase {
 
     public void testQueryingEmptyGeometryCollection() throws IOException, ParseException {
         mockFieldType(VALID_FIELD_TYPE);
-        GeometryCollection geometry = randomGeometryCollection(MIN_NUMBER_OF_GEOMETRY_OBJECTS);
+        GeometryCollection geometry = randomGeometryCollection(MIN_NUMBER_OF_GEOMETRY_OBJECTS, randomBoolean());
         when(mockQueryVisitor.visit(geometry)).thenReturn(List.of());
         final Query actualQuery = queryProcessor.shapeQuery(geometry, fieldName, relation, mockQueryVisitor, mockQueryShardContext);
         assertNotNull("failed to convert to Query", actualQuery);

--- a/src/test/java/org/opensearch/geospatial/index/query/xyshape/XYShapeQueryVisitorTests.java
+++ b/src/test/java/org/opensearch/geospatial/index/query/xyshape/XYShapeQueryVisitorTests.java
@@ -62,7 +62,7 @@ public class XYShapeQueryVisitorTests extends OpenSearchTestCase {
     }
 
     public void testQueryingCircle() {
-        Circle circle = randomCircle();
+        Circle circle = randomCircle(randomBoolean());
         final List<XYGeometry> geometries = queryVisitor.visit(circle);
         assertNotNull("failed to convert to XYCircle", geometries);
         assertEquals("Unexpected number of geomteries found", SIZE, geometries.size());
@@ -70,14 +70,14 @@ public class XYShapeQueryVisitorTests extends OpenSearchTestCase {
     }
 
     public void testQueryingLinearRing() {
-        LinearRing ring = randomLinearRing(randomIntBetween(MIN_NUMBER_OF_VERTICES, MAX_NUMBER_OF_VERTICES));
+        LinearRing ring = randomLinearRing(randomIntBetween(MIN_NUMBER_OF_VERTICES, MAX_NUMBER_OF_VERTICES), randomBoolean());
         QueryShardException exception = expectThrows(QueryShardException.class, () -> queryVisitor.visit(ring));
         assertEquals("Field [" + fieldName + "] found an unsupported shape LinearRing", exception.getMessage());
     }
 
     public void testQueryingLine() {
         int verticesLimit = randomIntBetween(MIN_NUMBER_OF_VERTICES, MAX_NUMBER_OF_VERTICES);
-        Line geometry = randomLine(verticesLimit);
+        Line geometry = randomLine(verticesLimit, randomBoolean());
         final List<XYGeometry> geometries = queryVisitor.visit(geometry);
         assertNotNull("Query geometries cannot be null", geometries);
         assertEquals("Unexpected number of geomteries found", SIZE, geometries.size());
@@ -87,7 +87,7 @@ public class XYShapeQueryVisitorTests extends OpenSearchTestCase {
     public void testQueryingMultiLine() {
         int verticesLimit = randomIntBetween(MIN_NUMBER_OF_VERTICES, MAX_NUMBER_OF_VERTICES);
         final int linesLimit = atLeast(MIN_NUMBER_OF_GEOMETRY_OBJECTS);
-        MultiLine multiLine = randomMultiLine(verticesLimit, linesLimit);
+        MultiLine multiLine = randomMultiLine(verticesLimit, linesLimit, randomBoolean());
         final List<XYGeometry> geometries = queryVisitor.visit(multiLine);
         assertNotNull("Query geometries cannot be null", geometries);
         assertEquals("Unexpected number of geomteries found", geometries.size(), multiLine.size());
@@ -97,7 +97,7 @@ public class XYShapeQueryVisitorTests extends OpenSearchTestCase {
     }
 
     public void testQueryingPoint() {
-        Point geometry = randomPoint();
+        Point geometry = randomPoint(randomBoolean());
         final List<XYGeometry> geometries = queryVisitor.visit(geometry);
         assertNotNull("Query geometries cannot be null", geometries);
         assertEquals("Unexpected number of geomteries found", SIZE, geometries.size());
@@ -107,7 +107,7 @@ public class XYShapeQueryVisitorTests extends OpenSearchTestCase {
 
     public void testQueryingMultiPoint() {
         int pointLimit = atLeast(MIN_NUMBER_OF_GEOMETRY_OBJECTS);
-        MultiPoint multiPoint = randomMultiPoint(pointLimit);
+        MultiPoint multiPoint = randomMultiPoint(pointLimit, randomBoolean());
         final List<XYGeometry> geometries = queryVisitor.visit(multiPoint);
         assertNotNull("Query geometries cannot be null", geometries);
         assertEquals("Unexpected number of geomteries found", geometries.size(), multiPoint.size());
@@ -135,7 +135,7 @@ public class XYShapeQueryVisitorTests extends OpenSearchTestCase {
     }
 
     public void testQueryingGeometryCollection() throws IOException, ParseException {
-        GeometryCollection<?> collection = randomGeometryCollection(MIN_NUMBER_OF_GEOMETRY_OBJECTS);
+        GeometryCollection<?> collection = randomGeometryCollection(MIN_NUMBER_OF_GEOMETRY_OBJECTS, randomBoolean());
         final List<XYGeometry> geometries = queryVisitor.visit(collection);
         assertNotNull("Query geometries cannot be null", geometries);
         assertTrue("Some geometries are not processed", geometries.size() >= collection.size());


### PR DESCRIPTION
### Description
Include whether to add z coords into Geometry or not
as param to random function, except Polygon.
Generating true random polygon is very complicated since 3 points at least
to be non-collinear. Will add support to be truly random
during later commit.

Why?
In ShapeQueryBuilderTests (unit test), we will not be processing z coordinates ( xy_shape is 2d object). Hence, needed an
interface to only create Geometry without z coordinates to compare shape output with query input.
These tests are added from super class AbstractQueryTestCase, hence, we cannot modify it. 
 
 
### Check List
- [x] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
