### PR TITLE
Flip X and Y coordinates for WKT and array formats in XYPoint

### DIFF
--- a/src/main/java/org/opensearch/geospatial/index/mapper/xypoint/XYPoint.java
+++ b/src/main/java/org/opensearch/geospatial/index/mapper/xypoint/XYPoint.java
@@ -160,7 +160,7 @@ public class XYPoint implements AbstractPointGeometryFieldMapper.ParsedPoint, To
             throw new OpenSearchParseException("[xy_point] supports only POINT among WKT primitives, but found [{}]", geometry.type());
         }
         Point point = (Point) geometry;
-        return reset(point.getY(), point.getX());
+        return reset(point.getX(), point.getY());
     }
 
     /**

--- a/src/main/java/org/opensearch/geospatial/index/mapper/xypoint/XYPointParser.java
+++ b/src/main/java/org/opensearch/geospatial/index/mapper/xypoint/XYPointParser.java
@@ -157,9 +157,9 @@ public class XYPointParser {
             }
             element++;
             if (element == 1) {
-                y = subParser.doubleValue();
-            } else if (element == 2) {
                 x = subParser.doubleValue();
+            } else if (element == 2) {
+                y = subParser.doubleValue();
             } else if (element == 3) {
                 XYPoint.assertZValue(ignoreZValue, subParser.doubleValue());
             } else {

--- a/src/test/java/org/opensearch/geospatial/index/mapper/xypoint/XYPointParsingTests.java
+++ b/src/test/java/org/opensearch/geospatial/index/mapper/xypoint/XYPointParsingTests.java
@@ -170,7 +170,7 @@ public class XYPointParsingTests extends OpenSearchTestCase {
 
     private XContentParser xyAsArray(double x, double y) throws IOException {
         XContentBuilder content = JsonXContent.contentBuilder();
-        content.startArray().value(y).value(x).endArray();
+        content.startArray().value(x).value(y).endArray();
         XContentParser parser = createParser(JsonXContent.jsonXContent, BytesReference.bytes(content));
         parser.nextToken();
         return parser;
@@ -178,7 +178,7 @@ public class XYPointParsingTests extends OpenSearchTestCase {
 
     private XContentParser xyAsWKT(double x, double y) throws IOException {
         XContentBuilder content = JsonXContent.contentBuilder();
-        content.value("POINT (" + y + " " + x + ")");
+        content.value("POINT (" + x + " " + y + ")");
         XContentParser parser = createParser(JsonXContent.jsonXContent, BytesReference.bytes(content));
         parser.nextToken();
         return parser;


### PR DESCRIPTION
Signed-off-by: Naveen Tatikonda <navtat@amazon.com>

### Description
Change the order(flip) of X and Y coordinates for WKT and array formats used to index xy_point field type documents.
 
### Issues Resolved
https://github.com/opensearch-project/geospatial/issues/155
 
### Check List
- [x] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
