### PR TITLE
Fixed flaky test

### DIFF
--- a/libs/h3/build.gradle
+++ b/libs/h3/build.gradle
@@ -39,6 +39,7 @@ dependencies {
     api "org.apache.logging.log4j:log4j-core:${versions.log4j}"
     testImplementation "org.opensearch.test:framework:${opensearch_version}"
     testImplementation "org.apache.commons:commons-compress:1.21"
+    testImplementation "org.apache.lucene:lucene-spatial3d:${versions.lucene}"
 }
 licenseFile = "LICENSE.txt"
 noticeFile = "NOTICE.txt"

--- a/libs/h3/src/test/java/org/opensearch/geospatial/h3/GeoToH3Tests.java
+++ b/libs/h3/src/test/java/org/opensearch/geospatial/h3/GeoToH3Tests.java
@@ -22,8 +22,15 @@
  */
 package org.opensearch.geospatial.h3;
 
+import org.apache.lucene.spatial3d.geom.GeoPoint;
+import org.apache.lucene.spatial3d.geom.GeoPolygon;
+import org.apache.lucene.spatial3d.geom.GeoPolygonFactory;
+import org.apache.lucene.spatial3d.geom.PlanetModel;
 import org.apache.lucene.tests.geo.GeoTestUtil;
 import org.opensearch.test.OpenSearchTestCase;
+
+import java.util.ArrayList;
+import java.util.List;
 
 public class GeoToH3Tests extends OpenSearchTestCase {
 
@@ -33,28 +40,25 @@ public class GeoToH3Tests extends OpenSearchTestCase {
             double lat = randomValueOtherThanMany(d -> d > 60 || d < -60, GeoTestUtil::nextLatitude);
             // avoid points close to the dateline
             double lon = randomValueOtherThanMany(d -> d > 150 || d < -150, GeoTestUtil::nextLongitude);
-            testPoint(lat, lon);
+            testPoint(GeoTestUtil.nextLatitude(), GeoTestUtil.nextLongitude());
         }
     }
 
     private void testPoint(double lat, double lon) {
+        GeoPoint point = new GeoPoint(PlanetModel.SPHERE, Math.toRadians(lat), Math.toRadians(lon));
         for (int i = 0; i < Constants.MAX_H3_RES; i++) {
             String h3Address = H3.geoToH3Address(lat, lon, i);
-            CellBoundary cellBoundary = H3.h3ToGeoBoundary(h3Address);
-            double minLat = cellBoundary.getLatLon(0).getLatDeg();
-            double maxLat = cellBoundary.getLatLon(0).getLatDeg();
-            double minLon = cellBoundary.getLatLon(0).getLonDeg();
-            double maxLon = cellBoundary.getLatLon(0).getLonDeg();
-            for (int j = 0; j < cellBoundary.numPoints(); j++) {
-                minLat = Math.min(minLat, cellBoundary.getLatLon(j).getLatDeg());
-                maxLat = Math.max(maxLat, cellBoundary.getLatLon(j).getLatDeg());
-                minLon = Math.min(minLon, cellBoundary.getLatLon(j).getLonDeg());
-                maxLon = Math.max(maxLon, cellBoundary.getLatLon(j).getLonDeg());
-            }
-            assertTrue(minLat <= lat);
-            assertTrue(maxLat >= lat);
-            assertTrue(minLon <= lon);
-            assertTrue(maxLon >= lon);
+            GeoPolygon polygon = buildGeoPolygon(h3Address);
+            assertTrue(polygon.isWithin(point));
         }
+    }
+    private GeoPolygon buildGeoPolygon(String h3Address) {
+        CellBoundary cellBoundary = H3.h3ToGeoBoundary(h3Address);
+        List<GeoPoint> points = new ArrayList<>(cellBoundary.numPoints());
+        for (int i = 0; i < cellBoundary.numPoints(); i++) {
+            LatLng latLng = cellBoundary.getLatLon(i);
+            points.add(new GeoPoint(PlanetModel.SPHERE, latLng.getLatRad(), latLng.getLonRad()));
+        }
+        return GeoPolygonFactory.makeGeoPolygon(PlanetModel.SPHERE, points);
     }
 }


### PR DESCRIPTION

### Description
This fixes flaky reported test in testing random points.
Signed-off-by: Vijayan Balasubramanian <balasvij@amazon.com>
```
3c22fb3bf9b7:geospatial balasvij$ ./gradlew ':libs:h3:test' --tests "org.opensearch.geospatial.h3.GeoToH3Tests.testRandomPoints" -Dtests.seed=D62B244E662CCF3F -Dtests.security.manager=true
Picked up JAVA_TOOL_OPTIONS: -Dlog4j2.formatMsgNoLookups=true
=======================================
OpenSearch Build Hamster says Hello!
  Gradle Version        : 7.5.1
  OS Info               : Mac OS X 10.16 (x86_64)
  JDK Version           : 14 (OpenJDK)
  JAVA_HOME             : /Users/balasvij/.sdkman/candidates/java/14.0.2-open
  Random Testing Seed   : D62B244E662CCF3F
  In FIPS 140 mode      : false
=======================================

> Task :libs:h3:test
Picked up JAVA_TOOL_OPTIONS: -Dlog4j2.formatMsgNoLookups=true

Deprecated Gradle features were used in this build, making it incompatible with Gradle 8.0.

You can use '--warning-mode all' to show the individual deprecation warnings and determine if they come from your own scripts or plugins.

See https://docs.gradle.org/7.5.1/userguide/command_line_interface.html#sec:command_line_warnings

BUILD SUCCESSFUL in 4s
```
 
### Issues Resolved
#188 
 
### Check List
- [x] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
