### PR TITLE
[Backport 2.x] Add XYPoint Field Type to index and query documents that contains cartesian points

### DIFF
--- a/src/main/java/org/opensearch/geospatial/index/mapper/xypoint/XYPoint.java
+++ b/src/main/java/org/opensearch/geospatial/index/mapper/xypoint/XYPoint.java
@@ -1,0 +1,239 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package org.opensearch.geospatial.index.mapper.xypoint;
+
+import static org.opensearch.index.mapper.AbstractGeometryFieldMapper.Names.IGNORE_Z_VALUE;
+
+import java.io.IOException;
+import java.util.Locale;
+import java.util.Objects;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import org.opensearch.OpenSearchParseException;
+import org.opensearch.common.xcontent.ToXContentFragment;
+import org.opensearch.common.xcontent.XContentBuilder;
+import org.opensearch.geometry.Geometry;
+import org.opensearch.geometry.Point;
+import org.opensearch.geometry.ShapeType;
+import org.opensearch.geometry.utils.StandardValidator;
+import org.opensearch.geometry.utils.WellKnownText;
+import org.opensearch.index.mapper.AbstractPointGeometryFieldMapper;
+
+/**
+ * Represents a point in a 2-dimensional planar coordinate system with no range limitations.
+ */
+@AllArgsConstructor
+@Getter
+@NoArgsConstructor
+public class XYPoint implements AbstractPointGeometryFieldMapper.ParsedPoint, ToXContentFragment {
+    private double x;
+    private double y;
+    private static final String POINT_PRIMITIVE = "point";
+    private static final String X_PARAMETER = "x";
+    private static final String Y_PARAMETER = "y";
+    private static final String XY_POINT = "XY_POINT";
+
+    /**
+     * To set x and y values
+     *
+     * @param x  x coordinate value
+     * @param y  y coordinate value
+     * @return initialized XYPoint
+     */
+    public XYPoint reset(double x, double y) {
+        this.x = x;
+        this.y = y;
+        return this;
+    }
+
+    @Override
+    public void validate(String fieldName) {
+        // validation is not required for xy_point
+    }
+
+    @Override
+    public void normalize(String fieldName) {
+        // normalization is not required for xy_point
+    }
+
+    /**
+     * To set x and y values
+     *
+     * @param x  x coordinate
+     * @param y  y coordinate
+     */
+    @Override
+    public void resetCoords(double x, double y) {
+        this.reset(x, y);
+    }
+
+    /**
+     * @return returns geometry of type point
+     */
+    @Override
+    public Point asGeometry() {
+        return new Point(getX(), getY());
+    }
+
+    /**
+     * Set x and y coordinates of XYPoint if input contains WKT or coordinates.
+     *
+     * @param value  input String which needs to be parsed and validated
+     * @param ignoreZValue  boolean parameter which decides if z coordinate needs to be ignored or not
+     * @return XYPoint after setting the x and y coordinates
+     */
+    public XYPoint resetFromString(String value, final boolean ignoreZValue) {
+        Objects.requireNonNull(value, "input string which needs to be parsed should not be null");
+
+        if (value.toLowerCase(Locale.ROOT).contains(POINT_PRIMITIVE)) {
+            return resetFromWKT(value, ignoreZValue);
+        }
+        return resetFromCoordinates(value, ignoreZValue);
+    }
+
+    /**
+     * Set x and y coordinates of XYPoint if input contains coordinates.
+     *
+     * @param value  input String which contains coordinates that needs to be parsed and validated
+     * @param ignoreZValue  boolean parameter which decides if z coordinate needs to be ignored or not
+     * @return XYPoint after setting the x and y coordinates
+     * throws OpenSearchParseException
+     */
+    public XYPoint resetFromCoordinates(String value, final boolean ignoreZValue) {
+        Objects.requireNonNull(value, "input string which needs to be parsed should not be null");
+
+        String[] values = value.split(",");
+        int numOfValues = values.length;
+
+        if (numOfValues > 3) {
+            throw new OpenSearchParseException("expected 2 or 3 coordinates, but found: [{}]", values.length);
+        }
+
+        if (numOfValues > 2) {
+            assertZValue(ignoreZValue, Double.parseDouble(values[2].trim()));
+        }
+
+        double x = parseCoordinate(values[0], X_PARAMETER);
+        double y = parseCoordinate(values[1], Y_PARAMETER);
+
+        return reset(x, y);
+    }
+
+    /**
+     * Parse and extract coordinate value from given String.
+     *
+     * @param value  input String which contains coordinate that needs to be parsed and validated
+     * @param parameter  x or y parameter
+     * @return parsed coordinate value
+     * throws OpenSearchParseException
+     */
+    private double parseCoordinate(String value, String parameter) {
+        try {
+            return Double.parseDouble(value.trim());
+        } catch (NumberFormatException ex) {
+            throw new OpenSearchParseException("[{}] must be a number", parameter, ex);
+        }
+    }
+
+    /**
+     * Set x and y coordinates of XYPoint if input contains WKT POINT.
+     *
+     * @param value  input String which contains WKT POINT that needs to be parsed and validated
+     * @param ignoreZValue  boolean parameter which decides if z coordinate needs to be ignored or not
+     * @return XYPoint after setting the x and y coordinates
+     * throws OpenSearchParseException
+     */
+    private XYPoint resetFromWKT(String value, boolean ignoreZValue) {
+        Geometry geometry;
+        try {
+            geometry = new WellKnownText(false, new StandardValidator(ignoreZValue)).fromWKT(value);
+        } catch (Exception e) {
+            throw new OpenSearchParseException("Invalid WKT format, [{}]", value, e);
+        }
+        if (geometry.type() != ShapeType.POINT) {
+            throw new OpenSearchParseException("[xy_point] supports only POINT among WKT primitives, but found [{}]", geometry.type());
+        }
+        Point point = (Point) geometry;
+        return reset(point.getY(), point.getX());
+    }
+
+    /**
+     * Validates if z coordinate value needs to be ignored or not.
+     *
+     * @param ignoreZValue  boolean parameter which decides if z coordinate needs to be ignored or not
+     * @param zValue  z coordinate value
+     * throws OpenSearchParseException
+     */
+    public static void assertZValue(boolean ignoreZValue, double zValue) {
+        if (!ignoreZValue) {
+            throw new OpenSearchParseException(
+                "Exception parsing coordinates: found Z value [{}] but [{}] parameter is [{}]",
+                zValue,
+                IGNORE_Z_VALUE,
+                ignoreZValue
+            );
+        }
+    }
+
+    /**
+     * Deep Comparison to compare object of XYPoint class w.r.t state of the object
+     *
+     * @param obj  Object
+     * @return true if the parameter obj is of type XYPoint and its data members (x and y) are same, else false
+     */
+    @Override
+    public boolean equals(Object obj) {
+        if (this == obj) return true;
+        if (!(obj instanceof XYPoint)) return false;
+        XYPoint point = (XYPoint) obj;
+        return point.x == x && point.y == y;
+    }
+
+    /**
+     * This method returns the hash code value for the object on which this method is invoked.
+     *
+     * @return hashcode value as an Integer
+     */
+    @Override
+    public int hashCode() {
+        int result = Double.hashCode(x);
+        result = 31 * result + Double.hashCode(y);
+        return result;
+    }
+
+    /**
+     * String representation of XYPoint object.
+     *
+     * @return XYPoint object as "Point(x,y)" where x and y are coordinate values
+     */
+    @Override
+    public String toString() {
+        StringBuilder sb = new StringBuilder();
+        sb.append(XY_POINT);
+        sb.append('(');
+        sb.append(x);
+        sb.append(",");
+        sb.append(y);
+        sb.append(')');
+        return sb.toString();
+    }
+
+    /**
+     * Return x and y coordinates in the object form.
+     *
+     * @param builder  XContentBuilder object
+     * @param params  Params object
+     * @return x and y coordinates in the object form. For example: {"x" : 100.35, "y" : -200.54}
+     * @throws IOException
+     */
+    @Override
+    public XContentBuilder toXContent(XContentBuilder builder, Params params) throws IOException {
+        return builder.startObject().field(X_PARAMETER, x).field(Y_PARAMETER, y).endObject();
+    }
+}

--- a/src/main/java/org/opensearch/geospatial/index/mapper/xypoint/XYPointFieldMapper.java
+++ b/src/main/java/org/opensearch/geospatial/index/mapper/xypoint/XYPointFieldMapper.java
@@ -1,0 +1,190 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package org.opensearch.geospatial.index.mapper.xypoint;
+
+import java.util.List;
+import java.util.Map;
+import java.util.Objects;
+
+import org.apache.lucene.document.FieldType;
+import org.apache.lucene.document.StoredField;
+import org.apache.lucene.document.XYDocValuesField;
+import org.apache.lucene.geo.XYPoint;
+import org.apache.lucene.index.IndexOptions;
+import org.apache.lucene.index.IndexableField;
+import org.apache.lucene.search.Query;
+import org.opensearch.common.Explicit;
+import org.opensearch.common.geo.ShapeRelation;
+import org.opensearch.geometry.Geometry;
+import org.opensearch.geospatial.index.mapper.xyshape.XYShapeQueryable;
+import org.opensearch.geospatial.index.query.xypoint.XYPointQueryProcessor;
+import org.opensearch.index.mapper.AbstractPointGeometryFieldMapper;
+import org.opensearch.index.mapper.MappedFieldType;
+import org.opensearch.index.mapper.ParseContext;
+import org.opensearch.index.query.QueryShardContext;
+
+/**
+ *  FieldMapper for indexing {@link XYPoint} points
+ */
+public class XYPointFieldMapper extends AbstractPointGeometryFieldMapper<
+    List<org.opensearch.geospatial.index.mapper.xypoint.XYPoint>,
+    List<? extends XYPoint>> {
+    public static final String CONTENT_TYPE = "xy_point";
+    private static final FieldType FIELD_TYPE = new FieldType();
+
+    static {
+        FIELD_TYPE.setStored(false);
+        FIELD_TYPE.setIndexOptions(IndexOptions.DOCS);
+        FIELD_TYPE.freeze();
+    }
+
+    private XYPointFieldMapper(
+        String simpleName,
+        FieldType fieldType,
+        MappedFieldType mappedFieldType,
+        MultiFields multiFields,
+        Explicit<Boolean> ignoreMalformed,
+        Explicit<Boolean> ignoreZValue,
+        ParsedPoint nullValue,
+        CopyTo copyTo
+    ) {
+        super(simpleName, fieldType, mappedFieldType, multiFields, ignoreMalformed, ignoreZValue, nullValue, copyTo);
+    }
+
+    @Override
+    protected void addStoredFields(ParseContext context, List<? extends XYPoint> points) {
+        for (XYPoint point : points) {
+            context.doc().add(new StoredField(fieldType().name(), point.toString()));
+        }
+    }
+
+    @Override
+    protected void addDocValuesFields(String name, List<? extends XYPoint> points, List<IndexableField> fields, ParseContext context) {
+        for (XYPoint point : points) {
+            context.doc().add(new XYDocValuesField(fieldType().name(), point.getX(), point.getY()));
+        }
+    }
+
+    @Override
+    protected void addMultiFields(ParseContext context, List<? extends XYPoint> points) {
+        // Any other fields will not be added
+    }
+
+    @Override
+    protected String contentType() {
+        return CONTENT_TYPE;
+    }
+
+    @Override
+    public XYPointFieldType fieldType() {
+        return (XYPointFieldType) mappedFieldType;
+    }
+
+    /**
+     * Builder class to create an instance of {@link XYPointFieldMapper}
+     */
+    public static class XYPointFieldMapperBuilder extends AbstractPointGeometryFieldMapper.Builder<
+        XYPointFieldMapperBuilder,
+        XYPointFieldType> {
+
+        public XYPointFieldMapperBuilder(String fieldName) {
+            super(fieldName, FIELD_TYPE);
+            this.hasDocValues = true;
+        }
+
+        /**
+         * Set the GeometryParser and GeometryIndexer for XYPointFieldType and create an instance of XYPointFieldMapper
+         *
+         * The point {@link org.opensearch.geospatial.index.mapper.xypoint.XYPoint} sent as a parameter by
+         * {@link AbstractPointGeometryFieldMapper} to PointParser is of no use and can be ignored.
+         *
+         * @param context  BuilderContext
+         * @param simpleName  field name
+         * @param fieldType  indicates the kind of data the field contains
+         * @param multiFields  used to index same field in different ways for different purposes
+         * @param ignoreMalformed  if true, malformed points are ignored else. If false(default) malformed points throw an exception
+         * @param ignoreZValue  if true (default), third dimension is ignored. If false, points containing more than two dimension throw an exception
+         * @param nullValue  used as a substitute for any explicit null values
+         * @param copyTo  CopyTo instance
+         * @return instance of XYPointFieldMapper
+         */
+        @Override
+        public XYPointFieldMapper build(
+            BuilderContext context,
+            String simpleName,
+            FieldType fieldType,
+            MultiFields multiFields,
+            Explicit<Boolean> ignoreMalformed,
+            Explicit<Boolean> ignoreZValue,
+            ParsedPoint nullValue,
+            CopyTo copyTo
+        ) {
+            var processor = new XYPointQueryProcessor();
+            var xyPointFieldType = new XYPointFieldType(
+                buildFullName(context),
+                indexed,
+                this.fieldType.stored(),
+                hasDocValues,
+                meta,
+                processor
+            );
+
+            xyPointFieldType.setGeometryParser(
+                new PointParser<>(
+                    name,
+                    org.opensearch.geospatial.index.mapper.xypoint.XYPoint::new,
+                    (parser, point) -> XYPointParser.parseXYPoint(parser, ignoreZValue().value()),
+                    (org.opensearch.geospatial.index.mapper.xypoint.XYPoint) nullValue,
+                    ignoreZValue.value(),
+                    ignoreMalformed.value()
+                )
+            );
+            xyPointFieldType.setGeometryIndexer(new XYPointIndexer(xyPointFieldType.name()));
+            return new XYPointFieldMapper(name, fieldType, xyPointFieldType, multiFields, ignoreMalformed, ignoreZValue, nullValue, copyTo);
+        }
+    }
+
+    /**
+     * Concrete field type for xy_point
+     */
+    public static class XYPointFieldType extends AbstractPointGeometryFieldType<
+        List<org.opensearch.geospatial.index.mapper.xypoint.XYPoint>,
+        List<? extends XYPoint>> implements XYShapeQueryable {
+        private final XYPointQueryProcessor queryProcessor;
+
+        public XYPointFieldType(
+            String name,
+            boolean indexed,
+            boolean stored,
+            boolean hasDocValues,
+            Map<String, String> meta,
+            XYPointQueryProcessor processor
+        ) {
+            super(name, indexed, stored, hasDocValues, meta);
+            this.queryProcessor = Objects.requireNonNull(processor, "query processor cannot be null");
+        }
+
+        @Override
+        public String typeName() {
+            return CONTENT_TYPE;
+        }
+
+        /**
+         * Finds all previously indexed shapes that comply the given {@link ShapeRelation} with
+         * the specified {@link Geometry}.
+         *
+         * @param geometry  query parameter to search indexed points
+         * @param fieldName field name that contains indexed points
+         * @param relation  relation between search shape and indexed points
+         * @param context   instance of {@link QueryShardContext}
+         * @return Lucene {@link Query} to find indexed points based on given geometry
+         */
+        @Override
+        public Query shapeQuery(Geometry geometry, String fieldName, ShapeRelation relation, QueryShardContext context) {
+            return queryProcessor.shapeQuery(geometry, fieldName, relation, context);
+        }
+    }
+}

