### PR TITLE
Add failure message in datasource metadata

### DIFF
--- a/src/main/java/org/opensearch/geospatial/ip2geo/jobscheduler/DatasourceRunner.java
+++ b/src/main/java/org/opensearch/geospatial/ip2geo/jobscheduler/DatasourceRunner.java
@@ -9,7 +9,6 @@
 package org.opensearch.geospatial.ip2geo.jobscheduler;
 
 import java.io.IOException;
-import java.time.Instant;
 
 import lombok.extern.log4j.Log4j2;
 
@@ -143,7 +142,7 @@ public class DatasourceRunner implements ScheduledJobRunner {
         if (DatasourceState.AVAILABLE.equals(datasource.getState()) == false) {
             log.error("Invalid datasource state. Expecting {} but received {}", DatasourceState.AVAILABLE, datasource.getState());
             datasource.disable();
-            datasource.getUpdateStats().setLastFailedAt(Instant.now());
+            datasource.setAsFailed("Datasource state is not in AVAILABLE");
             datasourceFacade.updateDatasource(datasource);
             return;
         }
@@ -154,7 +153,7 @@ public class DatasourceRunner implements ScheduledJobRunner {
             datasourceUpdateService.deleteUnusedIndices(datasource);
         } catch (Exception e) {
             log.error("Failed to update datasource for {}", datasource.getName(), e);
-            datasource.getUpdateStats().setLastFailedAt(Instant.now());
+            datasource.setAsFailed(e.getMessage());
             datasourceFacade.updateDatasource(datasource);
         }
     }

--- a/src/main/resources/mappings/ip2geo_datasource.json
+++ b/src/main/resources/mappings/ip2geo_datasource.json
@@ -70,6 +70,9 @@
         },
         "last_succeeded_at_in_epoch_millis" : {
           "type" : "long"
+        },
+        "last_failure_message" : {
+          "type" : "text"
         }
       }
     }

--- a/src/test/java/org/opensearch/geospatial/ip2geo/action/PutDatasourceTransportActionTests.java
+++ b/src/test/java/org/opensearch/geospatial/ip2geo/action/PutDatasourceTransportActionTests.java
@@ -102,12 +102,14 @@ public class PutDatasourceTransportActionTests extends Ip2GeoTestCase {
         // Verify
         assertEquals(DatasourceState.CREATE_FAILED, datasource.getState());
         assertNotNull(datasource.getUpdateStats().getLastFailedAt());
+        assertTrue(datasource.getUpdateStats().getLastFailureMessage().contains("not in CREATING"));
         verify(datasourceFacade).updateDatasource(datasource);
     }
 
     public void testCreateDatasourceWithException() throws Exception {
+        String errMsg = GeospatialTestHelper.randomLowerCaseString();
         Datasource datasource = new Datasource();
-        doThrow(new RuntimeException()).when(datasourceUpdateService).updateOrCreateGeoIpData(datasource);
+        doThrow(new RuntimeException(errMsg)).when(datasourceUpdateService).updateOrCreateGeoIpData(datasource);
 
         // Run
         action.createDatasource(datasource);
@@ -115,6 +117,7 @@ public class PutDatasourceTransportActionTests extends Ip2GeoTestCase {
         // Verify
         assertEquals(DatasourceState.CREATE_FAILED, datasource.getState());
         assertNotNull(datasource.getUpdateStats().getLastFailedAt());
+        assertTrue(datasource.getUpdateStats().getLastFailureMessage().contains(errMsg));
         verify(datasourceFacade).updateDatasource(datasource);
     }
 
@@ -127,5 +130,7 @@ public class PutDatasourceTransportActionTests extends Ip2GeoTestCase {
         // Verify
         verify(datasourceUpdateService).updateOrCreateGeoIpData(datasource);
         assertEquals(DatasourceState.CREATING, datasource.getState());
+        assertNull(datasource.getUpdateStats().getLastFailedAt());
+        assertNull(datasource.getUpdateStats().getLastFailureMessage());
     }
 }


### PR DESCRIPTION
### Description
Add failure message in datasource metadata based on comments in previous PR. https://github.com/opensearch-project/geospatial/pull/257/files#r1177299458
 
### Issues Resolved
N/A
 
### Check List
- [X] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
