### PR TITLE
[Backport 2.x] Make jacoco report to be generated faster in local (#267)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 ### Enhancements
 ### Bug Fixes
 ### Infrastructure
+* Make jacoco report to be generated faster in local ([#267](https://github.com/opensearch-project/geospatial/pull/267))
+* Exclude lombok generated code from jacoco coverage report ([#268](https://github.com/opensearch-project/geospatial/pull/268))
 ### Documentation
 ### Maintenance
 ### Refactoring

--- a/build.gradle
+++ b/build.gradle
@@ -261,7 +261,7 @@ spotless {
 }
 
 jacocoTestReport {
-    dependsOn integTest, test, yamlRestTest
+    dependsOn test
     reports {
         xml.enabled = true
         html.enabled = true


### PR DESCRIPTION
Backport https://github.com/opensearch-project/geospatial/commit/71c71f4fe87703ab08f8931259a3104535b6de7d from https://github.com/opensearch-project/geospatial/pull/267