--- a/src/main/java/org/opensearch/geospatial/index/mapper/xypoint/XYPointFieldTypeParser.java
+++ b/src/main/java/org/opensearch/geospatial/index/mapper/xypoint/XYPointFieldTypeParser.java
@@ -1,0 +1,41 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package org.opensearch.geospatial.index.mapper.xypoint;
+
+import java.util.Map;
+
+import org.opensearch.index.mapper.AbstractPointGeometryFieldMapper;
+
+/**
+ * XYPointFieldTypeParser is used to parse and validate mapping parameters
+ */
+public class XYPointFieldTypeParser extends AbstractPointGeometryFieldMapper.TypeParser {
+    /**
+     * Invoke XYPointFieldMapperBuilder constructor and return object.
+     *
+     * @param name  field name
+     * @param params  parameters
+     * @return invoked XYPointFieldMapperBuilder object
+     */
+    @Override
+    protected AbstractPointGeometryFieldMapper.Builder newBuilder(String name, Map params) {
+        return new XYPointFieldMapper.XYPointFieldMapperBuilder(name);
+    }
+
+    /**
+     * Parse nullValue and reset XYPoint.
+     *
+     * @param nullValue  null_value parameter value used as a substitute for any explicit null values
+     * @param ignoreZValue  if true (default), third dimension is ignored. If false, points containing more than two dimension throw an exception
+     * @param ignoreMalformed  if true, malformed points are ignored else. If false(default) malformed points throw an exception
+     * @return XYPoint after parsing null_value and resetting coordinates
+     */
+    @Override
+    protected XYPoint parseNullValue(Object nullValue, boolean ignoreZValue, boolean ignoreMalformed) {
+        return XYPointParser.parseXYPoint(nullValue, ignoreZValue);
+    }
+
+}

--- a/src/main/java/org/opensearch/geospatial/index/mapper/xypoint/XYPointIndexer.java
+++ b/src/main/java/org/opensearch/geospatial/index/mapper/xypoint/XYPointIndexer.java
@@ -1,0 +1,70 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package org.opensearch.geospatial.index.mapper.xypoint;
+
+import java.util.List;
+import java.util.Objects;
+import java.util.stream.Collectors;
+
+import lombok.AllArgsConstructor;
+
+import org.apache.lucene.document.XYPointField;
+import org.apache.lucene.geo.XYPoint;
+import org.apache.lucene.index.IndexableField;
+import org.opensearch.geometry.Point;
+import org.opensearch.geospatial.index.common.xyshape.XYShapeConverter;
+import org.opensearch.index.mapper.AbstractGeometryFieldMapper;
+import org.opensearch.index.mapper.ParseContext;
+
+/**
+ * Converts points into Lucene-compatible form{@link XYPoint} for indexing in a xy_point field.
+ */
+@AllArgsConstructor
+public class XYPointIndexer
+    implements
+        AbstractGeometryFieldMapper.Indexer<List<org.opensearch.geospatial.index.mapper.xypoint.XYPoint>, List<? extends XYPoint>> {
+    private final String fieldName;
+
+    /**
+     * Converts the list of {@link org.opensearch.geospatial.index.mapper.xypoint.XYPoint} to list of {@link XYPoint}
+     * @param points list of {@link org.opensearch.geospatial.index.mapper.xypoint.XYPoint}
+     * @return list of {@link XYPoint} that are converted from opensearch to lucene type
+     */
+    @Override
+    public List<? extends XYPoint> prepareForIndexing(List<org.opensearch.geospatial.index.mapper.xypoint.XYPoint> points) {
+        Objects.requireNonNull(points, "XYPoint cannot be null");
+
+        if (points.isEmpty()) {
+            throw new IllegalArgumentException("XYPoint cannot be empty");
+        }
+
+        return points.stream()
+            .map(parsedXYPoint -> new Point(parsedXYPoint.getX(), parsedXYPoint.getY()))
+            .map(XYShapeConverter::toXYPoint)
+            .collect(Collectors.toList());
+    }
+
+    /**
+     * @return processed class type
+     */
+    @Override
+    public Class<List<? extends XYPoint>> processedClass() {
+        Object listToObjectClass = List.class;
+        return (Class<List<? extends XYPoint>>) listToObjectClass.getClass();
+    }
+
+    /**
+     * converts the List of {@link XYPoint} to list of {@link IndexableField}.
+     * The {@link IndexableField} returned are of type {@link XYPointField}
+     * @param context {@link ParseContext}
+     * @param xyPoints {@link XYPoint} list
+     * @return List of {@link IndexableField}
+     */
+    @Override
+    public List<IndexableField> indexShape(ParseContext context, List<? extends XYPoint> xyPoints) {
+        return xyPoints.stream().map(xyPoint -> new XYPointField(fieldName, xyPoint.getX(), xyPoint.getY())).collect(Collectors.toList());
+    }
+}

--- a/src/main/java/org/opensearch/geospatial/index/mapper/xypoint/XYPointParser.java
+++ b/src/main/java/org/opensearch/geospatial/index/mapper/xypoint/XYPointParser.java
@@ -1,0 +1,171 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package org.opensearch.geospatial.index.mapper.xypoint;
+
+import java.io.IOException;
+import java.util.Collections;
+import java.util.Objects;
+
+import org.opensearch.OpenSearchParseException;
+import org.opensearch.common.xcontent.LoggingDeprecationHandler;
+import org.opensearch.common.xcontent.NamedXContentRegistry;
+import org.opensearch.common.xcontent.XContentParser;
+import org.opensearch.common.xcontent.XContentSubParser;
+import org.opensearch.common.xcontent.support.MapXContentParser;
+
+/**
+ * Parse the value and set XYPoint represented as a String, Object, WKT, array.
+ */
+public class XYPointParser {
+    private static final String X_PARAMETER = "x";
+    private static final String Y_PARAMETER = "y";
+    private static final String NULL_VALUE_PARAMETER = "null_value";
+    private static final Boolean TRUE = true;
+
+    /**
+     * Parses the value and set XYPoint which was represented as an object.
+     *
+     * @param value  input which needs to be parsed which contains x and y coordinates in object form
+     * @param ignoreZValue  boolean parameter which decides if third coordinate needs to be ignored or not
+     * @return {@link XYPoint} after setting the x and y coordinates parsed from the parse
+     * @throws OpenSearchParseException
+     */
+    public static XYPoint parseXYPoint(Object value, final boolean ignoreZValue) throws OpenSearchParseException {
+        Objects.requireNonNull(value, "input value which needs to be parsed should not be null");
+
+        try (
+            XContentParser parser = new MapXContentParser(
+                NamedXContentRegistry.EMPTY,
+                LoggingDeprecationHandler.INSTANCE,
+                Collections.singletonMap(NULL_VALUE_PARAMETER, value),
+                null
+            )
+        ) {
+            parser.nextToken(); // start object
+            parser.nextToken(); // field name
+            parser.nextToken(); // field value
+            return parseXYPoint(parser, ignoreZValue);
+        } catch (IOException ex) {
+            throw new OpenSearchParseException("error parsing xy_point", ex);
+        }
+    }
+
+    /**
+     * Parse the values to set the XYPoint which was represented as a String, Object, WKT or an array.
+     *
+     * <ul>
+     *     <li> String: "100.35, -200.54" </li>
+     *     <li> Object: {"x" : 100.35, "y" : -200.54} </li>
+     *     <li> WKT: "POINT (-200.54 100.35)"</li>
+     *     <li> Array: [ -200.54, 100.35 ]</li>
+     * </ul>
+     *
+     * @param parser  {@link XContentParser} to parse the value from
+     * @param ignoreZValue  boolean parameter which decides if third coordinate needs to be ignored or not
+     * @return {@link XYPoint} after setting the x and y coordinates parsed from the parse
+     * @throws IOException
+     * @throws OpenSearchParseException
+     */
+    public static XYPoint parseXYPoint(XContentParser parser, final boolean ignoreZValue) throws IOException, OpenSearchParseException {
+        Objects.requireNonNull(parser, "parser should not be null");
+
+        XYPoint point = new XYPoint();
+        double x = Double.NaN;
+        double y = Double.NaN;
+
+        if (parser.currentToken() == XContentParser.Token.START_OBJECT) {
+            try (XContentSubParser subParser = new XContentSubParser(parser)) {
+                while (subParser.nextToken() != XContentParser.Token.END_OBJECT) {
+                    if (subParser.currentToken() != XContentParser.Token.FIELD_NAME) {
+                        throw new OpenSearchParseException("token [{}] not allowed", subParser.currentToken());
+                    }
+                    String field = subParser.currentName();
+                    if (!(X_PARAMETER.equals(field) || Y_PARAMETER.equals(field))) {
+                        throw new OpenSearchParseException("field must be either [{}] or [{}]", X_PARAMETER, Y_PARAMETER);
+                    }
+                    if (X_PARAMETER.equals(field)) {
+                        subParser.nextToken();
+                        switch (subParser.currentToken()) {
+                            case VALUE_NUMBER:
+                            case VALUE_STRING:
+                                try {
+                                    x = subParser.doubleValue(TRUE);
+                                } catch (NumberFormatException numberFormatException) {
+                                    throw new OpenSearchParseException("[x] must be valid double value", numberFormatException);
+                                }
+                                break;
+                            default:
+                                throw new OpenSearchParseException("[x] must be a number");
+                        }
+                    }
+                    if (Y_PARAMETER.equals(field)) {
+                        subParser.nextToken();
+                        switch (subParser.currentToken()) {
+                            case VALUE_NUMBER:
+                            case VALUE_STRING:
+                                try {
+                                    y = subParser.doubleValue(TRUE);
+                                } catch (NumberFormatException numberFormatException) {
+                                    throw new OpenSearchParseException("[y] must be valid double value", numberFormatException);
+                                }
+                                break;
+                            default:
+                                throw new OpenSearchParseException("[y] must be a number");
+                        }
+                    }
+                }
+            }
+            if (Double.isNaN(x)) {
+                throw new OpenSearchParseException("field [{}] missing", X_PARAMETER);
+            }
+            if (Double.isNaN(y)) {
+                throw new OpenSearchParseException("field [{}] missing", Y_PARAMETER);
+            }
+            return point.reset(x, y);
+        }
+
+        if (parser.currentToken() == XContentParser.Token.START_ARRAY) {
+            return parseXYPointArray(parser, ignoreZValue, x, y);
+        }
+
+        if (parser.currentToken() == XContentParser.Token.VALUE_STRING) {
+            String val = parser.text();
+            return point.resetFromString(val, ignoreZValue);
+        }
+        throw new OpenSearchParseException("Expected xy_point. But, the provided mapping is not of type xy_point");
+    }
+
+    /**
+     * Parse the values to set the XYPoint which was represented as an array.
+     *
+     * @param subParser  {@link XContentParser} to parse the values from an array
+     * @param ignoreZValue  boolean parameter which decides if third coordinate needs to be ignored or not
+     * @param x  x coordinate that will be set by parsing the value from array
+     * @param y  y coordinate that will be set by parsing the value from array
+     * @return {@link XYPoint} after setting the x and y coordinates parsed from the parse
+     * @throws IOException
+     */
+    private static XYPoint parseXYPointArray(XContentParser subParser, final boolean ignoreZValue, double x, double y) throws IOException {
+        XYPoint point = new XYPoint();
+        int element = 0;
+        while (subParser.nextToken() != XContentParser.Token.END_ARRAY) {
+            if (subParser.currentToken() != XContentParser.Token.VALUE_NUMBER) {
+                throw new OpenSearchParseException("numeric value expected");
+            }
+            element++;
+            if (element == 1) {
+                y = subParser.doubleValue();
+            } else if (element == 2) {
+                x = subParser.doubleValue();
+            } else if (element == 3) {
+                XYPoint.assertZValue(ignoreZValue, subParser.doubleValue());
+            } else {
+                throw new OpenSearchParseException("[xy_point] field type does not accept more than 3 dimensions");
+            }
+        }
+        return point.reset(x, y);
+    }
+}

--- a/src/main/java/org/opensearch/geospatial/index/query/xypoint/XYPointQueryProcessor.java
+++ b/src/main/java/org/opensearch/geospatial/index/query/xypoint/XYPointQueryProcessor.java
@@ -1,0 +1,65 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package org.opensearch.geospatial.index.query.xypoint;
+
+import java.util.Locale;
+
+import org.apache.lucene.search.Query;
+import org.opensearch.common.geo.ShapeRelation;
+import org.opensearch.geometry.Geometry;
+import org.opensearch.geospatial.index.mapper.xypoint.XYPointFieldMapper;
+import org.opensearch.index.query.QueryShardContext;
+import org.opensearch.index.query.QueryShardException;
+
+/**
+ * Query Processor to convert given Geometry into Lucene query
+ */
+public class XYPointQueryProcessor {
+    /**
+     * Creates a {@link Query} that matches all indexed shapes to the provided {@link Geometry}  based on {@link ShapeRelation}
+     *
+     * @param shape  OpenSearch {@link Geometry} as an input
+     * @param fieldName  field name that contains indexed points
+     * @param relation  Relation to be used to get all points from given Geometry
+     * @param context  QueryShardContext instance
+     * @return {@link Query} instance from XYPointField.XYPointInGeometryQuery
+     */
+    public Query shapeQuery(Geometry shape, String fieldName, ShapeRelation relation, QueryShardContext context) {
+        validateIsXYPointFieldType(fieldName, context);
+        // XYPoint only support "intersects" spatial relation which returns points that are on the edge and inside the given geometry
+        if (relation != ShapeRelation.INTERSECTS) {
+            throw new QueryShardException(
+                context,
+                String.format(Locale.ROOT, "[%s] query relation not supported for Field [%s]", relation, fieldName)
+            );
+        }
+
+        return getVectorQueryFromShape(shape, fieldName, context);
+    }
+
+    private void validateIsXYPointFieldType(String fieldName, QueryShardContext context) {
+        var fieldType = context.fieldMapper(fieldName);
+        if (fieldType instanceof XYPointFieldMapper.XYPointFieldType) {
+            return;
+        }
+
+        throw new QueryShardException(
+            context,
+            String.format(
+                Locale.ROOT,
+                "Expected [%s] field type for Field [%s] but found [%s]",
+                XYPointFieldMapper.CONTENT_TYPE,
+                fieldName,
+                fieldType.typeName()
+            )
+        );
+    }
+
+    protected Query getVectorQueryFromShape(Geometry queryShape, String fieldName, QueryShardContext context) {
+        var xyPointQueryVisitor = new XYPointQueryVisitor(fieldName, context.fieldMapper(fieldName), context);
+        return queryShape.visit(xyPointQueryVisitor);
+    }
+}

