### PR TITLE
Include backport branch in workflow to trigger CI

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -4,10 +4,12 @@ on:
     branches:
       - "*"
       - "feature/**"
+      - "backport/**"
   pull_request:
     branches:
       - "*"
       - "feature/**"
+      - "backport/**"
 
 jobs:
   Build:


### PR DESCRIPTION
Signed-off-by: Heemin Kim <heemin@amazon.com>

### Description
Add backport branch in workflow to trigger CI
 
### Issues Resolved
Backport branch is not added in workflow to tigger CI which does not check any validation before merge
 
### Check List
- [X] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
