### PR TITLE
Introduce H3 min resolution as constant

### DIFF
--- a/libs/h3/src/main/java/org/opensearch/geospatial/h3/Constants.java
+++ b/libs/h3/src/main/java/org/opensearch/geospatial/h3/Constants.java
@@ -35,7 +35,12 @@ final class Constants {
      */
     public static double M_SQRT3_2 = 0.8660254037844386467637231707529361834714;
     /**
-     * max H3 resolution; H3 version 1 has 16 resolutions, numbered 0 through 15
+     * H3 version 1 has 16 resolutions, numbered 0 through 15
+     * min H3 resolution
+     */
+    public static int MIN_H3_RES = 0;
+    /**
+     * max H3 resolution;
      */
     public static int MAX_H3_RES = 15;
     /**

--- a/libs/h3/src/main/java/org/opensearch/geospatial/h3/H3.java
+++ b/libs/h3/src/main/java/org/opensearch/geospatial/h3/H3.java
@@ -35,6 +35,7 @@ import static java.lang.Math.toRadians;
  */
 public final class H3 {
 
+    public static int MIN_H3_RES = Constants.MIN_H3_RES;
     public static int MAX_H3_RES = Constants.MAX_H3_RES;
 
     /**
@@ -82,7 +83,7 @@ public final class H3 {
         }
 
         int res = H3Index.H3_get_resolution(h3);
-        if (res < 0 || res > Constants.MAX_H3_RES) {  // LCOV_EXCL_BR_LINE
+        if (res < Constants.MIN_H3_RES || res > Constants.MAX_H3_RES) {  // LCOV_EXCL_BR_LINE
             // Resolutions less than zero can not be represented in an index
             return false;
         }

--- a/libs/h3/src/test/java/org/opensearch/geospatial/h3/ParentChildNavigationTests.java
+++ b/libs/h3/src/test/java/org/opensearch/geospatial/h3/ParentChildNavigationTests.java
@@ -40,7 +40,7 @@ public class ParentChildNavigationTests extends OpenSearchTestCase {
         }
         h3Addresses = H3.h3ToChildren(h3Address);
         h3Address = RandomPicks.randomFrom(random(), h3Addresses);
-        for (int i = H3.MAX_H3_RES - 1; i >= 0; i--) {
+        for (int i = H3.MAX_H3_RES - 1; i >= H3.MIN_H3_RES; i--) {
             h3Address = H3.h3ToParent(h3Address);
             assertEquals(values[i], h3Address);
         }


### PR DESCRIPTION
### Description
H3 version 1 has 16 resolutions, numbered 0 through 15.
Introduced a constant to represent min value, similar
to max value.
 
### Issues Resolved
[List any issues this PR will resolve]
 
### Check List
- [x] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