--- a/src/main/java/org/opensearch/geospatial/index/query/xypoint/XYPointQueryVisitor.java
+++ b/src/main/java/org/opensearch/geospatial/index/query/xypoint/XYPointQueryVisitor.java
@@ -1,0 +1,206 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package org.opensearch.geospatial.index.query.xypoint;
+
+import static org.opensearch.geospatial.index.common.xyshape.XYShapeConverter.toXYCircle;
+import static org.opensearch.geospatial.index.common.xyshape.XYShapeConverter.toXYPolygon;
+import static org.opensearch.geospatial.index.common.xyshape.XYShapeConverter.toXYRectangle;
+
+import java.util.Collections;
+import java.util.Locale;
+import java.util.Objects;
+
+import lombok.AllArgsConstructor;
+
+import org.apache.lucene.document.XYDocValuesField;
+import org.apache.lucene.document.XYPointField;
+import org.apache.lucene.geo.XYCircle;
+import org.apache.lucene.geo.XYPolygon;
+import org.apache.lucene.geo.XYRectangle;
+import org.apache.lucene.search.BooleanClause;
+import org.apache.lucene.search.BooleanQuery;
+import org.apache.lucene.search.IndexOrDocValuesQuery;
+import org.apache.lucene.search.MatchNoDocsQuery;
+import org.apache.lucene.search.Query;
+import org.opensearch.geometry.Circle;
+import org.opensearch.geometry.Geometry;
+import org.opensearch.geometry.GeometryCollection;
+import org.opensearch.geometry.GeometryVisitor;
+import org.opensearch.geometry.Line;
+import org.opensearch.geometry.LinearRing;
+import org.opensearch.geometry.MultiLine;
+import org.opensearch.geometry.MultiPoint;
+import org.opensearch.geometry.MultiPolygon;
+import org.opensearch.geometry.Point;
+import org.opensearch.geometry.Polygon;
+import org.opensearch.geometry.Rectangle;
+import org.opensearch.geometry.ShapeType;
+import org.opensearch.index.mapper.MappedFieldType;
+import org.opensearch.index.query.QueryShardContext;
+import org.opensearch.index.query.QueryShardException;
+
+/**
+ * Geometry Visitor to create a query to find all cartesian XYPoints
+ * that comply ShapeRelation with all other XYShapes objects
+ */
+@AllArgsConstructor
+public class XYPointQueryVisitor implements GeometryVisitor<Query, RuntimeException> {
+    private final String fieldName;
+    private final MappedFieldType fieldType;
+    private final QueryShardContext context;
+
+    /**
+     * @param line  input geometry {@link Line}
+     * @return {@link Query} instance from XYPointField.XYPointInGeometryQuery
+     * throws QueryShardException
+     */
+    @Override
+    public Query visit(Line line) {
+        return geometryNotSupported(ShapeType.LINESTRING);
+    }
+
+    /**
+     * @param ring  input geometry {@link LinearRing}
+     * @return {@link Query} instance from XYPointField.XYPointInGeometryQuery
+     * throws QueryShardException
+     */
+    @Override
+    public Query visit(LinearRing ring) {
+        return geometryNotSupported(ShapeType.LINEARRING);
+    }
+
+    /**
+     * @param multiLine  input geometry {@link MultiLine}
+     * @return {@link Query} instance from XYPointField.XYPointInGeometryQuery
+     * throws QueryShardException
+     */
+    @Override
+    public Query visit(MultiLine multiLine) {
+        return geometryNotSupported(ShapeType.MULTILINESTRING);
+    }
+
+    /**
+     * @param multiPoint  input geometry {@link MultiPoint}
+     * @return {@link Query} instance from XYPointField.XYPointInGeometryQuery
+     * throws QueryShardException
+     */
+    @Override
+    public Query visit(MultiPoint multiPoint) {
+        return geometryNotSupported(ShapeType.MULTIPOINT);
+    }
+
+    /**
+     * @param point  input geometry {@link Point}
+     * @return {@link Query} instance from XYPointField.XYPointInGeometryQuery
+     * throws QueryShardException
+     */
+    @Override
+    public Query visit(Point point) {
+        return geometryNotSupported(ShapeType.POINT);
+    }
+
+    /**
+     * @param circle  input geometry {@link Circle}
+     * @return {@link Query} instance from XYPointField.XYPointInGeometryQuery
+     * throws QueryShardException
+     */
+    @Override
+    public Query visit(Circle circle) throws RuntimeException {
+        Objects.requireNonNull(circle, "Circle cannot be null");
+        XYCircle xyCircle = toXYCircle(circle);
+        var query = XYPointField.newDistanceQuery(fieldName, xyCircle.getX(), xyCircle.getY(), xyCircle.getRadius());
+        if (!fieldType.hasDocValues()) {
+            return query;
+        }
+
+        var dvQuery = XYDocValuesField.newSlowDistanceQuery(fieldName, xyCircle.getX(), xyCircle.getY(), xyCircle.getRadius());
+        return new IndexOrDocValuesQuery(query, dvQuery);
+    }
+
+    /**
+     * @param rectangle  input geometry {@link Rectangle}
+     * @return {@link Query} instance from XYPointField.XYPointInGeometryQuery
+     */
+    @Override
+    public Query visit(Rectangle rectangle) {
+        Objects.requireNonNull(rectangle, "Rectangle cannot be null");
+        XYRectangle xyRectangle = toXYRectangle(rectangle);
+        var query = XYPointField.newBoxQuery(fieldName, xyRectangle.minX, xyRectangle.maxX, xyRectangle.minY, xyRectangle.maxY);
+        if (!fieldType.hasDocValues()) {
+            return query;
+        }
+
+        var dvQuery = XYDocValuesField.newSlowBoxQuery(fieldName, xyRectangle.minX, xyRectangle.maxX, xyRectangle.minY, xyRectangle.maxY);
+        return new IndexOrDocValuesQuery(query, dvQuery);
+    }
+
+    /**
+     * @param multiPolygon  input geometry {@link MultiPolygon}
+     * @return {@link Query} instance from XYPointField.XYPointInGeometryQuery
+     */
+    @Override
+    public Query visit(MultiPolygon multiPolygon) {
+        Objects.requireNonNull(multiPolygon, "Multi Polygon cannot be null");
+        return visitCollection(multiPolygon);
+    }
+
+    /**
+     * @param polygon  input geometry {@link Polygon}
+     * @return {@link Query} instance from XYPointField.XYPointInGeometryQuery
+     */
+    @Override
+    public Query visit(Polygon polygon) {
+        Objects.requireNonNull(polygon, "Polygon cannot be null");
+        return visitCollection(new GeometryCollection(Collections.singletonList(polygon)));
+    }
+
+    /**
+     * @param collection  input geometry {@link GeometryCollection}
+     * @return {@link Query} instance from XYPointField.XYPointInGeometryQuery
+     */
+    @Override
+    public Query visit(GeometryCollection<?> collection) {
+        if (collection.isEmpty()) {
+            return new MatchNoDocsQuery();
+        }
+        var booleanQueryBuilder = new BooleanQuery.Builder();
+        visit(booleanQueryBuilder, collection);
+        return booleanQueryBuilder.build();
+    }
+
+    private void visit(BooleanQuery.Builder booleanQueryBuilder, GeometryCollection<?> collection) {
+        var occur = BooleanClause.Occur.FILTER;
+        for (Geometry shape : collection) {
+            booleanQueryBuilder.add(shape.visit(this), occur);
+        }
+    }
+
+    private Query visitCollection(GeometryCollection<Polygon> collection) {
+        if (collection.isEmpty()) {
+            return new MatchNoDocsQuery();
+        }
+
+        XYPolygon[] xyPolygons = new XYPolygon[collection.size()];
+        for (int i = 0; i < collection.size(); i++) {
+            xyPolygons[i] = toXYPolygon(collection.get(i));
+        }
+
+        var query = XYPointField.newPolygonQuery(fieldName, xyPolygons);
+        if (!fieldType.hasDocValues()) {
+            return query;
+        }
+
+        var dvQuery = XYDocValuesField.newSlowPolygonQuery(fieldName, xyPolygons);
+        return new IndexOrDocValuesQuery(query, dvQuery);
+    }
+
+    private Query geometryNotSupported(ShapeType shapeType) {
+        throw new QueryShardException(
+            context,
+            String.format(Locale.getDefault(), "Field [%s] found an unsupported shape [%s]", fieldName, shapeType.name())
+        );
+    }
+}

--- a/src/main/java/org/opensearch/geospatial/plugin/GeospatialPlugin.java
+++ b/src/main/java/org/opensearch/geospatial/plugin/GeospatialPlugin.java
@@ -27,6 +27,8 @@ import org.opensearch.env.Environment;
 import org.opensearch.env.NodeEnvironment;
 import org.opensearch.geospatial.action.upload.geojson.UploadGeoJSONAction;
 import org.opensearch.geospatial.action.upload.geojson.UploadGeoJSONTransportAction;
+import org.opensearch.geospatial.index.mapper.xypoint.XYPointFieldMapper;
+import org.opensearch.geospatial.index.mapper.xypoint.XYPointFieldTypeParser;
 import org.opensearch.geospatial.index.mapper.xyshape.XYShapeFieldMapper;
 import org.opensearch.geospatial.index.mapper.xyshape.XYShapeFieldTypeParser;
 import org.opensearch.geospatial.index.query.xyshape.XYShapeQueryBuilder;
@@ -105,7 +107,12 @@ public class GeospatialPlugin extends Plugin implements IngestPlugin, ActionPlug
 
     @Override
     public Map<String, Mapper.TypeParser> getMappers() {
-        return Map.of(XYShapeFieldMapper.CONTENT_TYPE, new XYShapeFieldTypeParser());
+        return Map.of(
+            XYShapeFieldMapper.CONTENT_TYPE,
+            new XYShapeFieldTypeParser(),
+            XYPointFieldMapper.CONTENT_TYPE,
+            new XYPointFieldTypeParser()
+        );
     }
 
     @Override

--- a/src/test/java/org/opensearch/geospatial/index/common/xyshape/ShapeObjectBuilder.java
+++ b/src/test/java/org/opensearch/geospatial/index/common/xyshape/ShapeObjectBuilder.java
@@ -15,6 +15,7 @@ import java.util.List;
 import java.util.stream.Collectors;
 import java.util.stream.IntStream;
 
+import org.apache.lucene.geo.XYPoint;
 import org.opensearch.common.Randomness;
 import org.opensearch.common.geo.ShapeRelation;
 import org.opensearch.geo.GeometryTestUtils;
@@ -206,6 +207,17 @@ public class ShapeObjectBuilder {
             }
         }
         throw new RuntimeException("failed to generate random geometry");
+    }
+
+    public static List<XYPoint> getRandomXYPoints(int size, boolean hasZCoords) {
+        List<XYPoint> xyPoints = new ArrayList<>();
+
+        for (int i = 0; i < size; i++) {
+            Point point = randomPoint(hasZCoords);
+            XYPoint xyPoint = new XYPoint((float) point.getX(), (float) point.getY());
+            xyPoints.add(xyPoint);
+        }
+        return xyPoints;
     }
 
 }

--- a/src/test/java/org/opensearch/geospatial/index/mapper/xypoint/XYPointFieldMapperIT.java
+++ b/src/test/java/org/opensearch/geospatial/index/mapper/xypoint/XYPointFieldMapperIT.java
@@ -1,0 +1,110 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package org.opensearch.geospatial.index.mapper.xypoint;
+
+import java.io.IOException;
+import java.util.List;
+import java.util.Locale;
+import java.util.Map;
+
+import org.opensearch.common.settings.Settings;
+import org.opensearch.geometry.Geometry;
+import org.opensearch.geometry.Point;
+import org.opensearch.geospatial.GeospatialRestTestCase;
+import org.opensearch.geospatial.GeospatialTestHelper;
+import org.opensearch.geospatial.index.common.xyshape.ShapeObjectBuilder;
+
+public class XYPointFieldMapperIT extends GeospatialRestTestCase {
+    private static final String FIELD_X_KEY = "x";
+    private static final String FIELD_Y_KEY = "y";
+
+    public void testMappingWithXYPointField() throws IOException {
+        String indexName = GeospatialTestHelper.randomLowerCaseString();
+        String fieldName = GeospatialTestHelper.randomLowerCaseString();
+        createIndex(indexName, Settings.EMPTY, Map.of(fieldName, XYPointFieldMapper.CONTENT_TYPE));
+        final Map<String, Object> fieldNameTypeMap = getIndexProperties(indexName);
+        assertTrue("field name is not found inside mapping", fieldNameTypeMap.containsKey(fieldName));
+        final Map<String, Object> fieldType = (Map<String, Object>) fieldNameTypeMap.get(fieldName);
+        assertEquals("invalid field type", XYPointFieldMapper.CONTENT_TYPE, fieldType.get(FIELD_TYPE_KEY));
+        deleteIndex(indexName);
+    }
+
+    public void testIndexWithXYPointFieldAsWKTFormat() throws IOException {
+        String indexName = GeospatialTestHelper.randomLowerCaseString();
+        String fieldName = GeospatialTestHelper.randomLowerCaseString();
+        createIndex(indexName, Settings.EMPTY, Map.of(fieldName, XYPointFieldMapper.CONTENT_TYPE));
+        final Point point = ShapeObjectBuilder.randomPoint(randomBoolean());
+        String docID = indexDocument(indexName, getDocumentWithWKTValueForXYPoint(fieldName, point));
+        assertTrue("failed to index document", getIndexDocumentCount(indexName) > 0);
+        final Map<String, Object> document = getDocument(docID, indexName);
+        assertNotNull("failed to get indexed document", document);
+        assertEquals("failed to index xy_point", point.toString(), document.get(fieldName));
+        deleteIndex(indexName);
+    }
+
+    public void testIndexWithXYPointFieldAsArrayFormat() throws IOException {
+        String indexName = GeospatialTestHelper.randomLowerCaseString();
+        String fieldName = GeospatialTestHelper.randomLowerCaseString();
+        createIndex(indexName, Settings.EMPTY, Map.of(fieldName, XYPointFieldMapper.CONTENT_TYPE));
+        final Point point = ShapeObjectBuilder.randomPoint(randomBoolean());
+        String docID = indexDocument(indexName, getDocumentWithArrayValueForXYPoint(fieldName, point));
+        assertTrue("failed to index document", getIndexDocumentCount(indexName) > 0);
+        final Map<String, Object> document = getDocument(docID, indexName);
+        assertNotNull("failed to get indexed document", document);
+        assertEquals("failed to index xy_point", List.of(point.getY(), point.getX()), document.get(fieldName));
+        deleteIndex(indexName);
+    }
+
+    public void testIndexWithXYPointFieldAsStringFormat() throws IOException {
+        String indexName = GeospatialTestHelper.randomLowerCaseString();
+        String fieldName = GeospatialTestHelper.randomLowerCaseString();
+        createIndex(indexName, Settings.EMPTY, Map.of(fieldName, XYPointFieldMapper.CONTENT_TYPE));
+        final Point point = ShapeObjectBuilder.randomPoint(randomBoolean());
+        String pointAsString = point.getX() + "," + point.getY();
+        String docID = indexDocument(indexName, getDocumentWithStringValueForXYPoint(fieldName, pointAsString));
+        assertTrue("failed to index document", getIndexDocumentCount(indexName) > 0);
+        final Map<String, Object> document = getDocument(docID, indexName);
+        assertNotNull("failed to get indexed document", document);
+        assertEquals("failed to index xy_point", pointAsString, document.get(fieldName));
+        deleteIndex(indexName);
+    }
+
+    public void testIndexWithXYPointFieldAsObjectFormat() throws IOException {
+        String indexName = GeospatialTestHelper.randomLowerCaseString();
+        String fieldName = GeospatialTestHelper.randomLowerCaseString();
+        createIndex(indexName, Settings.EMPTY, Map.of(fieldName, XYPointFieldMapper.CONTENT_TYPE));
+        final Point point = ShapeObjectBuilder.randomPoint(randomBoolean());
+        String docID = indexDocument(indexName, getDocumentWithObjectValueForXYPoint(fieldName, point));
+        assertTrue("failed to index document", getIndexDocumentCount(indexName) > 0);
+        final Map<String, Object> document = getDocument(docID, indexName);
+        assertNotNull("failed to get indexed document", document);
+        String expectedValue = String.format(Locale.ROOT, "{x=%s, y=%s}", point.getX(), point.getY());
+        assertEquals("failed to index xy_point", expectedValue, document.get(fieldName).toString());
+        deleteIndex(indexName);
+    }
+
+    private String getDocumentWithWKTValueForXYPoint(String fieldName, Geometry geometry) throws IOException {
+        return buildContentAsString(build -> build.field(fieldName, geometry.toString()));
+    }
+
+    private String getDocumentWithArrayValueForXYPoint(String fieldName, Point point) throws IOException {
+        return buildContentAsString(build -> build.field(fieldName, new double[] { point.getY(), point.getX() }));
+    }
+
+    private String getDocumentWithStringValueForXYPoint(String fieldName, String pointAsString) throws IOException {
+        return buildContentAsString(build -> build.field(fieldName, pointAsString));
+    }
+
+    private String getDocumentWithObjectValueForXYPoint(String fieldName, Point point) throws IOException {
+        return buildContentAsString(build -> {
+            build.startObject(fieldName);
+            build.field(FIELD_X_KEY, point.getX());
+            build.field(FIELD_Y_KEY, point.getY());
+            build.endObject();
+        });
+    }
+
+}

