### PR TITLE
Add group = 'org.opensearch' to `build.gradle`

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -70,6 +70,7 @@ ext {
 }
 
 allprojects {
+    group = 'org.opensearch'
     version = opensearch_version.tokenize('-')[0] + '.0'
     if (version_qualifier) {
         version += "-${version_qualifier}"

--- a/build.gradle
+++ b/build.gradle
@@ -70,7 +70,7 @@ ext {
 }
 
 allprojects {
-    group = 'org.opensearch'
+    group = opensearch_group
     version = opensearch_version.tokenize('-')[0] + '.0'
     if (version_qualifier) {
         version += "-${version_qualifier}"


### PR DESCRIPTION
Signed-off-by: prudhvigodithi <pgodithi@amazon.com>

### Description
Issue: fixes the following error
```
> Task :publishNebulaPublicationToMavenLocal FAILED
Execution optimizations have been disabled for task ':publishNebulaPublicationToMavenLocal' to ensure correctness due to the following reasons:
  - Gradle detected a problem with the following location: '/Users/balasvij/Documents/WORK/geospatial/build/distributions/opensearch-geospatial-2.2.0.0-SNAPSHOT.pom'. Reason: Task ':publishNebulaPublicationToMavenLocal' uses this output of task ':generatePomFileForPluginZipPublication' without declaring an explicit or implicit dependency. This can lead to incorrect results being produced, depending on what order the tasks are executed. Please refer to https://docs.gradle.org/7.4.1/userguide/validation_problems.html#implicit_dependency for more details about this problem.
```
 
### Issues Resolved
N/A
 
### Check List
- [x] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
