### PR TITLE
Include feature branch in workflow to trigger CI

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -3,9 +3,11 @@ on:
   push:
     branches:
       - "*"
+      - "feature/**"
   pull_request:
     branches:
       - "*"
+      - "feature/**"
 
 jobs:
   Build:


### PR DESCRIPTION
Signed-off-by: Naveen Tatikonda <navtat@amazon.com>

### Description
Include feature branch to trigger CI on `push` and `pull_request` events.
 
### Check List
- [x] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