--- a/src/test/java/org/opensearch/geospatial/index/mapper/xypoint/XYPointFieldMapperTests.java
+++ b/src/test/java/org/opensearch/geospatial/index/mapper/xypoint/XYPointFieldMapperTests.java
@@ -1,0 +1,295 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package org.opensearch.geospatial.index.mapper.xypoint;
+
+import java.io.IOException;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.Set;
+
+import org.apache.lucene.index.IndexableField;
+import org.opensearch.common.xcontent.XContentBuilder;
+import org.opensearch.geospatial.GeospatialTestHelper;
+import org.opensearch.geospatial.plugin.GeospatialPlugin;
+import org.opensearch.index.mapper.AbstractPointGeometryFieldMapper;
+import org.opensearch.index.mapper.DocumentMapper;
+import org.opensearch.index.mapper.FieldMapperTestCase2;
+import org.opensearch.index.mapper.Mapper;
+import org.opensearch.index.mapper.MapperParsingException;
+import org.opensearch.index.mapper.MapperService;
+import org.opensearch.index.mapper.ParsedDocument;
+import org.opensearch.plugins.Plugin;
+
+public class XYPointFieldMapperTests extends FieldMapperTestCase2<XYPointFieldMapper.XYPointFieldMapperBuilder> {
+
+    private static final String FIELD_TYPE_NAME = "type";
+    private static final String FIELD_NAME = "field";
+    private static final String FIELD_X_KEY = "x";
+    private static final String FIELD_Y_KEY = "y";
+    private final static Integer MIN_NUM_POINTS = 1;
+    private final static Integer MAX_NUM_POINTS = 10;
+
+    @Override
+    protected XYPointFieldMapper.XYPointFieldMapperBuilder newBuilder() {
+        return new XYPointFieldMapper.XYPointFieldMapperBuilder(GeospatialTestHelper.randomLowerCaseString());
+    }
+
+    @Override
+    protected void minimalMapping(XContentBuilder xContentBuilder) throws IOException {
+        xContentBuilder.field(FIELD_TYPE_NAME, XYPointFieldMapper.CONTENT_TYPE);
+    }
+
+    @Override
+    protected void writeFieldValue(XContentBuilder xContentBuilder) throws IOException {
+        xContentBuilder.value("POINT (14.0 15.0)");
+    }
+
+    @Override
+    protected void registerParameters(ParameterChecker parameterChecker) throws IOException {
+        parameterChecker.registerUpdateCheck(
+            b -> b.field(AbstractPointGeometryFieldMapper.Names.IGNORE_MALFORMED.getPreferredName(), true),
+            mapper -> {
+                assertTrue("invalid mapper retrieved", mapper instanceof XYPointFieldMapper);
+                XYPointFieldMapper xyPointFieldMapper = (XYPointFieldMapper) mapper;
+                assertTrue("param [ ignore_malformed ] is not updated", xyPointFieldMapper.ignoreMalformed().value());
+            }
+        );
+        parameterChecker.registerUpdateCheck(
+            b -> b.field(AbstractPointGeometryFieldMapper.Names.IGNORE_Z_VALUE.getPreferredName(), false),
+            mapper -> {
+                assertTrue("invalid mapper retrieved", mapper instanceof XYPointFieldMapper);
+                XYPointFieldMapper xyPointFieldMapper = (XYPointFieldMapper) mapper;
+                assertFalse("param [ ignore_z_value ] is not updated", xyPointFieldMapper.ignoreZValue().value());
+            }
+        );
+
+        XYPoint point = new XYPoint();
+        String pointAsString = "23.35,-50.55";
+        point.resetFromString(pointAsString, true);
+        parameterChecker.registerUpdateCheck(
+            b -> b.field(AbstractPointGeometryFieldMapper.Names.NULL_VALUE.getPreferredName(), pointAsString),
+            mapper -> {
+                assertTrue("invalid mapper retrieved", mapper instanceof XYPointFieldMapper);
+                XYPointFieldMapper xyPointFieldMapper = (XYPointFieldMapper) mapper;
+                assertEquals("param [ null_value ] is not updated", point, xyPointFieldMapper.nullValue());
+            }
+        );
+    }
+
+    @Override
+    protected Set<String> unsupportedProperties() {
+        return org.opensearch.common.collect.Set.of("analyzer", "similarity");
+    }
+
+    @Override
+    protected Collection<Plugin> getPlugins() {
+        return Collections.singletonList(new GeospatialPlugin());
+    }
+
+    @Override
+    protected boolean supportsMeta() {
+        return false;
+    }
+
+    @Override
+    protected boolean supportsOrIgnoresBoost() {
+        return false;
+    }
+
+    public final void testExistsQueryDocValuesDisabled() throws IOException {
+        MapperService mapperService = createMapperService(fieldMapping(builder -> {
+            minimalMapping(builder);
+            builder.field("doc_values", false);
+        }));
+        assertExistsQuery(mapperService);
+        assertParseMinimalWarnings();
+    }
+
+    public void testDefaultConfiguration() throws IOException {
+        DocumentMapper mapper = createDocumentMapper(fieldMapping(this::minimalMapping));
+        Mapper fieldMapper = mapper.mappers().getMapper(FIELD_NAME);
+        assertTrue("Invalid FieldMapper retrieved", fieldMapper instanceof XYPointFieldMapper);
+        XYPointFieldMapper xyPointFieldMapper = (XYPointFieldMapper) fieldMapper;
+
+        assertTrue("param [ docs_value ] default value should be true", xyPointFieldMapper.fieldType().hasDocValues());
+        assertEquals("param [ ignore_malformed ] default value should be false", xyPointFieldMapper.ignoreMalformed().value(), false);
+        assertEquals("param [ ignore_z_value ] default value should be true", xyPointFieldMapper.ignoreZValue().value(), true);
+        assertNull("param [ null_value ] default value should be null", xyPointFieldMapper.nullValue());
+
+    }
+
+    public void testFieldTypeContentType() throws IOException {
+        DocumentMapper mapper = createDocumentMapper(fieldMapping(this::minimalMapping));
+        Mapper fieldMapper = mapper.mappers().getMapper(FIELD_NAME);
+        assertTrue("Invalid FieldMapper retrieved", fieldMapper instanceof XYPointFieldMapper);
+        final XYPointFieldMapper.XYPointFieldType fieldType = ((XYPointFieldMapper) fieldMapper).fieldType();
+        assertEquals("invalid field type name", fieldType.typeName(), XYPointFieldMapper.CONTENT_TYPE);
+    }
+
+    public void testIndexAsWKT() throws IOException {
+        DocumentMapper mapper = createDocumentMapper(fieldMapping(this::minimalMapping));
+        ParsedDocument doc = mapper.parse(
+            source(builder -> builder.field(FIELD_NAME, "POINT (" + randomDouble() + " " + randomDouble() + ")"))
+        );
+        final IndexableField actualFieldValue = doc.rootDoc().getField(FIELD_NAME);
+        assertNotNull("FieldValue is null", actualFieldValue);
+    }
+
+    public void testIndexAsObject() throws IOException {
+        DocumentMapper mapper = createDocumentMapper(fieldMapping(this::minimalMapping));
+        ParsedDocument doc = mapper.parse(
+            source(
+                builder -> builder.startObject(FIELD_NAME).field(FIELD_X_KEY, randomDouble()).field(FIELD_Y_KEY, randomDouble()).endObject()
+            )
+        );
+        final IndexableField[] actualFieldValues = doc.rootDoc().getFields(FIELD_NAME);
+        assertNotNull("FieldValue is null", actualFieldValues);
+        assertEquals("mismatch in field values count", 2, actualFieldValues.length);
+    }
+
+    public void testIndexAsArray() throws IOException {
+        DocumentMapper mapper = createDocumentMapper(fieldMapping(this::minimalMapping));
+        ParsedDocument doc = mapper.parse(
+            source(builder -> builder.startArray(FIELD_NAME).value(randomDouble()).value(randomDouble()).endArray())
+        );
+        final IndexableField[] actualFieldValues = doc.rootDoc().getFields(FIELD_NAME);
+        assertNotNull("FieldValue is null", actualFieldValues);
+        assertEquals("mismatch in field values count", 2, actualFieldValues.length);
+    }
+
+    public void testIndexAsString() throws IOException {
+        DocumentMapper mapper = createDocumentMapper(fieldMapping(this::minimalMapping));
+        ParsedDocument doc = mapper.parse(source(builder -> builder.field(FIELD_NAME, randomDouble() + "," + randomDouble())));
+        final IndexableField actualFieldValue = doc.rootDoc().getField(FIELD_NAME);
+        assertNotNull("FieldValue is null", actualFieldValue);
+    }
+
+    public void testIndexAsArrayMultiPoints() throws IOException {
+        int numOfPoints = randomIntBetween(MIN_NUM_POINTS, MAX_NUM_POINTS);
+        DocumentMapper mapper = createDocumentMapper(fieldMapping(this::minimalMapping));
+        ParsedDocument doc = mapper.parse(source(builder -> {
+            builder.startArray(FIELD_NAME);
+            for (int i = 0; i < numOfPoints; i++) {
+                builder.startArray().value(randomDouble()).value(randomDouble()).endArray();
+            }
+            builder.endArray();
+        }));
+        final IndexableField[] actualFieldValues = doc.rootDoc().getFields(FIELD_NAME);
+        assertNotNull("FieldValue is null", actualFieldValues);
+        assertEquals("mismatch in field values count", 2 * numOfPoints, actualFieldValues.length);
+    }
+
+    public void testIndexAsObjectMultiPoints() throws IOException {
+        int numOfPoints = randomIntBetween(MIN_NUM_POINTS, MAX_NUM_POINTS);
+        DocumentMapper mapper = createDocumentMapper(fieldMapping(this::minimalMapping));
+        ParsedDocument doc = mapper.parse(source(builder -> {
+            builder.startArray(FIELD_NAME);
+            for (int i = 0; i < numOfPoints; i++) {
+                builder.startObject().field(FIELD_X_KEY, randomDouble()).field(FIELD_Y_KEY, randomDouble()).endObject();
+            }
+            builder.endArray();
+        }));
+        final IndexableField[] actualFieldValues = doc.rootDoc().getFields(FIELD_NAME);
+        assertNotNull("FieldValue is null", actualFieldValues);
+        assertEquals("mismatch in field values count", 2 * numOfPoints, actualFieldValues.length);
+    }
+
+    public void testIndexAsStringMultiPoints() throws IOException {
+        int numOfPoints = randomIntBetween(MIN_NUM_POINTS, MAX_NUM_POINTS);
+        DocumentMapper mapper = createDocumentMapper(fieldMapping(this::minimalMapping));
+        ParsedDocument doc = mapper.parse(source(builder -> {
+            builder.startArray(FIELD_NAME);
+            for (int i = 0; i < numOfPoints; i++) {
+                builder.value(randomDouble() + "," + randomDouble());
+            }
+            builder.endArray();
+        }));
+
+        final IndexableField[] actualFieldValues = doc.rootDoc().getFields(FIELD_NAME);
+        assertNotNull("FieldValue is null", actualFieldValues);
+        assertEquals("mismatch in field values count", 2 * numOfPoints, actualFieldValues.length);
+    }
+
+    public void testIndexAsWKTMultiPoints() throws IOException {
+        int numOfPoints = randomIntBetween(MIN_NUM_POINTS, MAX_NUM_POINTS);
+        DocumentMapper mapper = createDocumentMapper(fieldMapping(this::minimalMapping));
+        ParsedDocument doc = mapper.parse(source(builder -> {
+            builder.startArray(FIELD_NAME);
+            for (int i = 0; i < numOfPoints; i++) {
+                builder.value("POINT (" + randomDouble() + " " + randomDouble() + ")");
+            }
+            builder.endArray();
+        }));
+        final IndexableField[] actualFieldValues = doc.rootDoc().getFields(FIELD_NAME);
+        assertNotNull("FieldValue is null", actualFieldValues);
+        assertEquals("mismatch in field values count", 2 * numOfPoints, actualFieldValues.length);
+    }
+
+    public void testIgnoreZValue() throws IOException {
+        boolean z_value = randomBoolean();
+        DocumentMapper mapper = createDocumentMapper(
+            fieldMapping(
+                builder -> builder.field(FIELD_TYPE_NAME, XYPointFieldMapper.CONTENT_TYPE)
+                    .field(AbstractPointGeometryFieldMapper.Names.IGNORE_Z_VALUE.getPreferredName(), z_value)
+            )
+        );
+        if (z_value) {
+            ParsedDocument doc = mapper.parse(
+                source(builder -> builder.field(FIELD_NAME, randomDouble() + "," + randomDouble() + "," + randomDouble()))
+            );
+            final IndexableField actualFieldValue = doc.rootDoc().getField(FIELD_NAME);
+            assertNotNull("failed to ignore z value even if [ignore_z_value] is [true]", actualFieldValue);
+        } else {
+            MapperParsingException exception = expectThrows(
+                MapperParsingException.class,
+                () -> mapper.parse(
+                    source(builder -> builder.field(FIELD_NAME, randomDouble() + "," + randomDouble() + "," + randomDouble()))
+                )
+            );
+            assertTrue(
+                "failed to throw exception even if [ignore_z_value] is false",
+                exception.getCause().getMessage().contains("but [ignore_z_value] parameter is [false]")
+            );
+        }
+    }
+
+    public void testIgnoreMalformed() throws IOException {
+        boolean ignore_malformed_value = randomBoolean();
+        DocumentMapper mapper = createDocumentMapper(
+            fieldMapping(
+                builder -> builder.field(FIELD_TYPE_NAME, XYPointFieldMapper.CONTENT_TYPE)
+                    .field(AbstractPointGeometryFieldMapper.Names.IGNORE_MALFORMED.getPreferredName(), ignore_malformed_value)
+            )
+        );
+        if (ignore_malformed_value) {
+            ParsedDocument doc = mapper.parse(source(builder -> builder.field(FIELD_NAME, "50.0,abcd")));
+            assertNull("failed to ignore malformed point even if [ignore_malformed] is [true]", doc.rootDoc().getField(FIELD_NAME));
+        } else {
+            MapperParsingException exception = expectThrows(
+                MapperParsingException.class,
+                () -> mapper.parse(source(builder -> builder.field(FIELD_NAME, "50.0,abcd")))
+            );
+            assertTrue(
+                "failed to throw exception even if [ignore_malformed] is [false]",
+                exception.getCause().getMessage().contains("[y] must be a number")
+            );
+        }
+    }
+
+    public void testNullValue() throws Exception {
+        DocumentMapper mapper = createDocumentMapper(
+            fieldMapping(
+                builder -> builder.field(FIELD_TYPE_NAME, XYPointFieldMapper.CONTENT_TYPE)
+                    .field(AbstractPointGeometryFieldMapper.Names.NULL_VALUE.getPreferredName(), "91,181")
+            )
+        );
+        Mapper fieldMapper = mapper.mappers().getMapper(FIELD_NAME);
+
+        AbstractPointGeometryFieldMapper.ParsedPoint nullValue = ((XYPointFieldMapper) fieldMapper).nullValue();
+        assertEquals("assertion failed even if [null_value] parameter is set", nullValue, new XYPoint(91, 181));
+    }
+
+}

