### PR TITLE
Make some fields in manifest file as mandatory

### DIFF
--- a/src/main/java/org/opensearch/geospatial/ip2geo/action/PutDatasourceRequest.java
+++ b/src/main/java/org/opensearch/geospatial/ip2geo/action/PutDatasourceRequest.java
@@ -176,7 +176,7 @@ public class PutDatasourceRequest extends AcknowledgedRequest<PutDatasourceReque
             manifest = DatasourceManifest.Builder.build(url);
         } catch (Exception e) {
             log.info("Error occurred while reading a file from {}", url, e);
-            errors.addValidationError(String.format(Locale.ROOT, "Error occurred while reading a file from %s", url));
+            errors.addValidationError(String.format(Locale.ROOT, "Error occurred while reading a file from %s: %s", url, e.getMessage()));
             return;
         }
 
@@ -188,7 +188,7 @@ public class PutDatasourceRequest extends AcknowledgedRequest<PutDatasourceReque
             return;
         }
 
-        if (updateInterval.days() >= manifest.getValidForInDays()) {
+        if (manifest.getValidForInDays() != null && updateInterval.days() >= manifest.getValidForInDays()) {
             errors.addValidationError(
                 String.format(
                     Locale.ROOT,

--- a/src/main/java/org/opensearch/geospatial/ip2geo/common/DatasourceManifest.java
+++ b/src/main/java/org/opensearch/geospatial/ip2geo/common/DatasourceManifest.java
@@ -93,12 +93,12 @@ public class DatasourceManifest {
         }
     );
     static {
-        PARSER.declareString(ConstructingObjectParser.optionalConstructorArg(), URL_FIELD);
-        PARSER.declareString(ConstructingObjectParser.optionalConstructorArg(), DB_NAME_FIELD);
-        PARSER.declareString(ConstructingObjectParser.optionalConstructorArg(), SHA256_HASH_FIELD);
+        PARSER.declareString(ConstructingObjectParser.constructorArg(), URL_FIELD);
+        PARSER.declareString(ConstructingObjectParser.constructorArg(), DB_NAME_FIELD);
+        PARSER.declareString(ConstructingObjectParser.constructorArg(), SHA256_HASH_FIELD);
         PARSER.declareLong(ConstructingObjectParser.optionalConstructorArg(), VALID_FOR_IN_DAYS_FIELD);
-        PARSER.declareLong(ConstructingObjectParser.optionalConstructorArg(), UPDATED_AT_FIELD);
-        PARSER.declareString(ConstructingObjectParser.optionalConstructorArg(), PROVIDER_FIELD);
+        PARSER.declareLong(ConstructingObjectParser.constructorArg(), UPDATED_AT_FIELD);
+        PARSER.declareString(ConstructingObjectParser.constructorArg(), PROVIDER_FIELD);
     }
 
     /**

--- a/src/test/java/org/opensearch/geospatial/ip2geo/action/PutDatasourceRequestTests.java
+++ b/src/test/java/org/opensearch/geospatial/ip2geo/action/PutDatasourceRequestTests.java
@@ -23,7 +23,7 @@ import org.opensearch.geospatial.ip2geo.Ip2GeoTestCase;
 
 public class PutDatasourceRequestTests extends Ip2GeoTestCase {
 
-    public void testValidateWithInvalidUrl() {
+    public void testValidate_whenInvalidUrl_thenFails() {
         String datasourceName = GeospatialTestHelper.randomLowerCaseString();
         PutDatasourceRequest request = new PutDatasourceRequest(datasourceName);
         request.setEndpoint("invalidUrl");
@@ -33,7 +33,7 @@ public class PutDatasourceRequestTests extends Ip2GeoTestCase {
         assertEquals("Invalid URL format is provided", exception.validationErrors().get(0));
     }
 
-    public void testValidateWithInvalidManifestFile() {
+    public void testValidate_whenInvalidManifestFile_thenFails() {
         String datasourceName = GeospatialTestHelper.randomLowerCaseString();
         String domain = GeospatialTestHelper.randomLowerCaseString();
         PutDatasourceRequest request = new PutDatasourceRequest(datasourceName);
@@ -41,13 +41,10 @@ public class PutDatasourceRequestTests extends Ip2GeoTestCase {
         request.setUpdateInterval(TimeValue.timeValueDays(1));
         ActionRequestValidationException exception = request.validate();
         assertEquals(1, exception.validationErrors().size());
-        assertEquals(
-            String.format(Locale.ROOT, "Error occurred while reading a file from %s", request.getEndpoint()),
-            exception.validationErrors().get(0)
-        );
+        assertTrue(exception.validationErrors().get(0).contains("Error occurred while reading a file"));
     }
 
-    public void testValidate() throws Exception {
+    public void testValidate_whenValidInput_thenSucceed() throws Exception {
         String datasourceName = GeospatialTestHelper.randomLowerCaseString();
         PutDatasourceRequest request = new PutDatasourceRequest(datasourceName);
         request.setEndpoint(sampleManifestUrl());
@@ -55,7 +52,7 @@ public class PutDatasourceRequestTests extends Ip2GeoTestCase {
         assertNull(request.validate());
     }
 
-    public void testValidateWithZeroUpdateInterval() throws Exception {
+    public void testValidate_whenZeroUpdateInterval_thenFails() throws Exception {
         String datasourceName = GeospatialTestHelper.randomLowerCaseString();
         PutDatasourceRequest request = new PutDatasourceRequest(datasourceName);
         request.setEndpoint(sampleManifestUrl());
@@ -72,7 +69,7 @@ public class PutDatasourceRequestTests extends Ip2GeoTestCase {
         );
     }
 
-    public void testValidateWithLargeUpdateInterval() throws Exception {
+    public void testValidate_whenLargeUpdateInterval_thenFail() throws Exception {
         String datasourceName = GeospatialTestHelper.randomLowerCaseString();
         PutDatasourceRequest request = new PutDatasourceRequest(datasourceName);
         request.setEndpoint(sampleManifestUrl());
@@ -86,7 +83,7 @@ public class PutDatasourceRequestTests extends Ip2GeoTestCase {
         assertTrue(exception.validationErrors().get(0).contains("should be smaller"));
     }
 
-    public void testValidateWithInvalidUrlInsideManifest() throws Exception {
+    public void testValidate_whenInvalidUrlInsideManifest_thenFail() throws Exception {
         String datasourceName = GeospatialTestHelper.randomLowerCaseString();
         PutDatasourceRequest request = new PutDatasourceRequest(datasourceName);
         request.setEndpoint(sampleManifestUrlWithInvalidUrl());
@@ -100,7 +97,7 @@ public class PutDatasourceRequestTests extends Ip2GeoTestCase {
         assertTrue(exception.validationErrors().get(0).contains("Invalid URL format"));
     }
 
-    public void testValidateDatasourceNames() throws Exception {
+    public void testValidate_whenInvalidDatasourceNames_thenFails() throws Exception {
         String validDatasourceName = GeospatialTestHelper.randomLowerCaseString();
         String domain = GeospatialTestHelper.randomLowerCaseString();
         PutDatasourceRequest request = new PutDatasourceRequest(validDatasourceName);
@@ -154,7 +151,7 @@ public class PutDatasourceRequestTests extends Ip2GeoTestCase {
         }
     }
 
-    public void testStreamInOut() throws Exception {
+    public void testStreamInOut_whenValidInput_thenSucceed() throws Exception {
         String datasourceName = GeospatialTestHelper.randomLowerCaseString();
         String domain = GeospatialTestHelper.randomLowerCaseString();
         PutDatasourceRequest request = new PutDatasourceRequest(datasourceName);


### PR DESCRIPTION
### Description
Make some fields in manifest file as mandatory so that it can return failure message to a user in API response.

```
{"error":{"root_cause":[{"type":"action_request_validation_exception","reason":"Validation Failed: 1: Error occurred while reading a file from https://d17zozg08cgjfy.cloudfront.net/manifest-small.json: Required [sha256_hash];"}],"type":"action_request_validation_exception","reason":"Validation Failed: 1: Error occurred while reading a file from https://d17zozg08cgjfy.cloudfront.net/manifest-small.json: Required [sha256_hash];"},"status":400}%  
```
 
### Issues Resolved
N/A
 
### Check List
- [X] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
