### PR TITLE
Allow API to accept any index name without suffix

### DIFF
--- a/src/main/java/org/opensearch/geospatial/action/upload/geojson/UploadGeoJSONRequestContent.java
+++ b/src/main/java/org/opensearch/geospatial/action/upload/geojson/UploadGeoJSONRequestContent.java
@@ -29,7 +29,6 @@ public final class UploadGeoJSONRequestContent {
     public static final ParseField FIELD_GEOSPATIAL = new ParseField("field");
     public static final ParseField FIELD_GEOSPATIAL_TYPE = new ParseField("type");
     public static final ParseField FIELD_DATA = new ParseField("data");
-    public static final String ACCEPTED_INDEX_SUFFIX_PATH = "-map";
     private final String indexName;
     private final String fieldName;
     private final String fieldType;
@@ -67,22 +66,12 @@ public final class UploadGeoJSONRequestContent {
 
     private static String validateIndexName(Map<String, Object> input) {
         String index = extractValueAsString(input, FIELD_INDEX.getPreferredName());
-        if (!Strings.hasText(index)) {
-            throw new IllegalArgumentException(
-                String.format(Locale.getDefault(), "field [ %s ] cannot be empty", FIELD_INDEX.getPreferredName())
-            );
+        if (Strings.hasText(index)) {
+            return index;
         }
-        if (!index.endsWith(ACCEPTED_INDEX_SUFFIX_PATH)) {
-            throw new IllegalArgumentException(
-                String.format(
-                    Locale.getDefault(),
-                    "field [ %s ] should end with suffix %s",
-                    FIELD_INDEX.getPreferredName(),
-                    ACCEPTED_INDEX_SUFFIX_PATH
-                )
-            );
-        }
-        return index;
+        throw new IllegalArgumentException(
+            String.format(Locale.getDefault(), "field [ %s ] cannot be empty", FIELD_INDEX.getPreferredName())
+        );
     }
 
     public String getIndexName() {

--- a/src/test/java/org/opensearch/geospatial/GeospatialRestTestCase.java
+++ b/src/test/java/org/opensearch/geospatial/GeospatialRestTestCase.java
@@ -10,8 +10,6 @@ import static org.opensearch.common.xcontent.ToXContent.EMPTY_PARAMS;
 import static org.opensearch.geospatial.GeospatialObjectBuilder.buildProperties;
 import static org.opensearch.geospatial.GeospatialObjectBuilder.randomGeoJSONFeature;
 import static org.opensearch.geospatial.GeospatialTestHelper.randomLowerCaseString;
-import static org.opensearch.geospatial.GeospatialTestHelper.randomLowerCaseStringWithSuffix;
-import static org.opensearch.geospatial.action.upload.geojson.UploadGeoJSONRequestContent.ACCEPTED_INDEX_SUFFIX_PATH;
 import static org.opensearch.geospatial.action.upload.geojson.UploadGeoJSONRequestContent.FIELD_DATA;
 import static org.opensearch.geospatial.shared.URLBuilder.getPluginURLPrefix;
 import static org.opensearch.index.query.AbstractGeometryQueryBuilder.DEFAULT_SHAPE_FIELD_NAME;
@@ -162,7 +160,7 @@ public abstract class GeospatialRestTestCase extends OpenSearchSecureRestTestCas
     // TODO This method is copied from unit test. Refactor to common class to share across tests
     protected JSONObject buildUploadGeoJSONRequestContent(int totalGeoJSONObject, String index, String geoFieldName) {
         JSONObject contents = new JSONObject();
-        String indexName = Strings.hasText(index) ? index : randomLowerCaseStringWithSuffix(ACCEPTED_INDEX_SUFFIX_PATH);
+        String indexName = Strings.hasText(index) ? index : randomLowerCaseString();
         String fieldName = Strings.hasText(geoFieldName) ? geoFieldName : randomLowerCaseString();
         contents.put(UploadGeoJSONRequestContent.FIELD_INDEX.getPreferredName(), indexName);
         contents.put(UploadGeoJSONRequestContent.FIELD_GEOSPATIAL.getPreferredName(), fieldName);

--- a/src/test/java/org/opensearch/geospatial/GeospatialTestHelper.java
+++ b/src/test/java/org/opensearch/geospatial/GeospatialTestHelper.java
@@ -16,7 +16,6 @@ import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertTrue;
 import static org.opensearch.geospatial.GeospatialObjectBuilder.buildProperties;
 import static org.opensearch.geospatial.GeospatialObjectBuilder.randomGeoJSONFeature;
-import static org.opensearch.geospatial.action.upload.geojson.UploadGeoJSONRequestContent.ACCEPTED_INDEX_SUFFIX_PATH;
 import static org.opensearch.geospatial.action.upload.geojson.UploadGeoJSONRequestContent.FIELD_DATA;
 import static org.opensearch.test.OpenSearchTestCase.randomBoolean;
 import static org.opensearch.test.OpenSearchTestCase.randomIntBetween;
@@ -66,10 +65,7 @@ public class GeospatialTestHelper {
         if (Randomness.get().nextBoolean()) {
             contents.put(ContentBuilder.GEOJSON_FEATURE_ID_FIELD, randomLowerCaseString());
         }
-        contents.put(
-            UploadGeoJSONRequestContent.FIELD_INDEX.getPreferredName(),
-            randomLowerCaseStringWithSuffix(ACCEPTED_INDEX_SUFFIX_PATH)
-        );
+        contents.put(UploadGeoJSONRequestContent.FIELD_INDEX.getPreferredName(), randomLowerCaseString());
         contents.put(UploadGeoJSONRequestContent.FIELD_GEOSPATIAL.getPreferredName(), randomLowerCaseString());
         contents.put(UploadGeoJSONRequestContent.FIELD_GEOSPATIAL_TYPE.getPreferredName(), "geo_shape");
         JSONArray values = new JSONArray();
@@ -84,10 +80,6 @@ public class GeospatialTestHelper {
 
     public static String randomLowerCaseString() {
         return randomString().toLowerCase(Locale.getDefault());
-    }
-
-    public static String randomLowerCaseStringWithSuffix(String suffix) {
-        return String.format(Locale.getDefault(), "%s%s", randomString().toLowerCase(Locale.getDefault()), suffix);
     }
 
     /**

--- a/src/test/java/org/opensearch/geospatial/action/upload/geojson/UploadGeoJSONRequestContentTests.java
+++ b/src/test/java/org/opensearch/geospatial/action/upload/geojson/UploadGeoJSONRequestContentTests.java
@@ -8,8 +8,6 @@ package org.opensearch.geospatial.action.upload.geojson;
 import static org.opensearch.geospatial.GeospatialObjectBuilder.buildProperties;
 import static org.opensearch.geospatial.GeospatialObjectBuilder.randomGeoJSONFeature;
 import static org.opensearch.geospatial.GeospatialTestHelper.randomLowerCaseString;
-import static org.opensearch.geospatial.GeospatialTestHelper.randomLowerCaseStringWithSuffix;
-import static org.opensearch.geospatial.action.upload.geojson.UploadGeoJSONRequestContent.ACCEPTED_INDEX_SUFFIX_PATH;
 import static org.opensearch.geospatial.action.upload.geojson.UploadGeoJSONRequestContent.FIELD_DATA;
 import static org.opensearch.geospatial.action.upload.geojson.UploadGeoJSONRequestContent.GEOSPATIAL_DEFAULT_FIELD_NAME;
 
@@ -21,9 +19,18 @@ import org.json.JSONObject;
 import org.opensearch.test.OpenSearchTestCase;
 
 public class UploadGeoJSONRequestContentTests extends OpenSearchTestCase {
+    private String indexName;
+    private String fieldName;
+
+    @Override
+    public void setUp() throws Exception {
+        super.setUp();
+        indexName = randomLowerCaseString();
+        fieldName = randomLowerCaseString();
+    }
 
     private Map<String, Object> buildRequestContent(String indexName, String fieldName) {
-        JSONObject contents = new JSONObject();
+        final var contents = new JSONObject();
         contents.put(UploadGeoJSONRequestContent.FIELD_INDEX.getPreferredName(), indexName);
         contents.put(UploadGeoJSONRequestContent.FIELD_GEOSPATIAL.getPreferredName(), fieldName);
         contents.put(UploadGeoJSONRequestContent.FIELD_GEOSPATIAL_TYPE.getPreferredName(), "geo_shape");
@@ -36,10 +43,8 @@ public class UploadGeoJSONRequestContentTests extends OpenSearchTestCase {
     }
 
     public void testCreate() {
-        final String indexName = randomLowerCaseStringWithSuffix(ACCEPTED_INDEX_SUFFIX_PATH);
-        final String fieldName = "location";
         Map<String, Object> contents = buildRequestContent(indexName, fieldName);
-        UploadGeoJSONRequestContent content = UploadGeoJSONRequestContent.create(contents);
+        final var content = UploadGeoJSONRequestContent.create(contents);
         assertNotNull(content);
         assertEquals(fieldName, content.getFieldName());
         assertEquals(indexName, content.getIndexName());
@@ -55,32 +60,12 @@ public class UploadGeoJSONRequestContentTests extends OpenSearchTestCase {
     }
 
     public void testCreateEmptyGeospatialFieldName() {
-        UploadGeoJSONRequestContent content = UploadGeoJSONRequestContent.create(
-            buildRequestContent(randomLowerCaseStringWithSuffix(ACCEPTED_INDEX_SUFFIX_PATH), "")
-        );
+        final var content = UploadGeoJSONRequestContent.create(buildRequestContent(randomLowerCaseString(), ""));
         assertNotNull(content);
         assertEquals("wrong field name", GEOSPATIAL_DEFAULT_FIELD_NAME, content.getFieldName());
     }
 
-    public void testCreateInvalidIndexName() {
-        final String indexName = randomLowerCaseString();
-        final String fieldName = "location";
-        Map<String, Object> contents = buildRequestContent(indexName, fieldName);
-        contents.remove(UploadGeoJSONRequestContent.FIELD_GEOSPATIAL_TYPE.getPreferredName());
-        IllegalArgumentException invalidIndexName = assertThrows(
-            IllegalArgumentException.class,
-            () -> UploadGeoJSONRequestContent.create(contents)
-        );
-        assertEquals(
-            "wrong exception message",
-            "field [ index ] should end with suffix " + ACCEPTED_INDEX_SUFFIX_PATH,
-            invalidIndexName.getMessage()
-        );
-    }
-
     public void testCreateEmptyGeospatialFieldType() {
-        final String indexName = randomLowerCaseStringWithSuffix(ACCEPTED_INDEX_SUFFIX_PATH);
-        final String fieldName = "location";
         Map<String, Object> contents = buildRequestContent(indexName, fieldName);
         contents.remove(UploadGeoJSONRequestContent.FIELD_GEOSPATIAL_TYPE.getPreferredName());
         IllegalArgumentException invalidIndexName = assertThrows(
@@ -89,5 +74,4 @@ public class UploadGeoJSONRequestContentTests extends OpenSearchTestCase {
         );
         assertTrue(invalidIndexName.getMessage().contains("[ type ] cannot be empty"));
     }
-
 }

--- a/src/test/java/org/opensearch/geospatial/rest/action/upload/geojson/RestUploadGeoJSONActionIT.java
+++ b/src/test/java/org/opensearch/geospatial/rest/action/upload/geojson/RestUploadGeoJSONActionIT.java
@@ -12,7 +12,6 @@
 package org.opensearch.geospatial.rest.action.upload.geojson;
 
 import static org.opensearch.geospatial.GeospatialTestHelper.randomLowerCaseString;
-import static org.opensearch.geospatial.GeospatialTestHelper.randomLowerCaseStringWithSuffix;
 import static org.opensearch.geospatial.action.upload.geojson.UploadGeoJSONRequestContent.*;
 
 import java.io.IOException;
@@ -31,7 +30,7 @@ public class RestUploadGeoJSONActionIT extends GeospatialRestTestCase {
 
     public void testGeoJSONUploadSuccessPostMethod() throws Exception {
 
-        final String index = randomLowerCaseStringWithSuffix(ACCEPTED_INDEX_SUFFIX_PATH);
+        final String index = randomLowerCaseString();
         assertIndexNotExists(index);
         Response response = uploadGeoJSONFeatures(NUMBER_OF_FEATURES_TO_ADD, index, null);
         assertEquals(RestStatus.OK, RestStatus.fromCode(response.getStatusLine().getStatusCode()));
@@ -41,8 +40,7 @@ public class RestUploadGeoJSONActionIT extends GeospatialRestTestCase {
 
     public void testGeoJSONUploadFailIndexExists() throws IOException {
 
-        String index = randomLowerCaseStringWithSuffix(ACCEPTED_INDEX_SUFFIX_PATH);
-        ;
+        String index = randomLowerCaseString();
         String geoFieldName = randomLowerCaseString();
         Map<String, String> geoFields = new HashMap<>();
         geoFields.put(geoFieldName, "geo_shape");
@@ -57,7 +55,7 @@ public class RestUploadGeoJSONActionIT extends GeospatialRestTestCase {
 
     public void testGeoJSONUploadSuccessPutMethod() throws Exception {
 
-        String index = randomLowerCaseStringWithSuffix(ACCEPTED_INDEX_SUFFIX_PATH);
+        String index = randomLowerCaseString();
         Response response = uploadGeoJSONFeaturesIntoExistingIndex(NUMBER_OF_FEATURES_TO_ADD, index, null);
         assertEquals(RestStatus.OK, RestStatus.fromCode(response.getStatusLine().getStatusCode()));
         assertIndexExists(index);
@@ -66,7 +64,7 @@ public class RestUploadGeoJSONActionIT extends GeospatialRestTestCase {
 
     public void testGeoJSONPutMethodUploadIndexExists() throws Exception {
 
-        String index = randomLowerCaseStringWithSuffix(ACCEPTED_INDEX_SUFFIX_PATH);
+        String index = randomLowerCaseString();
         String geoFieldName = randomLowerCaseString();
         Response response = uploadGeoJSONFeaturesIntoExistingIndex(NUMBER_OF_FEATURES_TO_ADD, index, geoFieldName);
         assertEquals(RestStatus.OK, RestStatus.fromCode(response.getStatusLine().getStatusCode()));


### PR DESCRIPTION
### Description
Maps will support add import GeoJSON into an index. This will be used by more layers like document, cluster. The restriction was previously added since it was mainly used as Custom Vector map. This change is already incorporated by front end.

Signed-off-by: Vijayan Balasubramanian <balasvij@amazon.com>

### Issues
https://github.com/opensearch-project/geospatial/issues/183
 
 
### Check List
- [x] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