--- a/src/test/java/org/opensearch/geospatial/index/mapper/xypoint/XYPointIndexerTests.java
+++ b/src/test/java/org/opensearch/geospatial/index/mapper/xypoint/XYPointIndexerTests.java
@@ -1,0 +1,53 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package org.opensearch.geospatial.index.mapper.xypoint;
+
+import static org.mockito.Mockito.mock;
+import static org.opensearch.geospatial.index.common.xyshape.ShapeObjectBuilder.getRandomXYPoints;
+
+import java.util.Collections;
+import java.util.List;
+
+import org.apache.lucene.geo.XYPoint;
+import org.apache.lucene.index.IndexableField;
+import org.opensearch.index.mapper.ParseContext;
+import org.opensearch.test.OpenSearchTestCase;
+
+public class XYPointIndexerTests extends OpenSearchTestCase {
+    private XYPointIndexer indexer;
+    private ParseContext parseContext;
+    private final static String fieldName = "geometry";
+    private final static Integer MIN_NUM_POINTS = 1;
+    private final static Integer MAX_NUM_POINTS = 10;
+
+    @Override
+    public void setUp() throws Exception {
+        super.setUp();
+        indexer = new XYPointIndexer(fieldName);
+        parseContext = mock(ParseContext.class);
+    }
+
+    public void testIndexingNullGeometry() {
+        expectThrows(NullPointerException.class, () -> indexer.prepareForIndexing(null));
+    }
+
+    public void testIndexingEmptyList() {
+        expectThrows(IllegalArgumentException.class, () -> indexer.prepareForIndexing(Collections.emptyList()));
+    }
+
+    public void testPrepareIndexing() {
+        var point = mock(org.opensearch.geospatial.index.mapper.xypoint.XYPoint.class);
+        List<org.opensearch.geospatial.index.mapper.xypoint.XYPoint> points = List.of(point);
+        assertNotNull("failed to convert xypoints from opensearch to lucene type", indexer.prepareForIndexing(points));
+    }
+
+    public void testIndexShape() {
+        int numOfPoints = randomIntBetween(MIN_NUM_POINTS, MAX_NUM_POINTS);
+        List<XYPoint> xyPoints = getRandomXYPoints(numOfPoints, randomBoolean());
+        List<IndexableField> indexableFields = indexer.indexShape(parseContext, xyPoints);
+        assertEquals("failed to index xypoints", numOfPoints, indexableFields.size());
+    }
+}

--- a/src/test/java/org/opensearch/geospatial/index/mapper/xypoint/XYPointParsingTests.java
+++ b/src/test/java/org/opensearch/geospatial/index/mapper/xypoint/XYPointParsingTests.java
@@ -1,0 +1,186 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package org.opensearch.geospatial.index.mapper.xypoint;
+
+import java.io.IOException;
+
+import org.opensearch.OpenSearchParseException;
+import org.opensearch.common.bytes.BytesReference;
+import org.opensearch.common.xcontent.XContentBuilder;
+import org.opensearch.common.xcontent.XContentParser;
+import org.opensearch.common.xcontent.json.JsonXContent;
+import org.opensearch.test.OpenSearchTestCase;
+
+public class XYPointParsingTests extends OpenSearchTestCase {
+    private static final String FIELD_X_KEY = "x";
+    private static final String FIELD_Y_KEY = "y";
+
+    public void testXYPointReset() {
+        double x = randomDouble();
+        double y = randomDouble();
+
+        XYPoint point = new XYPoint();
+
+        assertEquals("Reset from WKT", point.resetFromString("POINT(" + y + " " + x + ")", randomBoolean()), point.reset(x, y));
+        assertEquals("Reset from Coordinates", point.resetFromString(x + ", " + y, randomBoolean()), point.reset(x, y));
+
+    }
+
+    public void testResetFromWKTInvalid() {
+        XYPoint point = new XYPoint();
+        OpenSearchParseException e = expectThrows(
+            OpenSearchParseException.class,
+            () -> point.resetFromString("NOT A POINT(1 2)", randomBoolean())
+        );
+        assertEquals("Validation failed for Invalid WKT", "Invalid WKT format, [NOT A POINT(1 2)]", e.getMessage());
+
+        OpenSearchParseException e2 = expectThrows(
+            OpenSearchParseException.class,
+            () -> point.resetFromString("MULTIPOINT(1 2, 3 4)", randomBoolean())
+        );
+        assertEquals(
+            "Validation failed for invalid WKT primitive",
+            "[xy_point] supports only POINT among WKT primitives, but found [MULTIPOINT]",
+            e2.getMessage()
+        );
+    }
+
+    public void testResetFromCoordinatesInvalid() {
+        XYPoint point = new XYPoint();
+        OpenSearchParseException e = expectThrows(
+            OpenSearchParseException.class,
+            () -> point.resetFromString("20.4, 50.6, 70.8, -200.6", randomBoolean())
+        );
+        assertEquals("Validation failed for checking count of coordinates", "expected 2 or 3 coordinates, but found: [4]", e.getMessage());
+
+        OpenSearchParseException e2 = expectThrows(OpenSearchParseException.class, () -> point.resetFromString("20.4, 50.6, 70.8", false));
+        assertEquals(
+            "Validation failed for [ignore_z_value] parameter",
+            "Exception parsing coordinates: found Z value [70.8] but [ignore_z_value] parameter is [false]",
+            e2.getMessage()
+        );
+
+        OpenSearchParseException e3 = expectThrows(
+            OpenSearchParseException.class,
+            () -> point.resetFromString("abcd, 50.6", randomBoolean())
+        );
+        assertEquals("Validation failed even if x is not a number", "[x] must be a number", e3.getMessage());
+
+        OpenSearchParseException e4 = expectThrows(
+            OpenSearchParseException.class,
+            () -> point.resetFromString("50.6, abcd", randomBoolean())
+        );
+        assertEquals("Validation failed even if y is not a number", "[y] must be a number", e4.getMessage());
+    }
+
+    public void testXYPointParsing() throws IOException {
+        XYPoint randomXYPoint = new XYPoint(randomDouble(), randomDouble());
+
+        XYPoint point = XYPointParser.parseXYPoint(xyAsObject(randomXYPoint.getX(), randomXYPoint.getY()), randomBoolean());
+        assertEquals("Parsing XYPoint as an object failed", randomXYPoint, point);
+
+        XYPoint point2 = XYPointParser.parseXYPoint(xyAsString(randomXYPoint.getX(), randomXYPoint.getY()), randomBoolean());
+        assertEquals("Parsing XYPoint as a string failed", randomXYPoint, point2);
+
+        XYPoint point3 = XYPointParser.parseXYPoint(xyAsArray(randomXYPoint.getX(), randomXYPoint.getY()), randomBoolean());
+        assertEquals("Parsing XYPoint as an array failed", randomXYPoint, point3);
+
+        XYPoint point4 = XYPointParser.parseXYPoint(xyAsWKT(randomXYPoint.getX(), randomXYPoint.getY()), randomBoolean());
+        assertEquals("Parsing XYPoint as a WKT failed", randomXYPoint, point4);
+    }
+
+    public void testInvalidField() throws IOException {
+        XContentBuilder content = JsonXContent.contentBuilder();
+        content.startObject();
+        content.field(FIELD_Y_KEY, 0).field(FIELD_X_KEY, 0).field("test", 0);
+        content.endObject();
+
+        try (XContentParser parser = createParser(JsonXContent.jsonXContent, BytesReference.bytes(content))) {
+            parser.nextToken();
+            OpenSearchParseException e = expectThrows(
+                OpenSearchParseException.class,
+                () -> XYPointParser.parseXYPoint(parser, randomBoolean())
+            );
+            assertEquals("Validation for invalid fields failed", "field must be either [x] or [y]", e.getMessage());
+        }
+    }
+
+    public void testParsingInvalidObject() throws IOException {
+        // Send empty string instead of double for y coordinate
+        XContentBuilder content = JsonXContent.contentBuilder();
+        content.startObject();
+        content.field(FIELD_X_KEY, randomDouble()).field(FIELD_Y_KEY, "");
+        content.endObject();
+        XContentParser parser = createParser(JsonXContent.jsonXContent, BytesReference.bytes(content));
+        parser.nextToken();
+        OpenSearchParseException e = expectThrows(
+            OpenSearchParseException.class,
+            () -> XYPointParser.parseXYPoint(parser, randomBoolean())
+        );
+        assertEquals("Validation failed for invalid x and y values", "[y] must be valid double value", e.getMessage());
+
+        // Skip the 'y' field and y coordinate
+        XContentBuilder content1 = JsonXContent.contentBuilder();
+        content1.startObject();
+        content1.field(FIELD_X_KEY, randomDouble());
+        content1.endObject();
+        XContentParser parser1 = createParser(JsonXContent.jsonXContent, BytesReference.bytes(content1));
+        parser1.nextToken();
+        OpenSearchParseException e1 = expectThrows(
+            OpenSearchParseException.class,
+            () -> XYPointParser.parseXYPoint(parser1, randomBoolean())
+        );
+        assertEquals("Validation failed even if field [y] is missing", "field [y] missing", e1.getMessage());
+
+        // Skip the 'x' field and x coordinate
+        XContentBuilder content2 = JsonXContent.contentBuilder();
+        content2.startObject();
+        content2.field(FIELD_Y_KEY, randomDouble());
+        content2.endObject();
+        XContentParser parser2 = createParser(JsonXContent.jsonXContent, BytesReference.bytes(content2));
+        parser2.nextToken();
+        OpenSearchParseException e2 = expectThrows(
+            OpenSearchParseException.class,
+            () -> XYPointParser.parseXYPoint(parser2, randomBoolean())
+        );
+        assertEquals("Validation failed even if field [x] is missing", "field [x] missing", e2.getMessage());
+
+    }
+
+    private XContentParser xyAsObject(double x, double y) throws IOException {
+        XContentBuilder content = JsonXContent.contentBuilder();
+        content.startObject();
+        content.field(FIELD_X_KEY, x).field(FIELD_Y_KEY, y);
+        content.endObject();
+        XContentParser parser = createParser(JsonXContent.jsonXContent, BytesReference.bytes(content));
+        parser.nextToken();
+        return parser;
+    }
+
+    private XContentParser xyAsString(double x, double y) throws IOException {
+        XContentBuilder content = JsonXContent.contentBuilder();
+        content.value(x + ", " + y);
+        XContentParser parser = createParser(JsonXContent.jsonXContent, BytesReference.bytes(content));
+        parser.nextToken();
+        return parser;
+    }
+
+    private XContentParser xyAsArray(double x, double y) throws IOException {
+        XContentBuilder content = JsonXContent.contentBuilder();
+        content.startArray().value(y).value(x).endArray();
+        XContentParser parser = createParser(JsonXContent.jsonXContent, BytesReference.bytes(content));
+        parser.nextToken();
+        return parser;
+    }
+
+    private XContentParser xyAsWKT(double x, double y) throws IOException {
+        XContentBuilder content = JsonXContent.contentBuilder();
+        content.value("POINT (" + y + " " + x + ")");
+        XContentParser parser = createParser(JsonXContent.jsonXContent, BytesReference.bytes(content));
+        parser.nextToken();
+        return parser;
+    }
+}

