### PR TITLE
[2.x] Add window and mac platform in CI

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -14,9 +14,10 @@ jobs:
     strategy:
       matrix:
         java: [11, 17]
+        os: [ubuntu-latest, windows-latest, macos-latest]
 
     name: Build and Test geospatial Plugin
-    runs-on: ubuntu-latest
+    runs-on: ${{ matrix.os }}
 
     steps:
       - name: Checkout geospatial


### PR DESCRIPTION
Signed-off-by: Heemin Kim <heemin@amazon.com>

### Description
Add window and mac platform in CI
 
### Issues Resolved
Only works with 2.x version of OpenSearch. Until we support 3.x version of OpenSearch, we will keep the following issue open. https://github.com/opensearch-project/geospatial/issues/158
 
### Check List
- [x] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
