### PR TITLE
Update opensearch build name in releases

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -45,7 +45,19 @@ validateNebulaPom.enabled = false
 buildscript {
     ext {
         opensearch_version = System.getProperty("opensearch.version", "2.2.0-SNAPSHOT")
-        version_qualifier = System.getProperty("build.version_qualifier", "")
+        buildVersionQualifier = System.getProperty("build.version_qualifier", "")
+        isSnapshot = "true" == System.getProperty("build.snapshot", "true")
+        // 2.2.0-SNAPSHOT -> 2.2.0.0-SNAPSHOT
+        version_tokens = opensearch_version.tokenize('-')
+        opensearch_build = version_tokens[0] + '.0'
+        plugin_no_snapshot = opensearch_build
+        if (buildVersionQualifier) {
+            opensearch_build += "-${buildVersionQualifier}"
+            plugin_no_snapshot += "-${buildVersionQualifier}"
+        }
+        if (isSnapshot) {
+            opensearch_build += "-SNAPSHOT"
+        }
         opensearch_group = "org.opensearch"
     }
 
@@ -69,13 +81,7 @@ ext {
 
 allprojects {
     group = opensearch_group
-    version = opensearch_version.tokenize('-')[0] + '.0'
-    if (version_qualifier) {
-        version += "-${version_qualifier}"
-    }
-    if (isSnapshot) {
-        version += "-SNAPSHOT"
-    }
+    version = "${opensearch_build}"
     targetCompatibility = JavaVersion.VERSION_11
     sourceCompatibility = JavaVersion.VERSION_11
 }


### PR DESCRIPTION
Signed-off-by: Junqiu Lei <junqiu@amazon.com>

### Description
Update opensearch build name in releases to 2.2 branch, it was merged to main by #119.
 
### Test
```
(base) ➜  geospatial-junqiu git:(update_os_name_2.2) ./gradlew assemble --no-daemon --refresh-dependencies -DskipTests=true
To honour the JVM settings for this build a single-use Daemon process will be forked. See https://docs.gradle.org/7.4.1/userguide/gradle_daemon.html#sec:disabling_the_daemon.
Daemon will be stopped at the end of the build 
=======================================
OpenSearch Build Hamster says Hello!
  Gradle Version        : 7.4.1
  OS Info               : Mac OS X 12.3.1 (x86_64)
  JDK Version           : 11 (Eclipse Temurin JDK)
  JAVA_HOME             : /Library/Java/JavaVirtualMachines/temurin-11.jdk/Contents/Home
  Random Testing Seed   : C24973C818C88780
  In FIPS 140 mode      : false
=======================================

BUILD SUCCESSFUL in 30s
11 actionable tasks: 11 executed
```
 
### Check List
- [ ] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