--- a/src/test/java/org/opensearch/geospatial/index/query/AbstractXYShapeQueryTestCase.java
+++ b/src/test/java/org/opensearch/geospatial/index/query/AbstractXYShapeQueryTestCase.java
@@ -1,0 +1,203 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package org.opensearch.geospatial.index.query;
+
+import static org.hamcrest.Matchers.equalTo;
+import static org.opensearch.geospatial.GeospatialTestHelper.randomLowerCaseString;
+import static org.opensearch.test.hamcrest.OpenSearchAssertions.assertHitCount;
+import static org.opensearch.test.hamcrest.OpenSearchAssertions.assertSearchResponse;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+
+import org.hamcrest.MatcherAssert;
+import org.hamcrest.Matchers;
+import org.opensearch.action.search.SearchResponse;
+import org.opensearch.common.geo.ShapeRelation;
+import org.opensearch.common.settings.Settings;
+import org.opensearch.geometry.Circle;
+import org.opensearch.geometry.LinearRing;
+import org.opensearch.geometry.MultiPolygon;
+import org.opensearch.geometry.Point;
+import org.opensearch.geometry.Polygon;
+import org.opensearch.geometry.Rectangle;
+import org.opensearch.geospatial.GeospatialRestTestCase;
+import org.opensearch.geospatial.index.mapper.xypoint.XYPointFieldMapper;
+import org.opensearch.geospatial.index.mapper.xyshape.XYShapeFieldMapper;
+import org.opensearch.search.SearchHit;
+
+public abstract class AbstractXYShapeQueryTestCase extends GeospatialRestTestCase {
+
+    public abstract String getIndexName();
+
+    public abstract String getFieldName();
+
+    public abstract String getContentType();
+
+    public void testNullShape() throws Exception {
+        createIndex(getIndexName(), Settings.EMPTY, Map.of(getFieldName(), getContentType()));
+        String body = buildContentAsString(builder -> builder.field(getFieldName(), (String) null));
+        String docID = indexDocument(getIndexName(), body);
+
+        final Map<String, Object> document = getDocument(docID, getIndexName());
+        assertTrue("failed to index document with type", document.containsKey(getFieldName()));
+        assertNull("failed to accept null value", document.get(getFieldName()));
+
+        deleteIndex(getIndexName());
+    }
+
+    public void testIndexPointsFilterRectangleWithIntersectsRelation() throws Exception {
+        createIndex(getIndexName(), Settings.EMPTY, Map.of(getFieldName(), getContentType()));
+        final String firstDocumentID = indexDocumentUsingWKT(getIndexName(), getFieldName(), "POINT(-30 -30)");
+        indexDocumentUsingWKT(getIndexName(), getFieldName(), "POINT(-45 -50)");
+
+        Rectangle rectangle = new Rectangle(-45, 45, 45, -45);
+        final SearchResponse searchResponse = searchUsingShapeRelation(getIndexName(), getFieldName(), rectangle, ShapeRelation.INTERSECTS);
+        assertSearchResponse(searchResponse);
+        assertHitCount(searchResponse, 1);
+        MatcherAssert.assertThat(searchResponse.getHits().getAt(0).getId(), equalTo(firstDocumentID));
+
+        deleteIndex(getIndexName());
+    }
+
+    public void testIndexPointsIndexedRectangleMatches() throws Exception {
+        String secondDocumentID = "";
+        createIndex(getIndexName(), Settings.EMPTY, Map.of(getFieldName(), getContentType()));
+        // Will index two points and search with envelope that will intersect only one point
+        indexDocumentUsingWKT(getIndexName(), getFieldName(), "POINT(-30 -30)");
+        if (XYPointFieldMapper.CONTENT_TYPE.equals(getContentType())) {
+            secondDocumentID = indexDocumentUsingWKT(getIndexName(), getFieldName(), "POINT(-45 -50)");
+        } else {
+            secondDocumentID = indexDocumentUsingGeoJSON(getIndexName(), getFieldName(), new Point(-45, -50));
+        }
+
+        // create an index to insert shape
+        String indexedShapeIndex = randomLowerCaseString();
+        String indexedShapePath = randomLowerCaseString();
+        createIndex(indexedShapeIndex, Settings.EMPTY, Map.of(indexedShapePath, XYShapeFieldMapper.CONTENT_TYPE));
+
+        final String shapeDocID = indexDocumentUsingWKT(indexedShapeIndex, indexedShapePath, "BBOX(-50, -40, -45, -55)");
+
+        final SearchResponse searchResponse = searchUsingIndexedShapeIndex(
+            getIndexName(),
+            indexedShapeIndex,
+            indexedShapePath,
+            shapeDocID,
+            getFieldName()
+        );
+        assertSearchResponse(searchResponse);
+        assertHitCount(searchResponse, 1);
+        MatcherAssert.assertThat(searchResponse.getHits().getAt(0).getId(), equalTo(secondDocumentID));
+
+        deleteIndex(getIndexName());
+        deleteIndex(indexedShapeIndex);
+    }
+
+    public void testIndexPointsCircle() throws Exception {
+        createIndex(getIndexName(), Settings.EMPTY, Map.of(getFieldName(), getContentType()));
+
+        indexDocumentUsingWKT(getIndexName(), getFieldName(), "POINT(-131 -30)");
+        final String secondDocumentID = indexDocumentUsingWKT(getIndexName(), getFieldName(), "POINT(-45 -50)");
+
+        Circle circle = new Circle(-30, -30, 100);
+
+        final SearchResponse searchResponse = searchUsingShapeRelation(getIndexName(), getFieldName(), circle, ShapeRelation.INTERSECTS);
+        assertSearchResponse(searchResponse);
+        assertHitCount(searchResponse, 1);
+        MatcherAssert.assertThat(searchResponse.getHits().getAt(0).getId(), equalTo(secondDocumentID));
+
+        deleteIndex(getIndexName());
+    }
+
+    public void testIndexPointsPolygon() throws Exception {
+        createIndex(getIndexName(), Settings.EMPTY, Map.of(getFieldName(), getContentType()));
+
+        final String firstDocumentID = indexDocumentUsingWKT(getIndexName(), getFieldName(), "POINT(-30 -30)");
+        indexDocumentUsingWKT(getIndexName(), getFieldName(), "POINT(-45 -50)");
+
+        double[] x = new double[] { -35, -35, -25, -25, -35 };
+        double[] y = new double[] { -35, -25, -25, -35, -35 };
+        LinearRing ring = new LinearRing(x, y);
+        Polygon polygon = new Polygon(ring);
+
+        final SearchResponse searchResponse = searchUsingShapeRelation(getIndexName(), getFieldName(), polygon, ShapeRelation.INTERSECTS);
+        assertSearchResponse(searchResponse);
+        assertHitCount(searchResponse, 1);
+        MatcherAssert.assertThat(searchResponse.getHits().getAt(0).getId(), equalTo(firstDocumentID));
+
+        deleteIndex(getIndexName());
+    }
+
+    public void testIndexPointsMultiPolygon() throws Exception {
+        String thirdDocumentId = "";
+        createIndex(getIndexName(), Settings.EMPTY, Map.of(getFieldName(), getContentType()));
+
+        final String firstDocumentID = indexDocumentUsingWKT(getIndexName(), getFieldName(), "POINT(-30 -30)");
+        indexDocumentUsingWKT(getIndexName(), getFieldName(), "POINT(-40 -40)");
+        if (XYPointFieldMapper.CONTENT_TYPE.equals(getContentType())) {
+            thirdDocumentId = indexDocumentUsingWKT(getIndexName(), getFieldName(), "POINT(-50 -50)");
+        } else {
+            thirdDocumentId = indexDocumentUsingGeoJSON(getIndexName(), getFieldName(), new Point(-50, -50));
+        }
+
+        LinearRing ring1 = new LinearRing(new double[] { -35, -35, -25, -25, -35 }, new double[] { -35, -25, -25, -35, -35 });
+        Polygon polygon1 = new Polygon(ring1);
+
+        LinearRing ring2 = new LinearRing(new double[] { -55, -55, -45, -45, -55 }, new double[] { -55, -45, -45, -55, -55 });
+        Polygon polygon2 = new Polygon(ring2);
+
+        MultiPolygon multiPolygon = new MultiPolygon(List.of(polygon1, polygon2));
+        List<String> expectedDocIDs = List.of(firstDocumentID, thirdDocumentId);
+
+        final SearchResponse searchResponse = searchUsingShapeRelation(
+            getIndexName(),
+            getFieldName(),
+            multiPolygon,
+            ShapeRelation.INTERSECTS
+        );
+        assertSearchResponse(searchResponse);
+        assertHitCount(searchResponse, expectedDocIDs.size());
+        List<String> actualDocIDS = new ArrayList<>();
+        for (SearchHit hit : searchResponse.getHits().getHits()) {
+            actualDocIDS.add(hit.getId());
+        }
+        MatcherAssert.assertThat(expectedDocIDs, Matchers.containsInAnyOrder(actualDocIDS.toArray()));
+
+        deleteIndex(getIndexName());
+    }
+
+    public void testIndexPointsIndexedRectangleNoMatch() throws Exception {
+        createIndex(getIndexName(), Settings.EMPTY, Map.of(getFieldName(), getContentType()));
+
+        indexDocumentUsingWKT(getIndexName(), getFieldName(), "POINT(-30 -30)");
+        if (XYPointFieldMapper.CONTENT_TYPE.equals(getContentType())) {
+            indexDocumentUsingWKT(getIndexName(), getFieldName(), "POINT(-45 -50)");
+        } else {
+            indexDocumentUsingGeoJSON(getIndexName(), getFieldName(), new Point(-45, -50));
+        }
+
+        // create an index to insert shape
+        String indexedShapeIndex = randomLowerCaseString();
+        String indexedShapePath = randomLowerCaseString();
+        createIndex(indexedShapeIndex, Settings.EMPTY, Map.of(indexedShapePath, XYShapeFieldMapper.CONTENT_TYPE));
+
+        final String shapeDocID = indexDocumentUsingWKT(indexedShapeIndex, indexedShapePath, "BBOX(-60, -50, -50, -60)");
+
+        final SearchResponse searchResponse = searchUsingIndexedShapeIndex(
+            getIndexName(),
+            indexedShapeIndex,
+            indexedShapePath,
+            shapeDocID,
+            getFieldName()
+        );
+        assertSearchResponse(searchResponse);
+        assertHitCount(searchResponse, 0);
+
+        deleteIndex(getIndexName());
+        deleteIndex(indexedShapeIndex);
+    }
+}

--- a/src/test/java/org/opensearch/geospatial/index/query/xypoint/XYPointQueryIT.java
+++ b/src/test/java/org/opensearch/geospatial/index/query/xypoint/XYPointQueryIT.java
@@ -1,0 +1,61 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package org.opensearch.geospatial.index.query.xypoint;
+
+import static org.opensearch.geospatial.GeospatialTestHelper.randomLowerCaseString;
+
+import java.util.Map;
+
+import org.opensearch.client.ResponseException;
+import org.opensearch.common.geo.ShapeRelation;
+import org.opensearch.common.settings.Settings;
+import org.opensearch.geometry.Rectangle;
+import org.opensearch.geospatial.index.mapper.xypoint.XYPointFieldMapper;
+import org.opensearch.geospatial.index.query.AbstractXYShapeQueryTestCase;
+
+public class XYPointQueryIT extends AbstractXYShapeQueryTestCase {
+    private String indexName;
+    private String xyPointFieldName;
+
+    @Override
+    public void setUp() throws Exception {
+        super.setUp();
+        indexName = randomLowerCaseString();
+        xyPointFieldName = randomLowerCaseString();
+    }
+
+    @Override
+    public String getIndexName() {
+        return indexName;
+    }
+
+    @Override
+    public String getFieldName() {
+        return xyPointFieldName;
+    }
+
+    @Override
+    public String getContentType() {
+        return XYPointFieldMapper.CONTENT_TYPE;
+    }
+
+    public void testIndexPointsFilterRectangleWithUnsupportedRelation() throws Exception {
+        createIndex(indexName, Settings.EMPTY, Map.of(xyPointFieldName, XYPointFieldMapper.CONTENT_TYPE));
+
+        final String firstDocument = buildDocumentWithWKT(xyPointFieldName, "POINT(-30 -30)");
+        indexDocument(indexName, firstDocument);
+
+        Rectangle rectangle = new Rectangle(-45, 45, 45, -45);
+
+        ResponseException exception = expectThrows(
+            ResponseException.class,
+            () -> searchUsingShapeRelation(indexName, xyPointFieldName, rectangle, ShapeRelation.CONTAINS)
+        );
+        assertTrue(exception.getMessage().contains("[CONTAINS] query relation not supported"));
+
+        deleteIndex(indexName);
+    }
+}

