### PR TITLE
Adding gradle task for running integ tests in remote cluster

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -211,6 +211,26 @@ tasks.withType(RestIntegTestTask)*.configure {
     classpath += files(project.configurations.runtimeClasspath.findAll { it.name.contains("log4j-core") })
 }
 
+task integTestRemote(type: RestIntegTestTask) {
+    testClassesDirs = sourceSets.test.output.classesDirs
+    classpath = sourceSets.test.runtimeClasspath
+
+    systemProperty "https", System.getProperty("https")
+    systemProperty "user", System.getProperty("user")
+    systemProperty "password", System.getProperty("password")
+
+    systemProperty 'cluster.number_of_nodes', "${_numNodes}"
+
+    systemProperty 'tests.security.manager', 'false'
+
+    // Run tests with remote cluster only if rest case is defined
+    if (System.getProperty("tests.rest.cluster") != null) {
+        filter {
+            includeTestsMatching "org.opensearch.geospatial.*IT"
+        }
+    }
+}
+
 spotless {
     java {
         removeUnusedImports()


### PR DESCRIPTION
### Description
Adding gradle task for running integ tests in remote cluster
 
### Issues Resolved
#115 
 
### Check List
- [x] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
