### PR TITLE
Make jacoco report to be generated faster in local

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 ### Enhancements
 ### Bug Fixes
 ### Infrastructure
+* Make jacoco report to be generated faster in local ([#267](https://github.com/opensearch-project/geospatial/pull/267))
 ### Documentation
 ### Maintenance
 ### Refactoring

--- a/build.gradle
+++ b/build.gradle
@@ -261,7 +261,7 @@ spotless {
 }
 
 jacocoTestReport {
-    dependsOn integTest, test, yamlRestTest
+    dependsOn test
     reports {
         xml.enabled = true
         html.enabled = true


### PR DESCRIPTION
### Description
Jacoco report only needs unit test to be run. Therefore we exclude yamlRestTest and integTest from dependency so that it can be generated faster during local development.
 
### Issues Resolved
N/A
 
### Check List
- [X] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
