### PR TITLE
Add XYPoint Field Mapper

### DIFF
--- a/src/main/java/org/opensearch/geospatial/index/mapper/xypoint/XYPoint.java
+++ b/src/main/java/org/opensearch/geospatial/index/mapper/xypoint/XYPoint.java
@@ -5,27 +5,41 @@
 
 package org.opensearch.geospatial.index.mapper.xypoint;
 
+import java.io.IOException;
+import java.util.Locale;
+
 import lombok.AllArgsConstructor;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
+import org.opensearch.OpenSearchParseException;
+import org.opensearch.common.geo.GeoPoint;
+import org.opensearch.common.xcontent.ToXContentFragment;
+import org.opensearch.common.xcontent.XContentBuilder;
+import org.opensearch.geometry.Geometry;
 import org.opensearch.geometry.Point;
+import org.opensearch.geometry.ShapeType;
+import org.opensearch.geometry.utils.StandardValidator;
+import org.opensearch.geometry.utils.WellKnownText;
 import org.opensearch.index.mapper.AbstractPointGeometryFieldMapper;
 
 /**
- * Represents a point in a 2-dimensional planar coordinate system with no range limitations
+ * Represents a point in a 2-dimensional planar coordinate system with no range limitations.
+ *
+ * @author Naveen Tatikonda
  */
 @AllArgsConstructor
 @Getter
 @NoArgsConstructor