--- a/src/test/java/org/opensearch/geospatial/index/query/xypoint/XYPointQueryProcessorTests.java
+++ b/src/test/java/org/opensearch/geospatial/index/query/xypoint/XYPointQueryProcessorTests.java
@@ -1,0 +1,209 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package org.opensearch.geospatial.index.query.xypoint;
+
+import static java.util.Collections.emptyMap;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+import static org.opensearch.geospatial.index.common.xyshape.ShapeObjectBuilder.randomCircle;
+import static org.opensearch.geospatial.index.common.xyshape.ShapeObjectBuilder.randomLine;
+import static org.opensearch.geospatial.index.common.xyshape.ShapeObjectBuilder.randomLinearRing;
+import static org.opensearch.geospatial.index.common.xyshape.ShapeObjectBuilder.randomMultiLine;
+import static org.opensearch.geospatial.index.common.xyshape.ShapeObjectBuilder.randomMultiPoint;
+import static org.opensearch.geospatial.index.common.xyshape.ShapeObjectBuilder.randomMultiPolygon;
+import static org.opensearch.geospatial.index.common.xyshape.ShapeObjectBuilder.randomPoint;
+import static org.opensearch.geospatial.index.common.xyshape.ShapeObjectBuilder.randomPolygon;
+import static org.opensearch.geospatial.index.common.xyshape.ShapeObjectBuilder.randomRectangle;
+
+import java.io.IOException;
+import java.text.ParseException;
+import java.util.Locale;
+
+import org.apache.lucene.search.MatchNoDocsQuery;
+import org.apache.lucene.search.Query;
+import org.opensearch.common.geo.ShapeRelation;
+import org.opensearch.geometry.Circle;
+import org.opensearch.geometry.Geometry;
+import org.opensearch.geometry.GeometryCollection;
+import org.opensearch.geometry.Line;
+import org.opensearch.geometry.LinearRing;
+import org.opensearch.geometry.MultiLine;
+import org.opensearch.geometry.MultiPoint;
+import org.opensearch.geometry.MultiPolygon;
+import org.opensearch.geometry.Point;
+import org.opensearch.geometry.Polygon;
+import org.opensearch.geometry.Rectangle;
+import org.opensearch.geospatial.GeospatialTestHelper;
+import org.opensearch.geospatial.index.mapper.xypoint.XYPointFieldMapper;
+import org.opensearch.index.mapper.GeoPointFieldMapper;
+import org.opensearch.index.query.QueryShardContext;
+import org.opensearch.index.query.QueryShardException;
+import org.opensearch.test.OpenSearchTestCase;
+
+public class XYPointQueryProcessorTests extends OpenSearchTestCase {
+    private XYPointQueryProcessor queryProcessor;
+    private String fieldName;
+    private ShapeRelation relation;
+    private QueryShardContext context;
+    private static final boolean VALID_FIELD_TYPE = true;
+    private static final boolean INVALID_FIELD_TYPE = false;
+    private final static Integer MAX_NUMBER_OF_VERTICES = 10;
+    private final static Integer MIN_NUMBER_OF_VERTICES = 2;
+    private final static Integer MIN_NUMBER_OF_GEOMETRY_OBJECTS = 10;
+
+    @Override
+    public void setUp() throws Exception {
+        super.setUp();
+        context = mock(QueryShardContext.class);
+        fieldName = GeospatialTestHelper.randomLowerCaseString();
+        relation = ShapeRelation.INTERSECTS;
+        queryProcessor = new XYPointQueryProcessor();
+    }
+
+    public void testInvalidRelation() {
+        mockFieldType(VALID_FIELD_TYPE);
+        QueryShardException exception = expectThrows(
+            QueryShardException.class,
+            () -> queryProcessor.shapeQuery(randomPolygon(), fieldName, ShapeRelation.CONTAINS, context)
+        );
+        assertTrue(exception.getMessage().contains("[CONTAINS] query relation not supported"));
+    }
+
+    public void testQueryingNullFieldName() {
+        assertThrows(NullPointerException.class, () -> queryProcessor.shapeQuery(randomPolygon(), null, relation, context));
+    }
+
+    public void testQueryingNullQueryContext() {
+        assertThrows(NullPointerException.class, () -> queryProcessor.shapeQuery(randomPolygon(), fieldName, relation, null));
+    }
+
+    public void testQueryingNullShapeRelation() {
+        mockFieldType(VALID_FIELD_TYPE);
+        QueryShardException exception = expectThrows(
+            QueryShardException.class,
+            () -> queryProcessor.shapeQuery(randomPolygon(), fieldName, null, context)
+        );
+        assertTrue(exception.getMessage().contains("[null] query relation not supported"));
+    }
+
+    public void testQueryingNullGeometry() {
+        mockFieldType(VALID_FIELD_TYPE);
+        assertThrows(NullPointerException.class, () -> queryProcessor.shapeQuery(null, fieldName, relation, context));
+    }
+
+    public void testQueryingEmptyGeometry() {
+        mockFieldType(VALID_FIELD_TYPE);
+        final Query query = queryProcessor.shapeQuery(new GeometryCollection<>(), fieldName, relation, context);
+        assertEquals("No match found query should be returned", new MatchNoDocsQuery(), query);
+    }
+
+    public void testQueryingInvalidFieldTypeGeometry() {
+        mockFieldType(INVALID_FIELD_TYPE);
+        final QueryShardException exception = expectThrows(
+            QueryShardException.class,
+            () -> queryProcessor.shapeQuery(randomPolygon(), fieldName, relation, context)
+        );
+        assertEquals(
+            "wrong exception message",
+            String.format(
+                Locale.ROOT,
+                "Expected [%s] field type for Field [%s] but found [geo_point]",
+                XYPointFieldMapper.CONTENT_TYPE,
+                fieldName
+            ),
+            exception.getMessage()
+        );
+    }
+
+    public void testQueryingLinearRing() {
+        mockFieldType(VALID_FIELD_TYPE);
+        LinearRing ring = randomLinearRing(randomIntBetween(MIN_NUMBER_OF_VERTICES, MAX_NUMBER_OF_VERTICES), randomBoolean());
+        expectThrows(QueryShardException.class, () -> queryProcessor.shapeQuery(ring, fieldName, relation, context));
+    }
+
+    public void testQueryingMultiLine() {
+        mockFieldType(VALID_FIELD_TYPE);
+        int verticesLimit = randomIntBetween(MIN_NUMBER_OF_VERTICES, MAX_NUMBER_OF_VERTICES);
+        final int linesLimit = atLeast(MIN_NUMBER_OF_GEOMETRY_OBJECTS);
+        MultiLine multiLine = randomMultiLine(verticesLimit, linesLimit, randomBoolean());
+        expectThrows(QueryShardException.class, () -> queryProcessor.shapeQuery(multiLine, fieldName, relation, context));
+    }
+
+    public void testQueryingMultiPoint() {
+        mockFieldType(VALID_FIELD_TYPE);
+        int pointLimit = atLeast(MIN_NUMBER_OF_GEOMETRY_OBJECTS);
+        MultiPoint multiPoint = randomMultiPoint(pointLimit, randomBoolean());
+        expectThrows(QueryShardException.class, () -> queryProcessor.shapeQuery(multiPoint, fieldName, relation, context));
+    }
+
+    public void testQueryingPoint() {
+        mockFieldType(VALID_FIELD_TYPE);
+        Point point = randomPoint(randomBoolean());
+        expectThrows(QueryShardException.class, () -> queryProcessor.shapeQuery(point, fieldName, relation, context));
+    }
+
+    public void testQueryingLine() {
+        mockFieldType(VALID_FIELD_TYPE);
+        int verticesLimit = randomIntBetween(MIN_NUMBER_OF_VERTICES, MAX_NUMBER_OF_VERTICES);
+        Line line = randomLine(verticesLimit, randomBoolean());
+        expectThrows(QueryShardException.class, () -> queryProcessor.shapeQuery(line, fieldName, relation, context));
+    }
+
+    public void testQueryingCircle() {
+        mockFieldType(VALID_FIELD_TYPE);
+        Circle circle = randomCircle(randomBoolean());
+        assertNotNull("failed to convert to Query", queryProcessor.shapeQuery(circle, fieldName, relation, context));
+    }
+
+    public void testQueryingRectangle() {
+        mockFieldType(VALID_FIELD_TYPE);
+        Rectangle rectangle = randomRectangle();
+        assertNotNull("failed to convert to Query", queryProcessor.shapeQuery(rectangle, fieldName, relation, context));
+    }
+
+    public void testQueryingPolygon() throws IOException, ParseException {
+        mockFieldType(VALID_FIELD_TYPE);
+        Polygon geometry = randomPolygon();
+        assertNotNull("failed to convert to Query", queryProcessor.shapeQuery(geometry, fieldName, relation, context));
+    }
+
+    public void testQueryingMultiPolygon() throws IOException, ParseException {
+        mockFieldType(VALID_FIELD_TYPE);
+        MultiPolygon geometry = randomMultiPolygon();
+        assertNotNull("failed to convert to Query", queryProcessor.shapeQuery(geometry, fieldName, relation, context));
+    }
+
+    public void testQueryingEmptyGeometryCollection() {
+        mockFieldType(VALID_FIELD_TYPE);
+        GeometryCollection<Geometry> geometry = new GeometryCollection<>();
+        final Query actualQuery = queryProcessor.shapeQuery(geometry, fieldName, relation, context);
+        assertNotNull("failed to convert to Query", actualQuery);
+        assertEquals("MatchNoDocs query should be returned", new MatchNoDocsQuery(), actualQuery);
+    }
+
+    public void testGetVectorQueryFromShape() {
+        mockFieldType(VALID_FIELD_TYPE);
+        Circle circle = randomCircle(randomBoolean());
+        assertNotNull("failed to convert to Query", queryProcessor.shapeQuery(circle, fieldName, relation, context));
+    }
+
+    private void mockFieldType(boolean success) {
+        if (success) {
+            when(context.fieldMapper(fieldName)).thenReturn(
+                new XYPointFieldMapper.XYPointFieldType(
+                    fieldName,
+                    randomBoolean(),
+                    randomBoolean(),
+                    randomBoolean(),
+                    emptyMap(),
+                    mock(XYPointQueryProcessor.class)
+                )
+            );
+            return;
+        }
+        when(context.fieldMapper(fieldName)).thenReturn(new GeoPointFieldMapper.GeoPointFieldType(fieldName));
+    }
+}

--- a/src/test/java/org/opensearch/geospatial/index/query/xypoint/XYPointQueryVisitorTests.java
+++ b/src/test/java/org/opensearch/geospatial/index/query/xypoint/XYPointQueryVisitorTests.java
@@ -1,0 +1,184 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package org.opensearch.geospatial.index.query.xypoint;
+
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+import static org.opensearch.geospatial.index.common.xyshape.ShapeObjectBuilder.randomCircle;
+import static org.opensearch.geospatial.index.common.xyshape.ShapeObjectBuilder.randomGeometryCollection;
+import static org.opensearch.geospatial.index.common.xyshape.ShapeObjectBuilder.randomLine;
+import static org.opensearch.geospatial.index.common.xyshape.ShapeObjectBuilder.randomLinearRing;
+import static org.opensearch.geospatial.index.common.xyshape.ShapeObjectBuilder.randomMultiLine;
+import static org.opensearch.geospatial.index.common.xyshape.ShapeObjectBuilder.randomMultiPoint;
+import static org.opensearch.geospatial.index.common.xyshape.ShapeObjectBuilder.randomMultiPolygon;
+import static org.opensearch.geospatial.index.common.xyshape.ShapeObjectBuilder.randomPoint;
+import static org.opensearch.geospatial.index.common.xyshape.ShapeObjectBuilder.randomPolygon;
+import static org.opensearch.geospatial.index.common.xyshape.ShapeObjectBuilder.randomRectangle;
+
+import java.io.IOException;
+import java.text.ParseException;
+import java.util.List;
+import java.util.Locale;
+
+import org.apache.lucene.search.MatchNoDocsQuery;
+import org.apache.lucene.search.Query;
+import org.opensearch.geometry.Circle;
+import org.opensearch.geometry.GeometryCollection;
+import org.opensearch.geometry.GeometryVisitor;
+import org.opensearch.geometry.Line;
+import org.opensearch.geometry.LinearRing;
+import org.opensearch.geometry.MultiLine;
+import org.opensearch.geometry.MultiPoint;
+import org.opensearch.geometry.MultiPolygon;
+import org.opensearch.geometry.Point;
+import org.opensearch.geometry.Polygon;
+import org.opensearch.geometry.Rectangle;
+import org.opensearch.geometry.ShapeType;
+import org.opensearch.geospatial.GeospatialTestHelper;
+import org.opensearch.geospatial.index.mapper.xypoint.XYPointFieldMapper;
+import org.opensearch.index.mapper.MappedFieldType;
+import org.opensearch.index.query.QueryShardContext;
+import org.opensearch.index.query.QueryShardException;
+import org.opensearch.test.OpenSearchTestCase;
+
+public class XYPointQueryVisitorTests extends OpenSearchTestCase {
+    private final static Integer MAX_NUMBER_OF_VERTICES = 10;
+    private final static Integer MIN_NUMBER_OF_VERTICES = 2;
+    private final static Integer MIN_NUMBER_OF_GEOMETRY_OBJECTS = 10;
+    private GeometryVisitor<Query, RuntimeException> queryVisitor;
+    private String fieldName;
+
+    private MappedFieldType fieldType;
+
+    @Override
+    public void setUp() throws Exception {
+        super.setUp();
+        QueryShardContext context = mock(QueryShardContext.class);
+        fieldType = mock(XYPointFieldMapper.XYPointFieldType.class);
+        fieldName = GeospatialTestHelper.randomLowerCaseString();
+        queryVisitor = new XYPointQueryVisitor(fieldName, fieldType, context);
+    }
+
+    public void testQueryingLinearRing() {
+        LinearRing ring = randomLinearRing(randomIntBetween(MIN_NUMBER_OF_VERTICES, MAX_NUMBER_OF_VERTICES), randomBoolean());
+        QueryShardException exception = expectThrows(QueryShardException.class, () -> ring.visit(queryVisitor));
+        assertEquals(
+            String.format(Locale.ROOT, "Field [%s] found an unsupported shape [%s]", fieldName, ShapeType.LINEARRING.name()),
+            exception.getMessage()
+        );
+    }
+
+    public void testQueryingMultiLine() {
+        int verticesLimit = randomIntBetween(MIN_NUMBER_OF_VERTICES, MAX_NUMBER_OF_VERTICES);
+        final int linesLimit = atLeast(MIN_NUMBER_OF_GEOMETRY_OBJECTS);
+        MultiLine multiLine = randomMultiLine(verticesLimit, linesLimit, randomBoolean());
+        QueryShardException exception = expectThrows(QueryShardException.class, () -> multiLine.visit(queryVisitor));
+        assertEquals(
+            String.format(Locale.ROOT, "Field [%s] found an unsupported shape [%s]", fieldName, ShapeType.MULTILINESTRING.name()),
+            exception.getMessage()
+        );
+    }
+
+    public void testQueryingMultiPoint() {
+        int pointLimit = atLeast(MIN_NUMBER_OF_GEOMETRY_OBJECTS);
+        MultiPoint multiPoint = randomMultiPoint(pointLimit, randomBoolean());
+        QueryShardException exception = expectThrows(QueryShardException.class, () -> multiPoint.visit(queryVisitor));
+        assertEquals(
+            String.format(Locale.ROOT, "Field [%s] found an unsupported shape [%s]", fieldName, ShapeType.MULTIPOINT.name()),
+            exception.getMessage()
+        );
+    }
+
+    public void testQueryingPoint() {
+        Point point = randomPoint(randomBoolean());
+        QueryShardException exception = expectThrows(QueryShardException.class, () -> point.visit(queryVisitor));
+        assertEquals(
+            String.format(Locale.ROOT, "Field [%s] found an unsupported shape [%s]", fieldName, ShapeType.POINT.name()),
+            exception.getMessage()
+        );
+    }
+
+    public void testQueryingLine() {
+        int verticesLimit = randomIntBetween(MIN_NUMBER_OF_VERTICES, MAX_NUMBER_OF_VERTICES);
+        Line line = randomLine(verticesLimit, randomBoolean());
+        QueryShardException exception = expectThrows(QueryShardException.class, () -> line.visit(queryVisitor));
+        assertEquals(
+            String.format(Locale.ROOT, "Field [%s] found an unsupported shape [%s]", fieldName, ShapeType.LINESTRING.name()),
+            exception.getMessage()
+        );
+    }
+
+    public void testQueryingCircleAsNull() {
+        NullPointerException nullPointerException = expectThrows(NullPointerException.class, () -> queryVisitor.visit((Circle) null));
+        assertEquals("Circle cannot be null", nullPointerException.getMessage());
+    }
+
+    public void testQueryingRectangleAsNull() {
+        NullPointerException nullPointerException = expectThrows(NullPointerException.class, () -> queryVisitor.visit((Rectangle) null));
+        assertEquals("Rectangle cannot be null", nullPointerException.getMessage());
+    }
+
+    public void testQueryingPolygonAsNull() {
+        NullPointerException nullPointerException = expectThrows(NullPointerException.class, () -> queryVisitor.visit((Polygon) null));
+        assertEquals("Polygon cannot be null", nullPointerException.getMessage());
+    }
+
+    public void testQueryingMultiPolygonAsNull() {
+        NullPointerException nullPointerException = expectThrows(NullPointerException.class, () -> queryVisitor.visit((MultiPolygon) null));
+        assertEquals("Multi Polygon cannot be null", nullPointerException.getMessage());
+    }
+
+    public void testQueryingCircle() {
+        Circle circle = randomCircle(randomBoolean());
+        when(fieldType.hasDocValues()).thenReturn(randomBoolean());
+        Query query = circle.visit(queryVisitor);
+        assertNotNull("failed to convert to Query", query);
+    }
+
+    public void testQueryingRectangle() {
+        Rectangle rectangle = randomRectangle();
+        when(fieldType.hasDocValues()).thenReturn(randomBoolean());
+        Query query = rectangle.visit(queryVisitor);
+        assertNotNull("failed to convert to Query", query);
+    }
+
+    public void testQueryingPolygon() throws IOException, ParseException {
+        Polygon polygon = randomPolygon();
+        when(fieldType.hasDocValues()).thenReturn(randomBoolean());
+        Query query = polygon.visit(queryVisitor);
+        assertNotNull("failed to convert to Query", query);
+    }
+
+    public void testQueryingMultiPolygon() throws IOException, ParseException {
+        MultiPolygon multiPolygon = randomMultiPolygon();
+        when(fieldType.hasDocValues()).thenReturn(randomBoolean());
+        Query query = multiPolygon.visit(queryVisitor);
+        assertNotNull("failed to convert to Query", query);
+    }
+
+    public void testQueryingEmptyGeometryCollection() {
+        GeometryCollection<?> collection = new GeometryCollection<>();
+        Query query = collection.visit(queryVisitor);
+        assertNotNull("failed to convert to Query", query);
+        assertEquals("MatchNoDocs query should be returned", new MatchNoDocsQuery(), query);
+    }
+
+    public void testQueryingUnsupportedGeometryCollection() {
+        GeometryCollection<?> collection = randomGeometryCollection(MIN_NUMBER_OF_GEOMETRY_OBJECTS, randomBoolean());
+        QueryShardException exception = expectThrows(QueryShardException.class, () -> collection.visit(queryVisitor));
+        assertTrue(
+            "Validation failed for unsupported geometries",
+            exception.getMessage().contains(String.format(Locale.ROOT, "Field [%s] found an unsupported shape", fieldName))
+        );
+    }
+
+    public void testQueryingGeometryCollection() throws IOException, ParseException {
+        GeometryCollection<?> collection = new GeometryCollection<>(List.of(randomPolygon(), randomRectangle()));
+        when(fieldType.hasDocValues()).thenReturn(randomBoolean());
+        Query query = collection.visit(queryVisitor);
+        assertNotNull("failed to convert to Query", query);
+    }
+}