-public class XYPoint implements AbstractPointGeometryFieldMapper.ParsedPoint {
+public class XYPoint implements AbstractPointGeometryFieldMapper.ParsedPoint, ToXContentFragment {
     private double x;
     private double y;
 
     /**
      * To set x and y values
-     * @param x x coordinate value
-     * @param y y coordinate value
+     *
+     * @param x  x coordinate value
+     * @param y  y coordinate value
      * @return initialized XYPoint
      */
     public XYPoint reset(double x, double y) {
@@ -46,8 +60,9 @@ public class XYPoint implements AbstractPointGeometryFieldMapper.ParsedPoint {
 
     /**
      * To set x and y values
-     * @param x x coordinate
-     * @param y y coordinate
+     *
+     * @param x  x coordinate
+     * @param y  y coordinate
      */
     @Override
     public void resetCoords(double x, double y) {
@@ -60,5 +75,106 @@ public class XYPoint implements AbstractPointGeometryFieldMapper.ParsedPoint {
     @Override
     public Point asGeometry() {
         return new Point(getX(), getY());
+    }
+
+    /**
+     * Set x and y coordinates of XYPoint if input contains WKT or coordinates.
+     *
+     * @param value  input String which needs to be parsed and validated
+     * @param ignoreZValue  boolean parameter which decides if z coordinate needs to be ignored or not
+     * @return XYPoint after setting the x and y coordinates
+     */
+    public XYPoint resetFromString(String value, final boolean ignoreZValue) {
+        if (value.toLowerCase(Locale.ROOT).contains("point")) {
+            return resetFromWKT(value, ignoreZValue);
+        }
+        return resetFromCoordinates(value, ignoreZValue);
+    }
+
+    /**
+     * Set x and y coordinates of XYPoint if input contains coordinates.
+     *
+     * @param value  input String which contains coordinates that needs to be parsed and validated
+     * @param ignoreZValue  boolean parameter which decides if z coordinate needs to be ignored or not
+     * @return XYPoint after setting the x and y coordinates
+     */
+    public XYPoint resetFromCoordinates(String value, final boolean ignoreZValue) {
+        String[] values = value.split(",");
+        final double x;
+        final double y;
+        int numOfValues = values.length;
+
+        if (numOfValues > 3) {
+            throw new OpenSearchParseException("expected 2 or 3 coordinates, but found: [{}]", values.length);
+        }
+
+        if (numOfValues > 2) {
+            GeoPoint.assertZValue(ignoreZValue, Double.parseDouble(values[2].trim()));
+        }
+
+        try {
+            x = Double.parseDouble(values[0].trim());
+        } catch (NumberFormatException ex) {
+            throw new OpenSearchParseException("x must be a number");
+        }
+        try {
+            y = Double.parseDouble(values[1].trim());
+        } catch (NumberFormatException ex) {
+            throw new OpenSearchParseException("y must be a number");
+        }
+
+        return reset(x, y);
+    }
+
+    /**
+     * Set x and y coordinates of XYPoint if input contains WKT POINT.
+     *
+     * @param value  input String which contains WKT POINT that needs to be parsed and validated
+     * @param ignoreZValue  boolean parameter which decides if z coordinate needs to be ignored or not
+     * @return XYPoint after setting the x and y coordinates
+     */
+    private XYPoint resetFromWKT(String value, boolean ignoreZValue) {
+        Geometry geometry;
+        try {
+            geometry = new WellKnownText(false, new StandardValidator(ignoreZValue)).fromWKT(value);
+        } catch (Exception e) {
+            throw new OpenSearchParseException("Invalid WKT format", e);
+        }
+        if (geometry.type() != ShapeType.POINT) {
+            throw new OpenSearchParseException("[xy_point] supports only POINT among WKT primitives, but found [{}]", geometry.type());
+        }
+        Point point = (Point) geometry;
+        return reset(point.getY(), point.getX());
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (!(o instanceof XYPoint)) return false;
+        XYPoint point = (XYPoint) o;
+        return point.x == x && point.y == y;
+    }
+
+    @Override
+    public int hashCode() {
+        int result = Double.hashCode(x);
+        result = 31 * result + Double.hashCode(y);
+        return result;
+    }
+
+    @Override
+    public String toString() {
+        StringBuilder sb = new StringBuilder();
+        sb.append("Point(");
+        sb.append(x);
+        sb.append(",");
+        sb.append(y);
+        sb.append(')');
+        return sb.toString();
+    }
+
+    @Override
+    public XContentBuilder toXContent(XContentBuilder builder, Params params) throws IOException {
+        return builder.startObject().field("x", x).field("y", y).endObject();
     }
 }

--- a/src/main/java/org/opensearch/geospatial/index/mapper/xypoint/XYPoint.java
+++ b/src/main/java/org/opensearch/geospatial/index/mapper/xypoint/XYPoint.java
@@ -5,15 +5,17 @@
 
 package org.opensearch.geospatial.index.mapper.xypoint;
 
+import static org.opensearch.index.mapper.AbstractGeometryFieldMapper.Names.IGNORE_Z_VALUE;
+
 import java.io.IOException;
 import java.util.Locale;
+import java.util.Objects;
 
 import lombok.AllArgsConstructor;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
 import org.opensearch.OpenSearchParseException;
-import org.opensearch.common.geo.GeoPoint;
 import org.opensearch.common.xcontent.ToXContentFragment;
 import org.opensearch.common.xcontent.XContentBuilder;
 import org.opensearch.geometry.Geometry;
@@ -25,8 +27,6 @@ import org.opensearch.index.mapper.AbstractPointGeometryFieldMapper;
 
 /**
  * Represents a point in a 2-dimensional planar coordinate system with no range limitations.
- *
- * @author Naveen Tatikonda
  */
 @AllArgsConstructor
 @Getter
@@ -34,6 +34,10 @@ import org.opensearch.index.mapper.AbstractPointGeometryFieldMapper;
 public class XYPoint implements AbstractPointGeometryFieldMapper.ParsedPoint, ToXContentFragment {
     private double x;
     private double y;
+    private static final String POINT_PRIMITIVE = "point";
+    private static final String X_PARAMETER = "x";
+    private static final String Y_PARAMETER = "y";
+    private static final String XY_POINT = "XY_POINT";
 
     /**
      * To set x and y values
@@ -85,7 +89,9 @@ public class XYPoint implements AbstractPointGeometryFieldMapper.ParsedPoint, To
      * @return XYPoint after setting the x and y coordinates
      */
     public XYPoint resetFromString(String value, final boolean ignoreZValue) {
-        if (value.toLowerCase(Locale.ROOT).contains("point")) {
+        Objects.requireNonNull(value, "input string which needs to be parsed should not be null");
+
+        if (value.toLowerCase(Locale.ROOT).contains(POINT_PRIMITIVE)) {
             return resetFromWKT(value, ignoreZValue);
         }
         return resetFromCoordinates(value, ignoreZValue);
@@ -97,11 +103,12 @@ public class XYPoint implements AbstractPointGeometryFieldMapper.ParsedPoint, To
      * @param value  input String which contains coordinates that needs to be parsed and validated
      * @param ignoreZValue  boolean parameter which decides if z coordinate needs to be ignored or not
      * @return XYPoint after setting the x and y coordinates
+     * throws OpenSearchParseException
      */
     public XYPoint resetFromCoordinates(String value, final boolean ignoreZValue) {
+        Objects.requireNonNull(value, "input string which needs to be parsed should not be null");
+
         String[] values = value.split(",");
-        final double x;
-        final double y;
         int numOfValues = values.length;
 
         if (numOfValues > 3) {
@@ -109,21 +116,29 @@ public class XYPoint implements AbstractPointGeometryFieldMapper.ParsedPoint, To
         }
 
         if (numOfValues > 2) {
-            GeoPoint.assertZValue(ignoreZValue, Double.parseDouble(values[2].trim()));
+            assertZValue(ignoreZValue, Double.parseDouble(values[2].trim()));
         }
 
-        try {
-            x = Double.parseDouble(values[0].trim());
-        } catch (NumberFormatException ex) {
-            throw new OpenSearchParseException("x must be a number");
-        }
-        try {
-            y = Double.parseDouble(values[1].trim());
-        } catch (NumberFormatException ex) {
-            throw new OpenSearchParseException("y must be a number");
-        }
+        double x = parseCoordinate(values[0], X_PARAMETER);
+        double y = parseCoordinate(values[1], Y_PARAMETER);
 
         return reset(x, y);
+    }
+
+    /**
+     * Parse and extract coordinate value from given String.
+     *
+     * @param value  input String which contains coordinate that needs to be parsed and validated
+     * @param parameter  x or y parameter
+     * @return parsed coordinate value
+     * throws OpenSearchParseException
+     */
+    private double parseCoordinate(String value, String parameter) {
+        try {
+            return Double.parseDouble(value.trim());
+        } catch (NumberFormatException ex) {
+            throw new OpenSearchParseException("[{}] must be a number", parameter, ex);
+        }
     }
 
     /**
@@ -132,13 +147,14 @@ public class XYPoint implements AbstractPointGeometryFieldMapper.ParsedPoint, To
      * @param value  input String which contains WKT POINT that needs to be parsed and validated
      * @param ignoreZValue  boolean parameter which decides if z coordinate needs to be ignored or not
      * @return XYPoint after setting the x and y coordinates
+     * throws OpenSearchParseException
      */
     private XYPoint resetFromWKT(String value, boolean ignoreZValue) {
         Geometry geometry;
         try {
             geometry = new WellKnownText(false, new StandardValidator(ignoreZValue)).fromWKT(value);
         } catch (Exception e) {
-            throw new OpenSearchParseException("Invalid WKT format", e);
+            throw new OpenSearchParseException("Invalid WKT format, [{}]", value, e);
         }
         if (geometry.type() != ShapeType.POINT) {
             throw new OpenSearchParseException("[xy_point] supports only POINT among WKT primitives, but found [{}]", geometry.type());
@@ -147,14 +163,43 @@ public class XYPoint implements AbstractPointGeometryFieldMapper.ParsedPoint, To
         return reset(point.getY(), point.getX());
     }
 
+    /**
+     * Validates if z coordinate value needs to be ignored or not.
+     *
+     * @param ignoreZValue  boolean parameter which decides if z coordinate needs to be ignored or not
+     * @param zValue  z coordinate value
+     * throws OpenSearchParseException
+     */
+    public static void assertZValue(boolean ignoreZValue, double zValue) {
+        if (!ignoreZValue) {
+            throw new OpenSearchParseException(
+                "Exception parsing coordinates: found Z value [{}] but [{}] parameter is [{}]",
+                zValue,
+                IGNORE_Z_VALUE,
+                ignoreZValue
+            );
+        }
+    }
+
+    /**
+     * Deep Comparison to compare object of XYPoint class w.r.t state of the object
+     *
+     * @param obj  Object
+     * @return true if the parameter obj is of type XYPoint and its data members (x and y) are same, else false
+     */
     @Override
-    public boolean equals(Object o) {
-        if (this == o) return true;
-        if (!(o instanceof XYPoint)) return false;
-        XYPoint point = (XYPoint) o;
+    public boolean equals(Object obj) {
+        if (this == obj) return true;
+        if (!(obj instanceof XYPoint)) return false;
+        XYPoint point = (XYPoint) obj;
         return point.x == x && point.y == y;
     }
 
+    /**
+     * This method returns the hash code value for the object on which this method is invoked.
+     *
+     * @return hashcode value as an Integer
+     */
     @Override
     public int hashCode() {
         int result = Double.hashCode(x);
@@ -162,10 +207,16 @@ public class XYPoint implements AbstractPointGeometryFieldMapper.ParsedPoint, To
         return result;
     }
 
+    /**
+     * String representation of XYPoint object.
+     *
+     * @return XYPoint object as "Point(x,y)" where x and y are coordinate values
+     */
     @Override
     public String toString() {
         StringBuilder sb = new StringBuilder();
-        sb.append("Point(");
+        sb.append(XY_POINT);
+        sb.append('(');
         sb.append(x);
         sb.append(",");
         sb.append(y);
@@ -173,8 +224,16 @@ public class XYPoint implements AbstractPointGeometryFieldMapper.ParsedPoint, To
         return sb.toString();
     }
 
+    /**
+     * Return x and y coordinates in the object form.
+     *
+     * @param builder  XContentBuilder object
+     * @param params  Params object
+     * @return x and y coordinates in the object form. For example: {"x" : 100.35, "y" : -200.54}
+     * @throws IOException
+     */
     @Override
     public XContentBuilder toXContent(XContentBuilder builder, Params params) throws IOException {
-        return builder.startObject().field("x", x).field("y", y).endObject();
+        return builder.startObject().field(X_PARAMETER, x).field(Y_PARAMETER, y).endObject();
     }
 }

--- a/src/main/java/org/opensearch/geospatial/index/mapper/xypoint/XYPointFieldMapper.java
+++ b/src/main/java/org/opensearch/geospatial/index/mapper/xypoint/XYPointFieldMapper.java
@@ -1,0 +1,152 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package org.opensearch.geospatial.index.mapper.xypoint;
+
+import java.util.List;
+import java.util.Map;
+
+import org.apache.lucene.document.FieldType;
+import org.apache.lucene.document.StoredField;
+import org.apache.lucene.document.XYDocValuesField;
+import org.apache.lucene.geo.XYPoint;
+import org.apache.lucene.index.IndexOptions;
+import org.apache.lucene.index.IndexableField;
+import org.opensearch.common.Explicit;
+import org.opensearch.index.mapper.AbstractPointGeometryFieldMapper;
+import org.opensearch.index.mapper.MappedFieldType;
+import org.opensearch.index.mapper.ParseContext;
+
+/**
+ *  FieldMapper for indexing {@link XYPoint} points
+ *
+ * @author Naveen Tatikonda
+ */
+public class XYPointFieldMapper extends AbstractPointGeometryFieldMapper<
+    List<org.opensearch.geospatial.index.mapper.xypoint.XYPoint>,
+    List<? extends XYPoint>> {
+    public static final String CONTENT_TYPE = "xy_point";
+    private static final FieldType FIELD_TYPE = new FieldType();
+
+    static {
+        FIELD_TYPE.setStored(false);
+        FIELD_TYPE.setIndexOptions(IndexOptions.DOCS);
+        FIELD_TYPE.freeze();
+    }
+
+    private XYPointFieldMapper(
+        String simpleName,
+        FieldType fieldType,
+        MappedFieldType mappedFieldType,
+        MultiFields multiFields,
+        Explicit<Boolean> ignoreMalformed,
+        Explicit<Boolean> ignoreZValue,
+        ParsedPoint nullValue,
+        CopyTo copyTo
+    ) {
+        super(simpleName, fieldType, mappedFieldType, multiFields, ignoreMalformed, ignoreZValue, nullValue, copyTo);
+    }
+
+    @Override
+    protected void addStoredFields(ParseContext context, List<? extends XYPoint> points) {
+        for (XYPoint point : points) {
+            context.doc().add(new StoredField(fieldType().name(), point.toString()));
+        }
+    }
+
+    @Override
+    protected void addDocValuesFields(String name, List<? extends XYPoint> points, List<IndexableField> fields, ParseContext context) {
+        for (XYPoint point : points) {
+            context.doc().add(new XYDocValuesField(fieldType().name(), point.getX(), point.getY()));
+        }
+    }
+
+    @Override
+    protected void addMultiFields(ParseContext context, List<? extends XYPoint> points) {
+        // Any other fields will not be added
+    }
+
+    @Override
+    protected String contentType() {
+        return CONTENT_TYPE;
+    }
+
+    @Override
+    public XYPointFieldType fieldType() {
+        return (XYPointFieldType) mappedFieldType;
+    }
+
+    /**
+     * Builder class to create an instance of {@link XYPointFieldMapper}
+     */
+    public static class XYPointFieldMapperBuilder extends AbstractPointGeometryFieldMapper.Builder<
+        XYPointFieldMapperBuilder,
+        XYPointFieldType> {
+
+        public XYPointFieldMapperBuilder(String fieldName) {
+            super(fieldName, FIELD_TYPE);
+            this.hasDocValues = true;
+        }
+
+        /**
+         * Set the GeometryParser and GeometryIndexer for XYPointFieldType and create an instance of XYPointFieldMapper
+         *
+         * @param context  BuilderContext
+         * @param simpleName  field name
+         * @param fieldType  indicates the kind of data the field contains
+         * @param multiFields  used to index same field in different ways for different purposes
+         * @param ignoreMalformed  if true, malformed points are ignored else. If false(default) malformed points throw an exception
+         * @param ignoreZValue  if true (default), third dimension is ignored. If false, points containing more than two dimension throw an exception
+         * @param nullValue  used as a substitute for any explicit null values
+         * @param copyTo  CopyTo instance
+         * @return instance of XYPointFieldMapper
+         */
+        @Override
+        public XYPointFieldMapper build(
+            BuilderContext context,
+            String simpleName,
+            FieldType fieldType,
+            MultiFields multiFields,
+            Explicit<Boolean> ignoreMalformed,
+            Explicit<Boolean> ignoreZValue,
+            ParsedPoint nullValue,
+            CopyTo copyTo
+        ) {
+            XYPointFieldType xyPointFieldType = new XYPointFieldType(
+                buildFullName(context),
+                indexed,
+                this.fieldType.stored(),
+                hasDocValues,
+                meta
+            );
+
+            xyPointFieldType.setGeometryParser(
+                new PointParser<>(name, org.opensearch.geospatial.index.mapper.xypoint.XYPoint::new, (parser, point) -> {
+                    XYPointParser.parseXYPoint(parser, point, ignoreZValue().value());
+                    return point;
+                }, (org.opensearch.geospatial.index.mapper.xypoint.XYPoint) nullValue, ignoreZValue.value(), ignoreMalformed.value())
+            );
+            xyPointFieldType.setGeometryIndexer(new XYPointIndexer(xyPointFieldType.name()));
+            return new XYPointFieldMapper(name, fieldType, xyPointFieldType, multiFields, ignoreMalformed, ignoreZValue, nullValue, copyTo);
+        }
+    }
+
+    /**
+     * Concrete field type for xy_point
+     */
+    public static class XYPointFieldType extends AbstractPointGeometryFieldType<
+        List<org.opensearch.geospatial.index.mapper.xypoint.XYPoint>,
+        List<? extends XYPoint>> {
+
+        public XYPointFieldType(String name, boolean indexed, boolean stored, boolean hasDocValues, Map<String, String> meta) {
+            super(name, indexed, stored, hasDocValues, meta);
+        }
+
+        @Override
+        public String typeName() {
+            return CONTENT_TYPE;
+        }
+    }
+}

--- a/src/main/java/org/opensearch/geospatial/index/mapper/xypoint/XYPointFieldMapper.java
+++ b/src/main/java/org/opensearch/geospatial/index/mapper/xypoint/XYPointFieldMapper.java
@@ -21,8 +21,6 @@ import org.opensearch.index.mapper.ParseContext;
 
 /**
  *  FieldMapper for indexing {@link XYPoint} points
- *
- * @author Naveen Tatikonda
  */
 public class XYPointFieldMapper extends AbstractPointGeometryFieldMapper<
     List<org.opensearch.geospatial.index.mapper.xypoint.XYPoint>,
@@ -93,6 +91,9 @@ public class XYPointFieldMapper extends AbstractPointGeometryFieldMapper<
         /**
          * Set the GeometryParser and GeometryIndexer for XYPointFieldType and create an instance of XYPointFieldMapper
          *
+         * The point {@link org.opensearch.geospatial.index.mapper.xypoint.XYPoint} sent as a parameter by
+         * {@link AbstractPointGeometryFieldMapper} to PointParser is of no use and can be ignored.
+         *
          * @param context  BuilderContext
          * @param simpleName  field name
          * @param fieldType  indicates the kind of data the field contains
@@ -124,7 +125,7 @@ public class XYPointFieldMapper extends AbstractPointGeometryFieldMapper<
 
             xyPointFieldType.setGeometryParser(
                 new PointParser<>(name, org.opensearch.geospatial.index.mapper.xypoint.XYPoint::new, (parser, point) -> {
-                    XYPointParser.parseXYPoint(parser, point, ignoreZValue().value());
+                    XYPointParser.parseXYPoint(parser, ignoreZValue().value());
                     return point;
                 }, (org.opensearch.geospatial.index.mapper.xypoint.XYPoint) nullValue, ignoreZValue.value(), ignoreMalformed.value())
             );

--- a/src/main/java/org/opensearch/geospatial/index/mapper/xypoint/XYPointFieldTypeParser.java
+++ b/src/main/java/org/opensearch/geospatial/index/mapper/xypoint/XYPointFieldTypeParser.java
@@ -11,18 +11,31 @@ import org.opensearch.index.mapper.AbstractPointGeometryFieldMapper;
 
 /**
  * XYPointFieldTypeParser is used to parse and validate mapping parameters
- *
- * @author Naveen Tatikonda
  */
 public class XYPointFieldTypeParser extends AbstractPointGeometryFieldMapper.TypeParser {
+    /**
+     * Invoke XYPointFieldMapperBuilder constructor and return object.
+     *
+     * @param name  field name
+     * @param params  parameters
+     * @return invoked XYPointFieldMapperBuilder object
+     */
     @Override
     protected AbstractPointGeometryFieldMapper.Builder newBuilder(String name, Map params) {
         return new XYPointFieldMapper.XYPointFieldMapperBuilder(name);
     }
 
+    /**
+     * Parse nullValue and reset XYPoint.
+     *
+     * @param nullValue  null_value parameter value used as a substitute for any explicit null values
+     * @param ignoreZValue  if true (default), third dimension is ignored. If false, points containing more than two dimension throw an exception
+     * @param ignoreMalformed  if true, malformed points are ignored else. If false(default) malformed points throw an exception
+     * @return XYPoint after parsing null_value and resetting coordinates
+     */
     @Override
     protected XYPoint parseNullValue(Object nullValue, boolean ignoreZValue, boolean ignoreMalformed) {
-        return XYPointParser.parseXYPoint(nullValue, ignoreZValue, new XYPoint());
+        return XYPointParser.parseXYPoint(nullValue, ignoreZValue);
     }
 
 }

--- a/src/main/java/org/opensearch/geospatial/index/mapper/xypoint/XYPointFieldTypeParser.java
+++ b/src/main/java/org/opensearch/geospatial/index/mapper/xypoint/XYPointFieldTypeParser.java
@@ -1,0 +1,28 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package org.opensearch.geospatial.index.mapper.xypoint;
+
+import java.util.Map;
+
+import org.opensearch.index.mapper.AbstractPointGeometryFieldMapper;
+
+/**
+ * XYPointFieldTypeParser is used to parse and validate mapping parameters
+ *
+ * @author Naveen Tatikonda
+ */
+public class XYPointFieldTypeParser extends AbstractPointGeometryFieldMapper.TypeParser {
+    @Override
+    protected AbstractPointGeometryFieldMapper.Builder newBuilder(String name, Map params) {
+        return new XYPointFieldMapper.XYPointFieldMapperBuilder(name);
+    }
+
+    @Override
+    protected XYPoint parseNullValue(Object nullValue, boolean ignoreZValue, boolean ignoreMalformed) {
+        return XYPointParser.parseXYPoint(nullValue, ignoreZValue, new XYPoint());
+    }
+
+}

--- a/src/main/java/org/opensearch/geospatial/index/mapper/xypoint/XYPointParser.java
+++ b/src/main/java/org/opensearch/geospatial/index/mapper/xypoint/XYPointParser.java
@@ -7,9 +7,9 @@ package org.opensearch.geospatial.index.mapper.xypoint;
 
 import java.io.IOException;
 import java.util.Collections;
+import java.util.Objects;
 
 import org.opensearch.OpenSearchParseException;
-import org.opensearch.common.geo.GeoPoint;
 import org.opensearch.common.xcontent.LoggingDeprecationHandler;
 import org.opensearch.common.xcontent.NamedXContentRegistry;
 import org.opensearch.common.xcontent.XContentParser;
@@ -18,24 +18,24 @@ import org.opensearch.common.xcontent.support.MapXContentParser;
 
 /**
  * Parse the value and set XYPoint represented as a String, Object, WKT, array.
- *
- * @author Naveen Tatikonda
  */
 public class XYPointParser {
-    public static final String X = "x";
-    public static final String Y = "y";
-    public static final String NULL_VALUE_PARAMETER = "null_value";
+    private static final String X_PARAMETER = "x";
+    private static final String Y_PARAMETER = "y";
+    private static final String NULL_VALUE_PARAMETER = "null_value";
+    private static final Boolean TRUE = true;
 
     /**
      * Parses the value and set XYPoint which was represented as an object.
      *
      * @param value  input which needs to be parsed which contains x and y coordinates in object form
      * @param ignoreZValue  boolean parameter which decides if third coordinate needs to be ignored or not
-     * @param point  A {@link XYPoint} that will be reset by the values parsed
      * @return {@link XYPoint} after setting the x and y coordinates parsed from the parse
      * @throws OpenSearchParseException
      */
-    public static XYPoint parseXYPoint(Object value, final boolean ignoreZValue, XYPoint point) throws OpenSearchParseException {
+    public static XYPoint parseXYPoint(Object value, final boolean ignoreZValue) throws OpenSearchParseException {
+        Objects.requireNonNull(value, "input value which needs to be parsed should not be null");
+
         try (
             XContentParser parser = new MapXContentParser(
                 NamedXContentRegistry.EMPTY,
@@ -47,7 +47,7 @@ public class XYPointParser {
             parser.nextToken(); // start object
             parser.nextToken(); // field name
             parser.nextToken(); // field value
-            return parseXYPoint(parser, point, ignoreZValue);
+            return parseXYPoint(parser, ignoreZValue);
         } catch (IOException ex) {
             throw new OpenSearchParseException("error parsing xy_point", ex);
         }
@@ -64,17 +64,17 @@ public class XYPointParser {
      * </ul>
      *
      * @param parser  {@link XContentParser} to parse the value from
-     * @param point  A {@link XYPoint} that will be reset by the values parsed
      * @param ignoreZValue  boolean parameter which decides if third coordinate needs to be ignored or not
      * @return {@link XYPoint} after setting the x and y coordinates parsed from the parse
      * @throws IOException
      * @throws OpenSearchParseException
      */
-    public static XYPoint parseXYPoint(XContentParser parser, XYPoint point, final boolean ignoreZValue) throws IOException,
-        OpenSearchParseException {
+    public static XYPoint parseXYPoint(XContentParser parser, final boolean ignoreZValue) throws IOException, OpenSearchParseException {
+        Objects.requireNonNull(parser, "parser should not be null");
+
+        XYPoint point = new XYPoint();
         double x = Double.NaN;
         double y = Double.NaN;
-        NumberFormatException numberFormatException = null;
 
         if (parser.currentToken() == XContentParser.Token.START_OBJECT) {
             try (XContentSubParser subParser = new XContentSubParser(parser)) {
@@ -83,77 +83,73 @@ public class XYPointParser {
                         throw new OpenSearchParseException("token [{}] not allowed", subParser.currentToken());
                     }
                     String field = subParser.currentName();
-                    if (!(X.equals(field) || Y.equals(field))) {
-                        throw new OpenSearchParseException("field must be either [{}] or [{}]", X, Y);
+                    if (!(X_PARAMETER.equals(field) || Y_PARAMETER.equals(field))) {
+                        throw new OpenSearchParseException("field must be either [{}] or [{}]", X_PARAMETER, Y_PARAMETER);
                     }
-                    if (X.equals(field)) {
+                    if (X_PARAMETER.equals(field)) {
                         subParser.nextToken();
                         switch (subParser.currentToken()) {
                             case VALUE_NUMBER:
                             case VALUE_STRING:
                                 try {
-                                    x = subParser.doubleValue(true);
-                                } catch (NumberFormatException e) {
-                                    numberFormatException = e;
+                                    x = subParser.doubleValue(TRUE);
+                                } catch (NumberFormatException numberFormatException) {
+                                    throw new OpenSearchParseException("[x] must be valid double value", numberFormatException);
                                 }
                                 break;
                             default:
-                                throw new OpenSearchParseException("x must be a number");
+                                throw new OpenSearchParseException("[x] must be a number");
                         }
                     }
-                    if (Y.equals(field)) {
+                    if (Y_PARAMETER.equals(field)) {
                         subParser.nextToken();
                         switch (subParser.currentToken()) {
                             case VALUE_NUMBER:
                             case VALUE_STRING:
                                 try {
-                                    y = subParser.doubleValue(true);
-                                } catch (NumberFormatException e) {
-                                    numberFormatException = e;
+                                    y = subParser.doubleValue(TRUE);
+                                } catch (NumberFormatException numberFormatException) {
+                                    throw new OpenSearchParseException("[y] must be valid double value", numberFormatException);
                                 }
                                 break;
                             default:
-                                throw new OpenSearchParseException("y must be a number");
+                                throw new OpenSearchParseException("[y] must be a number");
                         }
                     }
                 }
             }
-            if (numberFormatException != null) {
-                throw new OpenSearchParseException("[{}] and [{}] must be valid double values", numberFormatException, X, Y);
-            }
             if (Double.isNaN(x)) {
-                throw new OpenSearchParseException("field [{}] missing", X);
+                throw new OpenSearchParseException("field [{}] missing", X_PARAMETER);
             }
             if (Double.isNaN(y)) {
-                throw new OpenSearchParseException("field [{}] missing", Y);
+                throw new OpenSearchParseException("field [{}] missing", Y_PARAMETER);
             }
             return point.reset(x, y);
         }
 
         if (parser.currentToken() == XContentParser.Token.START_ARRAY) {
-            return parseXYPointArray(parser, point, ignoreZValue, x, y);
+            return parseXYPointArray(parser, ignoreZValue, x, y);
         }
 
         if (parser.currentToken() == XContentParser.Token.VALUE_STRING) {
             String val = parser.text();
             return point.resetFromString(val, ignoreZValue);
         }
-        throw new OpenSearchParseException("xy_point expected");
+        throw new OpenSearchParseException("Expected xy_point. But, the provided mapping is not of type xy_point");
     }
 
     /**
      * Parse the values to set the XYPoint which was represented as an array.
      *
      * @param subParser  {@link XContentParser} to parse the values from an array
-     * @param point  A {@link XYPoint} that will be reset by the values parsed
      * @param ignoreZValue  boolean parameter which decides if third coordinate needs to be ignored or not
      * @param x  x coordinate that will be set by parsing the value from array
      * @param y  y coordinate that will be set by parsing the value from array
      * @return {@link XYPoint} after setting the x and y coordinates parsed from the parse
      * @throws IOException
      */
-    public static XYPoint parseXYPointArray(XContentParser subParser, XYPoint point, final boolean ignoreZValue, double x, double y)
-        throws IOException {
+    private static XYPoint parseXYPointArray(XContentParser subParser, final boolean ignoreZValue, double x, double y) throws IOException {
+        XYPoint point = new XYPoint();
         int element = 0;
         while (subParser.nextToken() != XContentParser.Token.END_ARRAY) {
             if (subParser.currentToken() != XContentParser.Token.VALUE_NUMBER) {
@@ -165,7 +161,7 @@ public class XYPointParser {
             } else if (element == 2) {
                 x = subParser.doubleValue();
             } else if (element == 3) {
-                GeoPoint.assertZValue(ignoreZValue, subParser.doubleValue());
+                XYPoint.assertZValue(ignoreZValue, subParser.doubleValue());
             } else {
                 throw new OpenSearchParseException("[xy_point] field type does not accept more than 3 dimensions");
             }

--- a/src/main/java/org/opensearch/geospatial/index/mapper/xypoint/XYPointParser.java
+++ b/src/main/java/org/opensearch/geospatial/index/mapper/xypoint/XYPointParser.java
@@ -1,0 +1,175 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package org.opensearch.geospatial.index.mapper.xypoint;
+
+import java.io.IOException;
+import java.util.Collections;
+
+import org.opensearch.OpenSearchParseException;
+import org.opensearch.common.geo.GeoPoint;
+import org.opensearch.common.xcontent.LoggingDeprecationHandler;
+import org.opensearch.common.xcontent.NamedXContentRegistry;
+import org.opensearch.common.xcontent.XContentParser;
+import org.opensearch.common.xcontent.XContentSubParser;
+import org.opensearch.common.xcontent.support.MapXContentParser;
+
+/**
+ * Parse the value and set XYPoint represented as a String, Object, WKT, array.
+ *
+ * @author Naveen Tatikonda
+ */
+public class XYPointParser {
+    public static final String X = "x";
+    public static final String Y = "y";
+    public static final String NULL_VALUE_PARAMETER = "null_value";
+
+    /**
+     * Parses the value and set XYPoint which was represented as an object.
+     *
+     * @param value  input which needs to be parsed which contains x and y coordinates in object form
+     * @param ignoreZValue  boolean parameter which decides if third coordinate needs to be ignored or not
+     * @param point  A {@link XYPoint} that will be reset by the values parsed
+     * @return {@link XYPoint} after setting the x and y coordinates parsed from the parse
+     * @throws OpenSearchParseException
+     */
+    public static XYPoint parseXYPoint(Object value, final boolean ignoreZValue, XYPoint point) throws OpenSearchParseException {
+        try (
+            XContentParser parser = new MapXContentParser(
+                NamedXContentRegistry.EMPTY,
+                LoggingDeprecationHandler.INSTANCE,
+                Collections.singletonMap(NULL_VALUE_PARAMETER, value),
+                null
+            )
+        ) {
+            parser.nextToken(); // start object
+            parser.nextToken(); // field name
+            parser.nextToken(); // field value
+            return parseXYPoint(parser, point, ignoreZValue);
+        } catch (IOException ex) {
+            throw new OpenSearchParseException("error parsing xy_point", ex);
+        }
+    }
+
+    /**
+     * Parse the values to set the XYPoint which was represented as a String, Object, WKT or an array.
+     *
+     * <ul>
+     *     <li> String: "100.35, -200.54" </li>
+     *     <li> Object: {"x" : 100.35, "y" : -200.54} </li>
+     *     <li> WKT: "POINT (-200.54 100.35)"</li>
+     *     <li> Array: [ -200.54, 100.35 ]</li>
+     * </ul>
+     *
+     * @param parser  {@link XContentParser} to parse the value from
+     * @param point  A {@link XYPoint} that will be reset by the values parsed
+     * @param ignoreZValue  boolean parameter which decides if third coordinate needs to be ignored or not
+     * @return {@link XYPoint} after setting the x and y coordinates parsed from the parse
+     * @throws IOException
+     * @throws OpenSearchParseException
+     */
+    public static XYPoint parseXYPoint(XContentParser parser, XYPoint point, final boolean ignoreZValue) throws IOException,
+        OpenSearchParseException {
+        double x = Double.NaN;
+        double y = Double.NaN;
+        NumberFormatException numberFormatException = null;
+
+        if (parser.currentToken() == XContentParser.Token.START_OBJECT) {
+            try (XContentSubParser subParser = new XContentSubParser(parser)) {
+                while (subParser.nextToken() != XContentParser.Token.END_OBJECT) {
+                    if (subParser.currentToken() != XContentParser.Token.FIELD_NAME) {
+                        throw new OpenSearchParseException("token [{}] not allowed", subParser.currentToken());
+                    }
+                    String field = subParser.currentName();
+                    if (!(X.equals(field) || Y.equals(field))) {
+                        throw new OpenSearchParseException("field must be either [{}] or [{}]", X, Y);
+                    }
+                    if (X.equals(field)) {
+                        subParser.nextToken();
+                        switch (subParser.currentToken()) {
+                            case VALUE_NUMBER:
+                            case VALUE_STRING:
+                                try {
+                                    x = subParser.doubleValue(true);
+                                } catch (NumberFormatException e) {
+                                    numberFormatException = e;
+                                }
+                                break;
+                            default:
+                                throw new OpenSearchParseException("x must be a number");
+                        }
+                    }
+                    if (Y.equals(field)) {
+                        subParser.nextToken();
+                        switch (subParser.currentToken()) {
+                            case VALUE_NUMBER:
+                            case VALUE_STRING:
+                                try {
+                                    y = subParser.doubleValue(true);
+                                } catch (NumberFormatException e) {
+                                    numberFormatException = e;
+                                }
+                                break;
+                            default:
+                                throw new OpenSearchParseException("y must be a number");
+                        }
+                    }
+                }
+            }
+            if (numberFormatException != null) {
+                throw new OpenSearchParseException("[{}] and [{}] must be valid double values", numberFormatException, X, Y);
+            }
+            if (Double.isNaN(x)) {
+                throw new OpenSearchParseException("field [{}] missing", X);
+            }
+            if (Double.isNaN(y)) {
+                throw new OpenSearchParseException("field [{}] missing", Y);
+            }
+            return point.reset(x, y);
+        }
+
+        if (parser.currentToken() == XContentParser.Token.START_ARRAY) {
+            return parseXYPointArray(parser, point, ignoreZValue, x, y);
+        }
+
+        if (parser.currentToken() == XContentParser.Token.VALUE_STRING) {
+            String val = parser.text();
+            return point.resetFromString(val, ignoreZValue);
+        }
+        throw new OpenSearchParseException("xy_point expected");
+    }
+
+    /**
+     * Parse the values to set the XYPoint which was represented as an array.
+     *
+     * @param subParser  {@link XContentParser} to parse the values from an array
+     * @param point  A {@link XYPoint} that will be reset by the values parsed
+     * @param ignoreZValue  boolean parameter which decides if third coordinate needs to be ignored or not
+     * @param x  x coordinate that will be set by parsing the value from array
+     * @param y  y coordinate that will be set by parsing the value from array
+     * @return {@link XYPoint} after setting the x and y coordinates parsed from the parse
+     * @throws IOException
+     */
+    public static XYPoint parseXYPointArray(XContentParser subParser, XYPoint point, final boolean ignoreZValue, double x, double y)
+        throws IOException {
+        int element = 0;
+        while (subParser.nextToken() != XContentParser.Token.END_ARRAY) {
+            if (subParser.currentToken() != XContentParser.Token.VALUE_NUMBER) {
+                throw new OpenSearchParseException("numeric value expected");
+            }
+            element++;
+            if (element == 1) {
+                y = subParser.doubleValue();
+            } else if (element == 2) {
+                x = subParser.doubleValue();
+            } else if (element == 3) {
+                GeoPoint.assertZValue(ignoreZValue, subParser.doubleValue());
+            } else {
+                throw new OpenSearchParseException("[xy_point] field type does not accept more than 3 dimensions");
+            }
+        }
+        return point.reset(x, y);
+    }
+}

--- a/src/main/java/org/opensearch/geospatial/plugin/GeospatialPlugin.java
+++ b/src/main/java/org/opensearch/geospatial/plugin/GeospatialPlugin.java
@@ -27,6 +27,8 @@ import org.opensearch.env.Environment;
 import org.opensearch.env.NodeEnvironment;
 import org.opensearch.geospatial.action.upload.geojson.UploadGeoJSONAction;
 import org.opensearch.geospatial.action.upload.geojson.UploadGeoJSONTransportAction;
+import org.opensearch.geospatial.index.mapper.xypoint.XYPointFieldMapper;
+import org.opensearch.geospatial.index.mapper.xypoint.XYPointFieldTypeParser;
 import org.opensearch.geospatial.index.mapper.xyshape.XYShapeFieldMapper;
 import org.opensearch.geospatial.index.mapper.xyshape.XYShapeFieldTypeParser;
 import org.opensearch.geospatial.index.query.xyshape.XYShapeQueryBuilder;
@@ -105,7 +107,12 @@ public class GeospatialPlugin extends Plugin implements IngestPlugin, ActionPlug
 
     @Override
     public Map<String, Mapper.TypeParser> getMappers() {
-        return Map.of(XYShapeFieldMapper.CONTENT_TYPE, new XYShapeFieldTypeParser());
+        return Map.of(
+            XYShapeFieldMapper.CONTENT_TYPE,
+            new XYShapeFieldTypeParser(),
+            XYPointFieldMapper.CONTENT_TYPE,
+            new XYPointFieldTypeParser()
+        );
     }
 
     @Override

--- a/src/test/java/org/opensearch/geospatial/index/mapper/xypoint/XYPointFieldMapperIT.java
+++ b/src/test/java/org/opensearch/geospatial/index/mapper/xypoint/XYPointFieldMapperIT.java
@@ -1,0 +1,110 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package org.opensearch.geospatial.index.mapper.xypoint;
+
+import java.io.IOException;
+import java.util.List;
+import java.util.Locale;
+import java.util.Map;
+
+import org.opensearch.common.settings.Settings;
+import org.opensearch.geometry.Geometry;
+import org.opensearch.geometry.Point;
+import org.opensearch.geospatial.GeospatialRestTestCase;
+import org.opensearch.geospatial.GeospatialTestHelper;
+import org.opensearch.geospatial.index.common.xyshape.ShapeObjectBuilder;
+
+public class XYPointFieldMapperIT extends GeospatialRestTestCase {
+    private static final String FIELD_X_KEY = "x";
+    private static final String FIELD_Y_KEY = "y";
+
+    public void testMappingWithXYPointField() throws IOException {
+        String indexName = GeospatialTestHelper.randomLowerCaseString();
+        String fieldName = GeospatialTestHelper.randomLowerCaseString();
+        createIndex(indexName, Settings.EMPTY, Map.of(fieldName, XYPointFieldMapper.CONTENT_TYPE));
+        final Map<String, Object> fieldNameTypeMap = getIndexProperties(indexName);
+        assertTrue("field name is not found inside mapping", fieldNameTypeMap.containsKey(fieldName));
+        final Map<String, Object> fieldType = (Map<String, Object>) fieldNameTypeMap.get(fieldName);
+        assertEquals("invalid field type", XYPointFieldMapper.CONTENT_TYPE, fieldType.get(FIELD_TYPE_KEY));
+        deleteIndex(indexName);
+    }
+
+    public void testIndexWithXYPointFieldAsWKTFormat() throws IOException {
+        String indexName = GeospatialTestHelper.randomLowerCaseString();
+        String fieldName = GeospatialTestHelper.randomLowerCaseString();
+        createIndex(indexName, Settings.EMPTY, Map.of(fieldName, XYPointFieldMapper.CONTENT_TYPE));
+        final Point point = ShapeObjectBuilder.randomPoint(randomBoolean());
+        String docID = indexDocument(indexName, getDocumentWithWKTValueForXYPoint(fieldName, point));
+        assertTrue("failed to index document", getIndexDocumentCount(indexName) > 0);
+        final Map<String, Object> document = getDocument(docID, indexName);
+        assertNotNull("failed to get indexed document", document);
+        assertEquals("failed to index xy_point", point.toString(), document.get(fieldName));
+        deleteIndex(indexName);
+    }
+
+    public void testIndexWithXYPointFieldAsArrayFormat() throws IOException {
+        String indexName = GeospatialTestHelper.randomLowerCaseString();
+        String fieldName = GeospatialTestHelper.randomLowerCaseString();
+        createIndex(indexName, Settings.EMPTY, Map.of(fieldName, XYPointFieldMapper.CONTENT_TYPE));
+        final Point point = ShapeObjectBuilder.randomPoint(randomBoolean());
+        String docID = indexDocument(indexName, getDocumentWithArrayValueForXYPoint(fieldName, point));
+        assertTrue("failed to index document", getIndexDocumentCount(indexName) > 0);
+        final Map<String, Object> document = getDocument(docID, indexName);
+        assertNotNull("failed to get indexed document", document);
+        assertEquals("failed to index xy_point", List.of(point.getY(), point.getX()), document.get(fieldName));
+        deleteIndex(indexName);
+    }
+
+    public void testIndexWithXYPointFieldAsStringFormat() throws IOException {
+        String indexName = GeospatialTestHelper.randomLowerCaseString();
+        String fieldName = GeospatialTestHelper.randomLowerCaseString();
+        createIndex(indexName, Settings.EMPTY, Map.of(fieldName, XYPointFieldMapper.CONTENT_TYPE));
+        final Point point = ShapeObjectBuilder.randomPoint(randomBoolean());
+        String pointAsString = point.getX() + "," + point.getY();
+        String docID = indexDocument(indexName, getDocumentWithStringValueForXYPoint(fieldName, pointAsString));
+        assertTrue("failed to index document", getIndexDocumentCount(indexName) > 0);
+        final Map<String, Object> document = getDocument(docID, indexName);
+        assertNotNull("failed to get indexed document", document);
+        assertEquals("failed to index xy_point", pointAsString, document.get(fieldName));
+        deleteIndex(indexName);
+    }
+
+    public void testIndexWithXYPointFieldAsObjectFormat() throws IOException {
+        String indexName = GeospatialTestHelper.randomLowerCaseString();
+        String fieldName = GeospatialTestHelper.randomLowerCaseString();
+        createIndex(indexName, Settings.EMPTY, Map.of(fieldName, XYPointFieldMapper.CONTENT_TYPE));
+        final Point point = ShapeObjectBuilder.randomPoint(randomBoolean());
+        String docID = indexDocument(indexName, getDocumentWithObjectValueForXYPoint(fieldName, point));
+        assertTrue("failed to index document", getIndexDocumentCount(indexName) > 0);
+        final Map<String, Object> document = getDocument(docID, indexName);
+        assertNotNull("failed to get indexed document", document);
+        String expectedValue = String.format(Locale.ROOT, "{x=%s, y=%s}", point.getX(), point.getY());
+        assertEquals("failed to index xy_point", expectedValue, document.get(fieldName).toString());
+        deleteIndex(indexName);
+    }
+
+    private String getDocumentWithWKTValueForXYPoint(String fieldName, Geometry geometry) throws IOException {
+        return buildContentAsString(build -> build.field(fieldName, geometry.toString()));
+    }
+
+    private String getDocumentWithArrayValueForXYPoint(String fieldName, Point point) throws IOException {
+        return buildContentAsString(build -> build.field(fieldName, new double[] { point.getY(), point.getX() }));
+    }
+
+    private String getDocumentWithStringValueForXYPoint(String fieldName, String pointAsString) throws IOException {
+        return buildContentAsString(build -> build.field(fieldName, pointAsString));
+    }
+
+    private String getDocumentWithObjectValueForXYPoint(String fieldName, Point point) throws IOException {
+        return buildContentAsString(build -> {
+            build.startObject(fieldName);
+            build.field(FIELD_X_KEY, point.getX());
+            build.field(FIELD_Y_KEY, point.getY());
+            build.endObject();
+        });
+    }
+
+}

--- a/src/test/java/org/opensearch/geospatial/index/mapper/xypoint/XYPointFieldMapperTests.java
+++ b/src/test/java/org/opensearch/geospatial/index/mapper/xypoint/XYPointFieldMapperTests.java
@@ -1,0 +1,295 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package org.opensearch.geospatial.index.mapper.xypoint;
+
+import java.io.IOException;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.Set;
+
+import org.apache.lucene.index.IndexableField;
+import org.opensearch.common.xcontent.XContentBuilder;
+import org.opensearch.geospatial.GeospatialTestHelper;
+import org.opensearch.geospatial.plugin.GeospatialPlugin;
+import org.opensearch.index.mapper.AbstractPointGeometryFieldMapper;
+import org.opensearch.index.mapper.DocumentMapper;
+import org.opensearch.index.mapper.FieldMapperTestCase2;
+import org.opensearch.index.mapper.Mapper;
+import org.opensearch.index.mapper.MapperParsingException;
+import org.opensearch.index.mapper.MapperService;
+import org.opensearch.index.mapper.ParsedDocument;
+import org.opensearch.plugins.Plugin;
+
+public class XYPointFieldMapperTests extends FieldMapperTestCase2<XYPointFieldMapper.XYPointFieldMapperBuilder> {
+
+    private static final String FIELD_TYPE_NAME = "type";
+    private static final String FIELD_NAME = "field";
+    private static final String FIELD_X_KEY = "x";
+    private static final String FIELD_Y_KEY = "y";
+    private final static Integer MIN_NUM_POINTS = 1;
+    private final static Integer MAX_NUM_POINTS = 10;
+
+    @Override
+    protected XYPointFieldMapper.XYPointFieldMapperBuilder newBuilder() {
+        return new XYPointFieldMapper.XYPointFieldMapperBuilder(GeospatialTestHelper.randomLowerCaseString());
+    }
+
+    @Override
+    protected void minimalMapping(XContentBuilder xContentBuilder) throws IOException {
+        xContentBuilder.field(FIELD_TYPE_NAME, XYPointFieldMapper.CONTENT_TYPE);
+    }
+
+    @Override
+    protected void writeFieldValue(XContentBuilder xContentBuilder) throws IOException {
+        xContentBuilder.value("POINT (14.0 15.0)");
+    }
+
+    @Override
+    protected void registerParameters(ParameterChecker parameterChecker) throws IOException {
+        parameterChecker.registerUpdateCheck(
+            b -> b.field(AbstractPointGeometryFieldMapper.Names.IGNORE_MALFORMED.getPreferredName(), true),
+            mapper -> {
+                assertTrue("invalid mapper retrieved", mapper instanceof XYPointFieldMapper);
+                XYPointFieldMapper xyPointFieldMapper = (XYPointFieldMapper) mapper;
+                assertTrue("param [ ignore_malformed ] is not updated", xyPointFieldMapper.ignoreMalformed().value());
+            }
+        );
+        parameterChecker.registerUpdateCheck(
+            b -> b.field(AbstractPointGeometryFieldMapper.Names.IGNORE_Z_VALUE.getPreferredName(), false),
+            mapper -> {
+                assertTrue("invalid mapper retrieved", mapper instanceof XYPointFieldMapper);
+                XYPointFieldMapper xyPointFieldMapper = (XYPointFieldMapper) mapper;
+                assertFalse("param [ ignore_z_value ] is not updated", xyPointFieldMapper.ignoreZValue().value());
+            }
+        );
+
+        XYPoint point = new XYPoint();
+        String pointAsString = "23.35,-50.55";
+        point.resetFromString(pointAsString, true);
+        parameterChecker.registerUpdateCheck(
+            b -> b.field(AbstractPointGeometryFieldMapper.Names.NULL_VALUE.getPreferredName(), pointAsString),
+            mapper -> {
+                assertTrue("invalid mapper retrieved", mapper instanceof XYPointFieldMapper);
+                XYPointFieldMapper xyPointFieldMapper = (XYPointFieldMapper) mapper;
+                assertEquals("param [ null_value ] is not updated", point, xyPointFieldMapper.nullValue());
+            }
+        );
+    }
+
+    @Override
+    protected Set<String> unsupportedProperties() {
+        return org.opensearch.common.collect.Set.of("analyzer", "similarity");
+    }
+
+    @Override
+    protected Collection<Plugin> getPlugins() {
+        return Collections.singletonList(new GeospatialPlugin());
+    }
+
+    @Override
+    protected boolean supportsMeta() {
+        return false;
+    }
+
+    @Override
+    protected boolean supportsOrIgnoresBoost() {
+        return false;
+    }
+
+    public final void testExistsQueryDocValuesDisabled() throws IOException {
+        MapperService mapperService = createMapperService(fieldMapping(builder -> {
+            minimalMapping(builder);
+            builder.field("doc_values", false);
+        }));
+        assertExistsQuery(mapperService);
+        assertParseMinimalWarnings();
+    }
+
+    public void testDefaultConfiguration() throws IOException {
+        DocumentMapper mapper = createDocumentMapper(fieldMapping(this::minimalMapping));
+        Mapper fieldMapper = mapper.mappers().getMapper(FIELD_NAME);
+        assertTrue("Invalid FieldMapper retrieved", fieldMapper instanceof XYPointFieldMapper);
+        XYPointFieldMapper xyPointFieldMapper = (XYPointFieldMapper) fieldMapper;
+
+        assertTrue("param [ docs_value ] default value should be true", xyPointFieldMapper.fieldType().hasDocValues());
+        assertEquals("param [ ignore_malformed ] default value should be false", xyPointFieldMapper.ignoreMalformed().value(), false);
+        assertEquals("param [ ignore_z_value ] default value should be true", xyPointFieldMapper.ignoreZValue().value(), true);
+        assertNull("param [ null_value ] default value should be null", xyPointFieldMapper.nullValue());
+
+    }
+
+    public void testFieldTypeContentType() throws IOException {
+        DocumentMapper mapper = createDocumentMapper(fieldMapping(this::minimalMapping));
+        Mapper fieldMapper = mapper.mappers().getMapper(FIELD_NAME);
+        assertTrue("Invalid FieldMapper retrieved", fieldMapper instanceof XYPointFieldMapper);
+        final XYPointFieldMapper.XYPointFieldType fieldType = ((XYPointFieldMapper) fieldMapper).fieldType();
+        assertEquals("invalid field type name", fieldType.typeName(), XYPointFieldMapper.CONTENT_TYPE);
+    }
+
+    public void testIndexAsWKT() throws IOException {
+        DocumentMapper mapper = createDocumentMapper(fieldMapping(this::minimalMapping));
+        ParsedDocument doc = mapper.parse(
+            source(builder -> builder.field(FIELD_NAME, "POINT (" + randomDouble() + " " + randomDouble() + ")"))
+        );
+        final IndexableField actualFieldValue = doc.rootDoc().getField(FIELD_NAME);
+        assertNotNull("FieldValue is null", actualFieldValue);
+    }
+
+    public void testIndexAsObject() throws IOException {
+        DocumentMapper mapper = createDocumentMapper(fieldMapping(this::minimalMapping));
+        ParsedDocument doc = mapper.parse(
+            source(
+                builder -> builder.startObject(FIELD_NAME).field(FIELD_X_KEY, randomDouble()).field(FIELD_Y_KEY, randomDouble()).endObject()
+            )
+        );
+        final IndexableField[] actualFieldValues = doc.rootDoc().getFields(FIELD_NAME);
+        assertNotNull("FieldValue is null", actualFieldValues);
+        assertEquals("mismatch in field values count", 2, actualFieldValues.length);
+    }
+
+    public void testIndexAsArray() throws IOException {
+        DocumentMapper mapper = createDocumentMapper(fieldMapping(this::minimalMapping));
+        ParsedDocument doc = mapper.parse(
+            source(builder -> builder.startArray(FIELD_NAME).value(randomDouble()).value(randomDouble()).endArray())
+        );
+        final IndexableField[] actualFieldValues = doc.rootDoc().getFields(FIELD_NAME);
+        assertNotNull("FieldValue is null", actualFieldValues);
+        assertEquals("mismatch in field values count", 2, actualFieldValues.length);
+    }
+
+    public void testIndexAsString() throws IOException {
+        DocumentMapper mapper = createDocumentMapper(fieldMapping(this::minimalMapping));
+        ParsedDocument doc = mapper.parse(source(builder -> builder.field(FIELD_NAME, randomDouble() + "," + randomDouble())));
+        final IndexableField actualFieldValue = doc.rootDoc().getField(FIELD_NAME);
+        assertNotNull("FieldValue is null", actualFieldValue);
+    }
+
+    public void testIndexAsArrayMultiPoints() throws IOException {
+        int numOfPoints = randomIntBetween(MIN_NUM_POINTS, MAX_NUM_POINTS);
+        DocumentMapper mapper = createDocumentMapper(fieldMapping(this::minimalMapping));
+        ParsedDocument doc = mapper.parse(source(builder -> {
+            builder.startArray(FIELD_NAME);
+            for (int i = 0; i < numOfPoints; i++) {
+                builder.startArray().value(randomDouble()).value(randomDouble()).endArray();
+            }
+            builder.endArray();
+        }));
+        final IndexableField[] actualFieldValues = doc.rootDoc().getFields(FIELD_NAME);
+        assertNotNull("FieldValue is null", actualFieldValues);
+        assertEquals("mismatch in field values count", 2 * numOfPoints, actualFieldValues.length);
+    }
+
+    public void testIndexAsObjectMultiPoints() throws IOException {
+        int numOfPoints = randomIntBetween(MIN_NUM_POINTS, MAX_NUM_POINTS);
+        DocumentMapper mapper = createDocumentMapper(fieldMapping(this::minimalMapping));
+        ParsedDocument doc = mapper.parse(source(builder -> {
+            builder.startArray(FIELD_NAME);
+            for (int i = 0; i < numOfPoints; i++) {
+                builder.startObject().field(FIELD_X_KEY, randomDouble()).field(FIELD_Y_KEY, randomDouble()).endObject();
+            }
+            builder.endArray();
+        }));
+        final IndexableField[] actualFieldValues = doc.rootDoc().getFields(FIELD_NAME);
+        assertNotNull("FieldValue is null", actualFieldValues);
+        assertEquals("mismatch in field values count", 2 * numOfPoints, actualFieldValues.length);
+    }
+
+    public void testIndexAsStringMultiPoints() throws IOException {
+        int numOfPoints = randomIntBetween(MIN_NUM_POINTS, MAX_NUM_POINTS);
+        DocumentMapper mapper = createDocumentMapper(fieldMapping(this::minimalMapping));
+        ParsedDocument doc = mapper.parse(source(builder -> {
+            builder.startArray(FIELD_NAME);
+            for (int i = 0; i < numOfPoints; i++) {
+                builder.value(randomDouble() + "," + randomDouble());
+            }
+            builder.endArray();
+        }));
+
+        final IndexableField[] actualFieldValues = doc.rootDoc().getFields(FIELD_NAME);
+        assertNotNull("FieldValue is null", actualFieldValues);
+        assertEquals("mismatch in field values count", 2 * numOfPoints, actualFieldValues.length);
+    }
+
+    public void testIndexAsWKTMultiPoints() throws IOException {
+        int numOfPoints = randomIntBetween(MIN_NUM_POINTS, MAX_NUM_POINTS);
+        DocumentMapper mapper = createDocumentMapper(fieldMapping(this::minimalMapping));
+        ParsedDocument doc = mapper.parse(source(builder -> {
+            builder.startArray(FIELD_NAME);
+            for (int i = 0; i < numOfPoints; i++) {
+                builder.value("POINT (" + randomDouble() + " " + randomDouble() + ")");
+            }
+            builder.endArray();
+        }));
+        final IndexableField[] actualFieldValues = doc.rootDoc().getFields(FIELD_NAME);
+        assertNotNull("FieldValue is null", actualFieldValues);
+        assertEquals("mismatch in field values count", 2 * numOfPoints, actualFieldValues.length);
+    }
+
+    public void testIgnoreZValue() throws IOException {
+        boolean z_value = randomBoolean();
+        DocumentMapper mapper = createDocumentMapper(
+            fieldMapping(
+                builder -> builder.field(FIELD_TYPE_NAME, XYPointFieldMapper.CONTENT_TYPE)
+                    .field(AbstractPointGeometryFieldMapper.Names.IGNORE_Z_VALUE.getPreferredName(), z_value)
+            )
+        );
+        if (z_value) {
+            ParsedDocument doc = mapper.parse(
+                source(builder -> builder.field(FIELD_NAME, randomDouble() + "," + randomDouble() + "," + randomDouble()))
+            );
+            final IndexableField actualFieldValue = doc.rootDoc().getField(FIELD_NAME);
+            assertNotNull("failed to ignore z value even if [ignore_z_value] is [true]", actualFieldValue);
+        } else {
+            Exception exception = expectThrows(
+                MapperParsingException.class,
+                () -> mapper.parse(
+                    source(builder -> builder.field(FIELD_NAME, randomDouble() + "," + randomDouble() + "," + randomDouble()))
+                )
+            );
+            assertTrue(
+                "failed to throw exception even if [ignore_z_value] is false",
+                exception.getCause().getMessage().contains("but [ignore_z_value] parameter is [false]")
+            );
+        }
+    }
+
+    public void testIgnoreMalformed() throws IOException {
+        boolean ignore_malformed_value = randomBoolean();
+        DocumentMapper mapper = createDocumentMapper(
+            fieldMapping(
+                builder -> builder.field(FIELD_TYPE_NAME, XYPointFieldMapper.CONTENT_TYPE)
+                    .field(AbstractPointGeometryFieldMapper.Names.IGNORE_MALFORMED.getPreferredName(), ignore_malformed_value)
+            )
+        );
+        if (ignore_malformed_value) {
+            ParsedDocument doc = mapper.parse(source(builder -> builder.field(FIELD_NAME, "50.0,abcd")));
+            assertNull("failed to ignore malformed point even if [ignore_malformed] is [true]", doc.rootDoc().getField(FIELD_NAME));
+        } else {
+            MapperParsingException exception = expectThrows(
+                MapperParsingException.class,
+                () -> mapper.parse(source(builder -> builder.field(FIELD_NAME, "50.0,abcd")))
+            );
+            assertTrue(
+                "failed to throw exception even if [ignore_malformed] is [false]",
+                exception.getCause().getMessage().contains("y must be a number")
+            );
+        }
+    }
+
+    public void testNullValue() throws Exception {
+        DocumentMapper mapper = createDocumentMapper(
+            fieldMapping(
+                builder -> builder.field(FIELD_TYPE_NAME, XYPointFieldMapper.CONTENT_TYPE)
+                    .field(AbstractPointGeometryFieldMapper.Names.NULL_VALUE.getPreferredName(), "91,181")
+            )
+        );
+        Mapper fieldMapper = mapper.mappers().getMapper(FIELD_NAME);
+
+        AbstractPointGeometryFieldMapper.ParsedPoint nullValue = ((XYPointFieldMapper) fieldMapper).nullValue();
+        assertEquals("assertion failed even if [null_value] parameter is set", nullValue, new XYPoint(91, 181));
+    }
+
+}

--- a/src/test/java/org/opensearch/geospatial/index/mapper/xypoint/XYPointFieldMapperTests.java
+++ b/src/test/java/org/opensearch/geospatial/index/mapper/xypoint/XYPointFieldMapperTests.java
@@ -243,7 +243,7 @@ public class XYPointFieldMapperTests extends FieldMapperTestCase2<XYPointFieldMa
             final IndexableField actualFieldValue = doc.rootDoc().getField(FIELD_NAME);
             assertNotNull("failed to ignore z value even if [ignore_z_value] is [true]", actualFieldValue);
         } else {
-            Exception exception = expectThrows(
+            MapperParsingException exception = expectThrows(
                 MapperParsingException.class,
                 () -> mapper.parse(
                     source(builder -> builder.field(FIELD_NAME, randomDouble() + "," + randomDouble() + "," + randomDouble()))
@@ -274,7 +274,7 @@ public class XYPointFieldMapperTests extends FieldMapperTestCase2<XYPointFieldMa
             );
             assertTrue(
                 "failed to throw exception even if [ignore_malformed] is [false]",
-                exception.getCause().getMessage().contains("y must be a number")
+                exception.getCause().getMessage().contains("[y] must be a number")
             );
         }
     }

--- a/src/test/java/org/opensearch/geospatial/index/mapper/xypoint/XYPointParsingTests.java
+++ b/src/test/java/org/opensearch/geospatial/index/mapper/xypoint/XYPointParsingTests.java
@@ -1,0 +1,174 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package org.opensearch.geospatial.index.mapper.xypoint;
+
+import java.io.IOException;
+
+import org.opensearch.OpenSearchParseException;
+import org.opensearch.common.bytes.BytesReference;
+import org.opensearch.common.xcontent.XContentBuilder;
+import org.opensearch.common.xcontent.XContentParser;
+import org.opensearch.common.xcontent.json.JsonXContent;
+import org.opensearch.test.OpenSearchTestCase;
+
+public class XYPointParsingTests extends OpenSearchTestCase {
+    private static final String FIELD_X_KEY = "x";
+    private static final String FIELD_Y_KEY = "y";
+
+    public void testXYPointReset() {
+        double x = randomDouble();
+        double y = randomDouble();
+
+        XYPoint point = new XYPoint();
+
+        assertEquals("Reset from WKT", point.resetFromString("POINT(" + y + " " + x + ")", randomBoolean()), point.reset(x, y));
+        assertEquals("Reset from Coordinates", point.resetFromString(x + ", " + y, randomBoolean()), point.reset(x, y));
+
+    }
+
+    public void testResetFromWKTInvalid() {
+        XYPoint point = new XYPoint();
+        Exception e = expectThrows(OpenSearchParseException.class, () -> point.resetFromString("NOT A POINT(1 2)", randomBoolean()));
+        assertEquals("Validation failed for Invalid WKT", "Invalid WKT format", e.getMessage());
+
+        Exception e2 = expectThrows(OpenSearchParseException.class, () -> point.resetFromString("MULTIPOINT(1 2, 3 4)", randomBoolean()));
+        assertEquals(
+            "Validation failed for invalid WKT primitive",
+            "[xy_point] supports only POINT among WKT primitives, but found [MULTIPOINT]",
+            e2.getMessage()
+        );
+    }
+
+    public void testResetFromCoordinatesInvalid() {
+        XYPoint point = new XYPoint();
+        Exception e = expectThrows(
+            OpenSearchParseException.class,
+            () -> point.resetFromString("20.4, 50.6, 70.8, -200.6", randomBoolean())
+        );
+        assertEquals("Validation failed for checking count of coordinates", "expected 2 or 3 coordinates, but found: [4]", e.getMessage());
+
+        Exception e2 = expectThrows(OpenSearchParseException.class, () -> point.resetFromString("20.4, 50.6, 70.8", false));
+        assertEquals(
+            "Validation failed for [ignore_z_value] parameter",
+            "Exception parsing coordinates: found Z value [70.8] but [ignore_z_value] parameter is [false]",
+            e2.getMessage()
+        );
+
+        Exception e3 = expectThrows(OpenSearchParseException.class, () -> point.resetFromString("abcd, 50.6", randomBoolean()));
+        assertEquals("Validation failed even if x is not a number", "x must be a number", e3.getMessage());
+
+        Exception e4 = expectThrows(OpenSearchParseException.class, () -> point.resetFromString("50.6, abcd", randomBoolean()));
+        assertEquals("Validation failed even if y is not a number", "y must be a number", e4.getMessage());
+    }
+
+    public void testXYPointParsing() throws IOException {
+        XYPoint randomXYPoint = new XYPoint(randomDouble(), randomDouble());
+
+        XYPoint point = XYPointParser.parseXYPoint(xyAsObject(randomXYPoint.getX(), randomXYPoint.getY()), new XYPoint(), randomBoolean());
+        assertEquals("Parsing XYPoint as an object failed", randomXYPoint, point);
+
+        XYPoint point2 = XYPointParser.parseXYPoint(xyAsString(randomXYPoint.getX(), randomXYPoint.getY()), new XYPoint(), randomBoolean());
+        assertEquals("Parsing XYPoint as a string failed", randomXYPoint, point2);
+
+        XYPoint point3 = XYPointParser.parseXYPoint(xyAsArray(randomXYPoint.getX(), randomXYPoint.getY()), new XYPoint(), randomBoolean());
+        assertEquals("Parsing XYPoint as an array failed", randomXYPoint, point3);
+
+        XYPoint point4 = XYPointParser.parseXYPoint(xyAsWKT(randomXYPoint.getX(), randomXYPoint.getY()), new XYPoint(), randomBoolean());
+        assertEquals("Parsing XYPoint as a WKT failed", randomXYPoint, point4);
+    }
+
+    public void testInvalidField() throws IOException {
+        XContentBuilder content = JsonXContent.contentBuilder();
+        content.startObject();
+        content.field(FIELD_Y_KEY, 0).field(FIELD_X_KEY, 0).field("test", 0);
+        content.endObject();
+
+        try (XContentParser parser = createParser(JsonXContent.jsonXContent, BytesReference.bytes(content))) {
+            parser.nextToken();
+            Exception e = expectThrows(
+                OpenSearchParseException.class,
+                () -> XYPointParser.parseXYPoint(parser, new XYPoint(), randomBoolean())
+            );
+            assertEquals("Validation for invalid fields failed", "field must be either [x] or [y]", e.getMessage());
+        }
+    }
+
+    public void testParsingInvalidObject() throws IOException {
+        // Send empty string instead of double for y coordinate
+        XContentBuilder content = JsonXContent.contentBuilder();
+        content.startObject();
+        content.field(FIELD_X_KEY, randomDouble()).field(FIELD_Y_KEY, "");
+        content.endObject();
+        XContentParser parser = createParser(JsonXContent.jsonXContent, BytesReference.bytes(content));
+        parser.nextToken();
+        Exception e = expectThrows(
+            OpenSearchParseException.class,
+            () -> XYPointParser.parseXYPoint(parser, new XYPoint(), randomBoolean())
+        );
+        assertEquals("Validation failed for invalid x and y values", "[x] and [y] must be valid double values", e.getMessage());
+
+        // Skip the 'y' field and y coordinate
+        XContentBuilder content1 = JsonXContent.contentBuilder();
+        content1.startObject();
+        content1.field(FIELD_X_KEY, randomDouble());
+        content1.endObject();
+        XContentParser parser1 = createParser(JsonXContent.jsonXContent, BytesReference.bytes(content1));
+        parser1.nextToken();
+        Exception e1 = expectThrows(
+            OpenSearchParseException.class,
+            () -> XYPointParser.parseXYPoint(parser1, new XYPoint(), randomBoolean())
+        );
+        assertEquals("Validation failed even if field [y] is missing", "field [y] missing", e1.getMessage());
+
+        // Skip the 'x' field and x coordinate
+        XContentBuilder content2 = JsonXContent.contentBuilder();
+        content2.startObject();
+        content2.field(FIELD_Y_KEY, randomDouble());
+        content2.endObject();
+        XContentParser parser2 = createParser(JsonXContent.jsonXContent, BytesReference.bytes(content2));
+        parser2.nextToken();
+        Exception e2 = expectThrows(
+            OpenSearchParseException.class,
+            () -> XYPointParser.parseXYPoint(parser2, new XYPoint(), randomBoolean())
+        );
+        assertEquals("Validation failed even if field [x] is missing", "field [x] missing", e2.getMessage());
+
+    }
+
+    private XContentParser xyAsObject(double x, double y) throws IOException {
+        XContentBuilder content = JsonXContent.contentBuilder();
+        content.startObject();
+        content.field(FIELD_X_KEY, x).field(FIELD_Y_KEY, y);
+        content.endObject();
+        XContentParser parser = createParser(JsonXContent.jsonXContent, BytesReference.bytes(content));
+        parser.nextToken();
+        return parser;
+    }
+
+    private XContentParser xyAsString(double x, double y) throws IOException {
+        XContentBuilder content = JsonXContent.contentBuilder();
+        content.value(x + ", " + y);
+        XContentParser parser = createParser(JsonXContent.jsonXContent, BytesReference.bytes(content));
+        parser.nextToken();
+        return parser;
+    }
+
+    private XContentParser xyAsArray(double x, double y) throws IOException {
+        XContentBuilder content = JsonXContent.contentBuilder();
+        content.startArray().value(y).value(x).endArray();
+        XContentParser parser = createParser(JsonXContent.jsonXContent, BytesReference.bytes(content));
+        parser.nextToken();
+        return parser;
+    }
+
+    private XContentParser xyAsWKT(double x, double y) throws IOException {
+        XContentBuilder content = JsonXContent.contentBuilder();
+        content.value("POINT (" + y + " " + x + ")");
+        XContentParser parser = createParser(JsonXContent.jsonXContent, BytesReference.bytes(content));
+        parser.nextToken();
+        return parser;
+    }
+}

--- a/src/test/java/org/opensearch/geospatial/index/mapper/xypoint/XYPointParsingTests.java
+++ b/src/test/java/org/opensearch/geospatial/index/mapper/xypoint/XYPointParsingTests.java
@@ -31,10 +31,16 @@ public class XYPointParsingTests extends OpenSearchTestCase {
 
     public void testResetFromWKTInvalid() {
         XYPoint point = new XYPoint();
-        Exception e = expectThrows(OpenSearchParseException.class, () -> point.resetFromString("NOT A POINT(1 2)", randomBoolean()));
-        assertEquals("Validation failed for Invalid WKT", "Invalid WKT format", e.getMessage());
+        OpenSearchParseException e = expectThrows(
+            OpenSearchParseException.class,
+            () -> point.resetFromString("NOT A POINT(1 2)", randomBoolean())
+        );
+        assertEquals("Validation failed for Invalid WKT", "Invalid WKT format, [NOT A POINT(1 2)]", e.getMessage());
 
-        Exception e2 = expectThrows(OpenSearchParseException.class, () -> point.resetFromString("MULTIPOINT(1 2, 3 4)", randomBoolean()));
+        OpenSearchParseException e2 = expectThrows(
+            OpenSearchParseException.class,
+            () -> point.resetFromString("MULTIPOINT(1 2, 3 4)", randomBoolean())
+        );
         assertEquals(
             "Validation failed for invalid WKT primitive",
             "[xy_point] supports only POINT among WKT primitives, but found [MULTIPOINT]",
@@ -44,39 +50,45 @@ public class XYPointParsingTests extends OpenSearchTestCase {
 
     public void testResetFromCoordinatesInvalid() {
         XYPoint point = new XYPoint();
-        Exception e = expectThrows(
+        OpenSearchParseException e = expectThrows(
             OpenSearchParseException.class,
             () -> point.resetFromString("20.4, 50.6, 70.8, -200.6", randomBoolean())
         );
         assertEquals("Validation failed for checking count of coordinates", "expected 2 or 3 coordinates, but found: [4]", e.getMessage());
 
-        Exception e2 = expectThrows(OpenSearchParseException.class, () -> point.resetFromString("20.4, 50.6, 70.8", false));
+        OpenSearchParseException e2 = expectThrows(OpenSearchParseException.class, () -> point.resetFromString("20.4, 50.6, 70.8", false));
         assertEquals(
             "Validation failed for [ignore_z_value] parameter",
             "Exception parsing coordinates: found Z value [70.8] but [ignore_z_value] parameter is [false]",
             e2.getMessage()
         );
 
-        Exception e3 = expectThrows(OpenSearchParseException.class, () -> point.resetFromString("abcd, 50.6", randomBoolean()));
-        assertEquals("Validation failed even if x is not a number", "x must be a number", e3.getMessage());
+        OpenSearchParseException e3 = expectThrows(
+            OpenSearchParseException.class,
+            () -> point.resetFromString("abcd, 50.6", randomBoolean())
+        );
+        assertEquals("Validation failed even if x is not a number", "[x] must be a number", e3.getMessage());
 
-        Exception e4 = expectThrows(OpenSearchParseException.class, () -> point.resetFromString("50.6, abcd", randomBoolean()));
-        assertEquals("Validation failed even if y is not a number", "y must be a number", e4.getMessage());
+        OpenSearchParseException e4 = expectThrows(
+            OpenSearchParseException.class,
+            () -> point.resetFromString("50.6, abcd", randomBoolean())
+        );
+        assertEquals("Validation failed even if y is not a number", "[y] must be a number", e4.getMessage());
     }
 
     public void testXYPointParsing() throws IOException {
         XYPoint randomXYPoint = new XYPoint(randomDouble(), randomDouble());
 
-        XYPoint point = XYPointParser.parseXYPoint(xyAsObject(randomXYPoint.getX(), randomXYPoint.getY()), new XYPoint(), randomBoolean());
+        XYPoint point = XYPointParser.parseXYPoint(xyAsObject(randomXYPoint.getX(), randomXYPoint.getY()), randomBoolean());
         assertEquals("Parsing XYPoint as an object failed", randomXYPoint, point);
 
-        XYPoint point2 = XYPointParser.parseXYPoint(xyAsString(randomXYPoint.getX(), randomXYPoint.getY()), new XYPoint(), randomBoolean());
+        XYPoint point2 = XYPointParser.parseXYPoint(xyAsString(randomXYPoint.getX(), randomXYPoint.getY()), randomBoolean());
         assertEquals("Parsing XYPoint as a string failed", randomXYPoint, point2);
 
-        XYPoint point3 = XYPointParser.parseXYPoint(xyAsArray(randomXYPoint.getX(), randomXYPoint.getY()), new XYPoint(), randomBoolean());
+        XYPoint point3 = XYPointParser.parseXYPoint(xyAsArray(randomXYPoint.getX(), randomXYPoint.getY()), randomBoolean());
         assertEquals("Parsing XYPoint as an array failed", randomXYPoint, point3);
 
-        XYPoint point4 = XYPointParser.parseXYPoint(xyAsWKT(randomXYPoint.getX(), randomXYPoint.getY()), new XYPoint(), randomBoolean());
+        XYPoint point4 = XYPointParser.parseXYPoint(xyAsWKT(randomXYPoint.getX(), randomXYPoint.getY()), randomBoolean());
         assertEquals("Parsing XYPoint as a WKT failed", randomXYPoint, point4);
     }
 
@@ -88,9 +100,9 @@ public class XYPointParsingTests extends OpenSearchTestCase {
 
         try (XContentParser parser = createParser(JsonXContent.jsonXContent, BytesReference.bytes(content))) {
             parser.nextToken();
-            Exception e = expectThrows(
+            OpenSearchParseException e = expectThrows(
                 OpenSearchParseException.class,
-                () -> XYPointParser.parseXYPoint(parser, new XYPoint(), randomBoolean())
+                () -> XYPointParser.parseXYPoint(parser, randomBoolean())
             );
             assertEquals("Validation for invalid fields failed", "field must be either [x] or [y]", e.getMessage());
         }
@@ -104,11 +116,11 @@ public class XYPointParsingTests extends OpenSearchTestCase {
         content.endObject();
         XContentParser parser = createParser(JsonXContent.jsonXContent, BytesReference.bytes(content));
         parser.nextToken();
-        Exception e = expectThrows(
+        OpenSearchParseException e = expectThrows(
             OpenSearchParseException.class,
-            () -> XYPointParser.parseXYPoint(parser, new XYPoint(), randomBoolean())
+            () -> XYPointParser.parseXYPoint(parser, randomBoolean())
         );
-        assertEquals("Validation failed for invalid x and y values", "[x] and [y] must be valid double values", e.getMessage());
+        assertEquals("Validation failed for invalid x and y values", "[y] must be valid double value", e.getMessage());
 
         // Skip the 'y' field and y coordinate
         XContentBuilder content1 = JsonXContent.contentBuilder();
@@ -117,9 +129,9 @@ public class XYPointParsingTests extends OpenSearchTestCase {
         content1.endObject();
         XContentParser parser1 = createParser(JsonXContent.jsonXContent, BytesReference.bytes(content1));
         parser1.nextToken();
-        Exception e1 = expectThrows(
+        OpenSearchParseException e1 = expectThrows(
             OpenSearchParseException.class,
-            () -> XYPointParser.parseXYPoint(parser1, new XYPoint(), randomBoolean())
+            () -> XYPointParser.parseXYPoint(parser1, randomBoolean())
         );
         assertEquals("Validation failed even if field [y] is missing", "field [y] missing", e1.getMessage());
 
@@ -130,9 +142,9 @@ public class XYPointParsingTests extends OpenSearchTestCase {
         content2.endObject();
         XContentParser parser2 = createParser(JsonXContent.jsonXContent, BytesReference.bytes(content2));
         parser2.nextToken();
-        Exception e2 = expectThrows(
+        OpenSearchParseException e2 = expectThrows(
             OpenSearchParseException.class,
-            () -> XYPointParser.parseXYPoint(parser2, new XYPoint(), randomBoolean())
+            () -> XYPointParser.parseXYPoint(parser2, randomBoolean())
         );
         assertEquals("Validation failed even if field [x] is missing", "field [x] missing", e2.getMessage());
 


### PR DESCRIPTION
Signed-off-by: Naveen Tatikonda <navtat@amazon.com>

### Description
Field Mapper logic with new content type "xy_point" to index documents with field of type "xy_point" which is similar to geo_point. It indexes documents which contains value as either WKT, Object, String, Array format. It also indexes list of points in all these formats. It supports same parameters as geo_point like ignore_malformed, ignore_z_value, null_value. 
 
### Issues Resolved
https://github.com/opensearch-project/geospatial/issues/95
 
### Check List
- [x] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