--- a/src/test/java/org/opensearch/geospatial/index/query/xyshape/XYShapeQueryIT.java
+++ b/src/test/java/org/opensearch/geospatial/index/query/xyshape/XYShapeQueryIT.java
@@ -12,32 +12,18 @@ import static org.opensearch.index.query.AbstractGeometryQueryBuilder.DEFAULT_SH
 import static org.opensearch.test.hamcrest.OpenSearchAssertions.assertHitCount;
 import static org.opensearch.test.hamcrest.OpenSearchAssertions.assertSearchResponse;
 
-import java.util.ArrayList;
-import java.util.List;
 import java.util.Map;
 
 import org.hamcrest.MatcherAssert;
-import org.hamcrest.Matchers;
 import org.opensearch.action.search.SearchResponse;
 import org.opensearch.common.geo.GeoJson;
-import org.opensearch.common.geo.ShapeRelation;
 import org.opensearch.common.settings.Settings;
-import org.opensearch.geometry.Circle;
-import org.opensearch.geometry.LinearRing;
-import org.opensearch.geometry.MultiPolygon;
 import org.opensearch.geometry.Point;
-import org.opensearch.geometry.Polygon;
 import org.opensearch.geometry.Rectangle;
-import org.opensearch.geospatial.GeospatialRestTestCase;
 import org.opensearch.geospatial.index.mapper.xyshape.XYShapeFieldMapper;
-import org.opensearch.search.SearchHit;
+import org.opensearch.geospatial.index.query.AbstractXYShapeQueryTestCase;
 
-public class XYShapeQueryIT extends GeospatialRestTestCase {
-
-    private static final String INDEXED_SHAPE_FIELD = "indexed_shape";
-    private static final String SHAPE_INDEX_FIELD = "index";
-    private static final String SHAPE_ID_FIELD = "id";
-    private static final String SHAPE_INDEX_PATH_FIELD = "path";
+public class XYShapeQueryIT extends AbstractXYShapeQueryTestCase {
     private String indexName;
     private String xyShapeFieldName;
 
@@ -48,28 +34,26 @@ public class XYShapeQueryIT extends GeospatialRestTestCase {
         xyShapeFieldName = randomLowerCaseString();
     }
 
-    public void testNullShape() throws Exception {
-        createIndex(indexName, Settings.EMPTY, Map.of(xyShapeFieldName, XYShapeFieldMapper.CONTENT_TYPE));
-        String body = buildContentAsString(builder -> builder.field(xyShapeFieldName, (String) null));
-        String docID = indexDocument(indexName, body);
+    @Override
+    public String getIndexName() {
+        return indexName;
+    }
 
-        final Map<String, Object> document = getDocument(docID, indexName);
-        assertTrue("failed to index document with type", document.containsKey(xyShapeFieldName));
-        assertNull("failed to accept null value", document.get(xyShapeFieldName));
+    @Override
+    public String getFieldName() {
+        return xyShapeFieldName;
+    }
 
-        deleteIndex(indexName);
-
+    @Override
+    public String getContentType() {
+        return XYShapeFieldMapper.CONTENT_TYPE;
     }
 
     public void testIndexPointsFilterRectangleWithDefaultRelation() throws Exception {
         createIndex(indexName, Settings.EMPTY, Map.of(xyShapeFieldName, XYShapeFieldMapper.CONTENT_TYPE));
         // Will index two points and search with envelope that will intersect only one point
-        final String firstDocument = buildDocumentWithWKT(xyShapeFieldName, "POINT(-30 -30)");
-        final String firstDocumentID = indexDocument(indexName, firstDocument);
-
-        Point point = new Point(-45, -50);
-        final String secondDocument = buildDocumentWithGeoJSON(xyShapeFieldName, point);
-        indexDocument(indexName, secondDocument);
+        final String firstDocumentID = indexDocumentUsingWKT(indexName, xyShapeFieldName, "POINT(-30 -30)");
+        indexDocumentUsingGeoJSON(indexName, xyShapeFieldName, new Point(-45, -50));
 
         Rectangle rectangle = new Rectangle(-45, 45, 45, -45);
         String searchEntity = buildSearchBodyAsString(builder -> {
@@ -84,189 +68,4 @@ public class XYShapeQueryIT extends GeospatialRestTestCase {
 
         deleteIndex(indexName);
     }
-
-    public void testIndexPointsFilterRectangleWithIntersectsRelation() throws Exception {
-        createIndex(indexName, Settings.EMPTY, Map.of(xyShapeFieldName, XYShapeFieldMapper.CONTENT_TYPE));
-
-        final String firstDocument = buildDocumentWithWKT(xyShapeFieldName, "POINT(-30 -30)");
-        final String firstDocumentID = indexDocument(indexName, firstDocument);
-
-        final String secondDocument = buildDocumentWithWKT(xyShapeFieldName, "POINT(-45 -50)");
-        indexDocument(indexName, secondDocument);
-
-        Rectangle rectangle = new Rectangle(-45, 45, 45, -45);
-        String searchEntity = buildSearchBodyAsString(builder -> {
-            builder.field(DEFAULT_SHAPE_FIELD_NAME);
-            GeoJson.toXContent(rectangle, builder, EMPTY_PARAMS);
-            builder.field("relation", ShapeRelation.INTERSECTS.getRelationName());
-        }, XYShapeQueryBuilder.NAME, xyShapeFieldName);
-
-        final SearchResponse searchResponse = searchIndex(indexName, searchEntity);
-        assertSearchResponse(searchResponse);
-        assertHitCount(searchResponse, 1);
-        MatcherAssert.assertThat(searchResponse.getHits().getAt(0).getId(), equalTo(firstDocumentID));
-
-        deleteIndex(indexName);
-    }
-
-    public void testIndexPointsCircle() throws Exception {
-        createIndex(indexName, Settings.EMPTY, Map.of(xyShapeFieldName, XYShapeFieldMapper.CONTENT_TYPE));
-
-        final String firstDocument = buildDocumentWithWKT(xyShapeFieldName, "POINT(-131 -30)");
-        indexDocument(indexName, firstDocument);
-
-        final String secondDocument = buildDocumentWithWKT(xyShapeFieldName, "POINT(-45 -50)");
-        final String secondDocumentID = indexDocument(indexName, secondDocument);
-
-        Circle circle = new Circle(-30, -30, 100);
-        String searchEntity = buildSearchBodyAsString(builder -> {
-            builder.field(DEFAULT_SHAPE_FIELD_NAME);
-            GeoJson.toXContent(circle, builder, EMPTY_PARAMS);
-            builder.field("relation", ShapeRelation.INTERSECTS.getRelationName());
-        }, XYShapeQueryBuilder.NAME, xyShapeFieldName);
-
-        final SearchResponse searchResponse = searchIndex(indexName, searchEntity);
-        assertSearchResponse(searchResponse);
-        assertHitCount(searchResponse, 1);
-        MatcherAssert.assertThat(searchResponse.getHits().getAt(0).getId(), equalTo(secondDocumentID));
-
-        deleteIndex(indexName);
-    }
-
-    public void testIndexPointsPolygon() throws Exception {
-        createIndex(indexName, Settings.EMPTY, Map.of(xyShapeFieldName, XYShapeFieldMapper.CONTENT_TYPE));
-
-        final String firstDocument = buildDocumentWithWKT(xyShapeFieldName, "POINT(-30 -30)");
-        final String firstDocumentID = indexDocument(indexName, firstDocument);
-
-        final String secondDocument = buildDocumentWithWKT(xyShapeFieldName, "POINT(-45 -50)");
-        indexDocument(indexName, secondDocument);
-
-        double[] x = new double[] { -35, -35, -25, -25, -35 };
-        double[] y = new double[] { -35, -25, -25, -35, -35 };
-        LinearRing ring = new LinearRing(x, y);
-        Polygon polygon = new Polygon(ring);
-        String searchEntity = buildSearchBodyAsString(builder -> {
-            builder.field(DEFAULT_SHAPE_FIELD_NAME);
-            GeoJson.toXContent(polygon, builder, EMPTY_PARAMS);
-            builder.field("relation", ShapeRelation.INTERSECTS.getRelationName());
-        }, XYShapeQueryBuilder.NAME, xyShapeFieldName);
-
-        final SearchResponse searchResponse = searchIndex(indexName, searchEntity);
-        assertSearchResponse(searchResponse);
-        assertHitCount(searchResponse, 1);
-        MatcherAssert.assertThat(searchResponse.getHits().getAt(0).getId(), equalTo(firstDocumentID));
-
-        deleteIndex(indexName);
-    }
-
-    public void testIndexPointsMultiPolygon() throws Exception {
-
-        createIndex(indexName, Settings.EMPTY, Map.of(xyShapeFieldName, XYShapeFieldMapper.CONTENT_TYPE));
-
-        final String firstDocument = buildDocumentWithWKT(xyShapeFieldName, "POINT(-30 -30)");
-        final String firstDocumentID = indexDocument(indexName, firstDocument);
-
-        final String secondDocument = buildDocumentWithWKT(xyShapeFieldName, "POINT(-40 -40)");
-        indexDocument(indexName, secondDocument);
-
-        final String thirdDocument = buildDocumentWithGeoJSON(xyShapeFieldName, new Point(-50, -50));
-        final String thirdDocumentId = indexDocument(indexName, thirdDocument);
-
-        LinearRing ring1 = new LinearRing(new double[] { -35, -35, -25, -25, -35 }, new double[] { -35, -25, -25, -35, -35 });
-        Polygon polygon1 = new Polygon(ring1);
-
-        LinearRing ring2 = new LinearRing(new double[] { -55, -55, -45, -45, -55 }, new double[] { -55, -45, -45, -55, -55 });
-        Polygon polygon2 = new Polygon(ring2);
-
-        MultiPolygon multiPolygon = new MultiPolygon(List.of(polygon1, polygon2));
-        String searchEntity = buildSearchBodyAsString(builder -> {
-            builder.field(DEFAULT_SHAPE_FIELD_NAME);
-            GeoJson.toXContent(multiPolygon, builder, EMPTY_PARAMS);
-            builder.field("relation", ShapeRelation.INTERSECTS.getRelationName());
-        }, XYShapeQueryBuilder.NAME, xyShapeFieldName);
-        List<String> expectedDocIDs = List.of(firstDocumentID, thirdDocumentId);
-        final SearchResponse searchResponse = searchIndex(indexName, searchEntity);
-        assertSearchResponse(searchResponse);
-        assertHitCount(searchResponse, expectedDocIDs.size());
-        List<String> actualDocIDS = new ArrayList<>();
-        for (SearchHit hit : searchResponse.getHits().getHits()) {
-            actualDocIDS.add(hit.getId());
-        }
-        MatcherAssert.assertThat(expectedDocIDs, Matchers.containsInAnyOrder(actualDocIDS.toArray()));
-    }
-
-    public void testIndexPointsIndexedRectangleMatches() throws Exception {
-
-        createIndex(indexName, Settings.EMPTY, Map.of(xyShapeFieldName, XYShapeFieldMapper.CONTENT_TYPE));
-        // Will index two points and search with envelope that will intersect only one point
-        final String firstDocument = buildDocumentWithWKT(xyShapeFieldName, "POINT(-30 -30)");
-        indexDocument(indexName, firstDocument);
-
-        Point point = new Point(-45, -50);
-        final String secondDocument = buildDocumentWithGeoJSON(xyShapeFieldName, point);
-        final String secondDocumentID = indexDocument(indexName, secondDocument);
-
-        // create an index to insert shape
-        String indexedShapeIndex = randomLowerCaseString();
-        String indexedShapePath = randomLowerCaseString();
-        createIndex(indexedShapeIndex, Settings.EMPTY, Map.of(indexedShapePath, XYShapeFieldMapper.CONTENT_TYPE));
-
-        final String indexedRefDoc1 = buildDocumentWithWKT(indexedShapePath, "BBOX(-50, -40, -45, -55)");
-        final String shape = indexDocument(indexedShapeIndex, indexedRefDoc1);
-
-        String searchEntity = buildSearchBodyAsString(builder -> {
-            builder.startObject(INDEXED_SHAPE_FIELD);
-            builder.field(SHAPE_INDEX_FIELD, indexedShapeIndex);
-            builder.field(SHAPE_ID_FIELD, shape);
-            builder.field(SHAPE_INDEX_PATH_FIELD, indexedShapePath);
-            builder.endObject();
-        }, XYShapeQueryBuilder.NAME, xyShapeFieldName);
-
-        final SearchResponse searchResponse = searchIndex(indexName, searchEntity);
-
-        assertSearchResponse(searchResponse);
-        assertHitCount(searchResponse, 1);
-        MatcherAssert.assertThat(searchResponse.getHits().getAt(0).getId(), equalTo(secondDocumentID));
-
-        deleteIndex(indexName);
-        deleteIndex(indexedShapeIndex);
-    }
-
-    public void testIndexPointsIndexedRectangleNoMatch() throws Exception {
-
-        createIndex(indexName, Settings.EMPTY, Map.of(xyShapeFieldName, XYShapeFieldMapper.CONTENT_TYPE));
-        // Will index two points and search with envelope that will intersect only one point
-        final String firstDocument = buildDocumentWithWKT(xyShapeFieldName, "POINT(-30 -30)");
-        indexDocument(indexName, firstDocument);
-
-        Point point = new Point(-45, -50);
-        final String secondDocument = buildDocumentWithGeoJSON(xyShapeFieldName, point);
-        indexDocument(indexName, secondDocument);
-
-        // create an index to insert shape
-        String indexedShapeIndex = randomLowerCaseString();
-        String indexedShapePath = randomLowerCaseString();
-        createIndex(indexedShapeIndex, Settings.EMPTY, Map.of(indexedShapePath, XYShapeFieldMapper.CONTENT_TYPE));
-
-        final String indexedRefDoc2 = buildDocumentWithWKT(indexedShapePath, "BBOX(-60, -50, -50, -60)");
-        final String shape = indexDocument(indexedShapeIndex, indexedRefDoc2);
-
-        String searchEntity = buildSearchBodyAsString(builder -> {
-            builder.startObject(INDEXED_SHAPE_FIELD);
-            builder.field(SHAPE_INDEX_FIELD, indexedShapeIndex);
-            builder.field(SHAPE_ID_FIELD, shape);
-            builder.field(SHAPE_INDEX_PATH_FIELD, indexedShapePath);
-            builder.endObject();
-        }, XYShapeQueryBuilder.NAME, xyShapeFieldName);
-
-        final SearchResponse searchResponse = searchIndex(indexName, searchEntity);
-
-        assertSearchResponse(searchResponse);
-        assertHitCount(searchResponse, 0);
-
-        deleteIndex(indexName);
-        deleteIndex(indexedShapeIndex);
-    }
-
 }


### PR DESCRIPTION
Signed-off-by: Naveen Tatikonda <navtat@amazon.com>

### Description
Add XYPoint Field Type to index and query documents that contains cartesian points. 

Backporting it manually as bot failed to do it.
Original PR - https://github.com/opensearch-project/geospatial/pull/130

Issues Resolved
https://github.com/opensearch-project/geospatial/issues/95
 
### Check List
- [x] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
