### PR TITLE
Reduce lock duration and renew the lock during update

### DIFF
--- a/src/main/java/org/opensearch/geospatial/ip2geo/action/PutDatasourceTransportAction.java
+++ b/src/main/java/org/opensearch/geospatial/ip2geo/action/PutDatasourceTransportAction.java
@@ -5,11 +5,14 @@
 
 package org.opensearch.geospatial.ip2geo.action;
 
-import java.io.IOException;
+import static org.opensearch.geospatial.ip2geo.common.Ip2GeoLockService.LOCK_DURATION_IN_SECONDS;
+
 import java.time.Instant;
+import java.util.concurrent.atomic.AtomicReference;
 
 import lombok.extern.log4j.Log4j2;
 
+import org.opensearch.OpenSearchException;
 import org.opensearch.ResourceAlreadyExistsException;
 import org.opensearch.action.ActionListener;
 import org.opensearch.action.StepListener;
@@ -21,9 +24,11 @@ import org.opensearch.common.inject.Inject;
 import org.opensearch.geospatial.annotation.VisibleForTesting;
 import org.opensearch.geospatial.ip2geo.common.DatasourceFacade;
 import org.opensearch.geospatial.ip2geo.common.DatasourceState;
+import org.opensearch.geospatial.ip2geo.common.Ip2GeoLockService;
 import org.opensearch.geospatial.ip2geo.jobscheduler.Datasource;
 import org.opensearch.geospatial.ip2geo.jobscheduler.DatasourceUpdateService;
 import org.opensearch.index.engine.VersionConflictEngineException;
+import org.opensearch.jobscheduler.spi.LockModel;
 import org.opensearch.tasks.Task;
 import org.opensearch.threadpool.ThreadPool;
 import org.opensearch.transport.TransportService;
@@ -36,6 +41,7 @@ public class PutDatasourceTransportAction extends HandledTransportAction<PutData
     private final ThreadPool threadPool;
     private final DatasourceFacade datasourceFacade;
     private final DatasourceUpdateService datasourceUpdateService;
+    private final Ip2GeoLockService lockService;
 
     /**
      * Default constructor
@@ -44,6 +50,7 @@ public class PutDatasourceTransportAction extends HandledTransportAction<PutData
      * @param threadPool the thread pool
      * @param datasourceFacade the datasource facade
      * @param datasourceUpdateService the datasource update service
+     * @param lockService the lock service
      */
     @Inject
     public PutDatasourceTransportAction(
@@ -51,35 +58,57 @@ public class PutDatasourceTransportAction extends HandledTransportAction<PutData
         final ActionFilters actionFilters,
         final ThreadPool threadPool,
         final DatasourceFacade datasourceFacade,
-        final DatasourceUpdateService datasourceUpdateService
+        final DatasourceUpdateService datasourceUpdateService,
+        final Ip2GeoLockService lockService
     ) {
         super(PutDatasourceAction.NAME, transportService, actionFilters, PutDatasourceRequest::new);
         this.threadPool = threadPool;
         this.datasourceFacade = datasourceFacade;
         this.datasourceUpdateService = datasourceUpdateService;
+        this.lockService = lockService;
     }
 
     @Override
     protected void doExecute(final Task task, final PutDatasourceRequest request, final ActionListener<AcknowledgedResponse> listener) {
-        try {
-            StepListener<Void> createIndexStep = new StepListener<>();
-            datasourceFacade.createIndexIfNotExists(createIndexStep);
-            createIndexStep.whenComplete(v -> putDatasource(request, listener), exception -> listener.onFailure(exception));
-        } catch (Exception e) {
-            listener.onFailure(e);
-        }
+        lockService.acquireLock(request.getName(), LOCK_DURATION_IN_SECONDS, ActionListener.wrap(lock -> {
+            if (lock == null) {
+                listener.onFailure(new OpenSearchException("another processor is holding a lock on the resource. Try again later"));
+                return;
+            }
+            try {
+                internalDoExecute(request, lock, listener);
+            } catch (Exception e) {
+                listener.onFailure(e);
+            } finally {
+                lockService.releaseLock(
+                    lock,
+                    ActionListener.wrap(released -> {}, exception -> log.error("Failed to release the lock", exception))
+                );
+            }
+        }, exception -> { listener.onFailure(exception); }));
     }
 
     @VisibleForTesting
-    protected void putDatasource(final PutDatasourceRequest request, final ActionListener<AcknowledgedResponse> listener)
-        throws IOException {
-        Datasource datasource = Datasource.Builder.build(request);
-        datasourceFacade.putDatasource(datasource, getIndexResponseListener(datasource, listener));
+    protected void internalDoExecute(
+        final PutDatasourceRequest request,
+        final LockModel lock,
+        final ActionListener<AcknowledgedResponse> listener
+    ) {
+        StepListener<Void> createIndexStep = new StepListener<>();
+        datasourceFacade.createIndexIfNotExists(createIndexStep);
+        createIndexStep.whenComplete(v -> {
+            Datasource datasource = Datasource.Builder.build(request);
+            datasourceFacade.putDatasource(
+                datasource,
+                getIndexResponseListener(datasource, lockService.getRenewLockRunnable(new AtomicReference<>(lock)), listener)
+            );
+        }, exception -> listener.onFailure(exception));
     }
 
     @VisibleForTesting
     protected ActionListener<IndexResponse> getIndexResponseListener(
         final Datasource datasource,
+        final Runnable renewLock,
         final ActionListener<AcknowledgedResponse> listener
     ) {
         return new ActionListener<>() {
@@ -87,7 +116,7 @@ public class PutDatasourceTransportAction extends HandledTransportAction<PutData
             public void onResponse(final IndexResponse indexResponse) {
                 // This is user initiated request. Therefore, we want to handle the first datasource update task in a generic thread
                 // pool.
-                threadPool.generic().submit(() -> { createDatasource(datasource); });
+                threadPool.generic().submit(() -> { createDatasource(datasource, renewLock); });
                 listener.onResponse(new AcknowledgedResponse(true));
             }
 
@@ -103,7 +132,7 @@ public class PutDatasourceTransportAction extends HandledTransportAction<PutData
     }
 
     @VisibleForTesting
-    protected void createDatasource(final Datasource datasource) {
+    protected void createDatasource(final Datasource datasource, final Runnable renewLock) {
         if (DatasourceState.CREATING.equals(datasource.getState()) == false) {
             log.error("Invalid datasource state. Expecting {} but received {}", DatasourceState.CREATING, datasource.getState());
             markDatasourceAsCreateFailed(datasource);
@@ -111,7 +140,7 @@ public class PutDatasourceTransportAction extends HandledTransportAction<PutData
         }
 
         try {
-            datasourceUpdateService.updateOrCreateGeoIpData(datasource);
+            datasourceUpdateService.updateOrCreateGeoIpData(datasource, renewLock);
         } catch (Exception e) {
             log.error("Failed to create datasource for {}", datasource.getName(), e);
             markDatasourceAsCreateFailed(datasource);

--- a/src/main/java/org/opensearch/geospatial/ip2geo/jobscheduler/Datasource.java
+++ b/src/main/java/org/opensearch/geospatial/ip2geo/jobscheduler/Datasource.java
@@ -33,6 +33,7 @@ import org.opensearch.geospatial.annotation.VisibleForTesting;
 import org.opensearch.geospatial.ip2geo.action.PutDatasourceRequest;
 import org.opensearch.geospatial.ip2geo.common.DatasourceManifest;
 import org.opensearch.geospatial.ip2geo.common.DatasourceState;
+import org.opensearch.geospatial.ip2geo.common.Ip2GeoLockService;
 import org.opensearch.jobscheduler.spi.ScheduledJobParameter;
 import org.opensearch.jobscheduler.spi.schedule.IntervalSchedule;
 import org.opensearch.jobscheduler.spi.schedule.ScheduleParser;
@@ -50,7 +51,6 @@ public class Datasource implements Writeable, ScheduledJobParameter {
      * Prefix of indices having Ip2Geo data
      */
     public static final String IP2GEO_DATA_INDEX_NAME_PREFIX = ".ip2geo-data";
-    private static final long LOCK_DURATION_IN_SECONDS = 60 * 60;
     private static final long MAX_JITTER_IN_MINUTES = 5;
     private static final long ONE_DAY_IN_HOURS = 24;
     private static final long ONE_HOUR_IN_MINUTES = 60;
@@ -282,7 +282,7 @@ public class Datasource implements Writeable, ScheduledJobParameter {
 
     @Override
     public Long getLockDurationSeconds() {
-        return LOCK_DURATION_IN_SECONDS;
+        return Ip2GeoLockService.LOCK_DURATION_IN_SECONDS;
     }
 
     /**

--- a/src/main/java/org/opensearch/geospatial/ip2geo/jobscheduler/DatasourceUpdateService.java
+++ b/src/main/java/org/opensearch/geospatial/ip2geo/jobscheduler/DatasourceUpdateService.java
@@ -48,10 +48,11 @@ public class DatasourceUpdateService {
     /**
      * Update GeoIp data
      *
-     * @param datasource
+     * @param datasource the datasource
+     * @param renewLock runnable to renew lock
      * @throws Exception
      */
-    public void updateOrCreateGeoIpData(final Datasource datasource) throws Exception {
+    public void updateOrCreateGeoIpData(final Datasource datasource, final Runnable renewLock) throws Exception {
         URL url = new URL(datasource.getEndpoint());
         DatasourceManifest manifest = DatasourceManifest.Builder.build(url);
 
@@ -77,7 +78,13 @@ public class DatasourceUpdateService {
                     datasource.getDatabase().getFields().toString()
                 );
             }
-            geoIpDataFacade.putGeoIpData(indexName, header, reader.iterator(), clusterSettings.get(Ip2GeoSettings.INDEXING_BULK_SIZE));
+            geoIpDataFacade.putGeoIpData(
+                indexName,
+                header,
+                reader.iterator(),
+                clusterSettings.get(Ip2GeoSettings.INDEXING_BULK_SIZE),
+                renewLock
+            );
         }
 
         Instant endTime = Instant.now();

--- a/src/main/java/org/opensearch/geospatial/plugin/GeospatialPlugin.java
+++ b/src/main/java/org/opensearch/geospatial/plugin/GeospatialPlugin.java
@@ -45,6 +45,7 @@ import org.opensearch.geospatial.ip2geo.action.RestPutDatasourceHandler;
 import org.opensearch.geospatial.ip2geo.common.DatasourceFacade;
 import org.opensearch.geospatial.ip2geo.common.GeoIpDataFacade;
 import org.opensearch.geospatial.ip2geo.common.Ip2GeoExecutor;
+import org.opensearch.geospatial.ip2geo.common.Ip2GeoLockService;
 import org.opensearch.geospatial.ip2geo.common.Ip2GeoSettings;
 import org.opensearch.geospatial.ip2geo.jobscheduler.DatasourceRunner;
 import org.opensearch.geospatial.ip2geo.jobscheduler.DatasourceUpdateService;
@@ -130,13 +131,22 @@ public class GeospatialPlugin extends Plugin implements IngestPlugin, ActionPlug
         DatasourceFacade datasourceFacade = new DatasourceFacade(client, clusterService);
         DatasourceUpdateService datasourceUpdateService = new DatasourceUpdateService(clusterService, datasourceFacade, geoIpDataFacade);
         Ip2GeoExecutor ip2GeoExecutor = new Ip2GeoExecutor(threadPool);
+        Ip2GeoLockService ip2GeoLockService = new Ip2GeoLockService(clusterService, client);
         /**
          * We don't need to return datasource runner because it is used only by job scheduler and job scheduler
          * does not use DI but it calls DatasourceExtension#getJobRunner to get DatasourceRunner instance.
          */
-        DatasourceRunner.getJobRunnerInstance().initialize(clusterService, datasourceUpdateService, ip2GeoExecutor, datasourceFacade);
+        DatasourceRunner.getJobRunnerInstance()
+            .initialize(clusterService, datasourceUpdateService, ip2GeoExecutor, datasourceFacade, ip2GeoLockService);
 
-        return List.of(UploadStats.getInstance(), datasourceUpdateService, datasourceFacade, ip2GeoExecutor, geoIpDataFacade);
+        return List.of(
+            UploadStats.getInstance(),
+            datasourceUpdateService,
+            datasourceFacade,
+            ip2GeoExecutor,
+            geoIpDataFacade,
+            ip2GeoLockService
+        );
     }
 
     @Override

--- a/src/test/java/org/opensearch/geospatial/ip2geo/action/PutDatasourceRequestTests.java
+++ b/src/test/java/org/opensearch/geospatial/ip2geo/action/PutDatasourceRequestTests.java
@@ -36,7 +36,11 @@ public class PutDatasourceRequestTests extends Ip2GeoTestCase {
         PutDatasourceRequest request = new PutDatasourceRequest(datasourceName);
         request.setEndpoint(String.format(Locale.ROOT, "https://%s.com", domain));
         request.setUpdateInterval(TimeValue.timeValueDays(1));
+
+        // Run
         ActionRequestValidationException exception = request.validate();
+
+        // Verify
         assertEquals(1, exception.validationErrors().size());
         assertTrue(exception.validationErrors().get(0).contains("Error occurred while reading a file"));
     }

--- a/src/test/java/org/opensearch/geospatial/ip2geo/action/PutDatasourceTransportActionTests.java
+++ b/src/test/java/org/opensearch/geospatial/ip2geo/action/PutDatasourceTransportActionTests.java
@@ -6,14 +6,22 @@
 package org.opensearch.geospatial.ip2geo.action;
 
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyLong;
+import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.doThrow;
 import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import java.io.IOException;
+import java.time.Instant;
 
 import lombok.SneakyThrows;
 
 import org.junit.Before;
 import org.mockito.ArgumentCaptor;
+import org.opensearch.OpenSearchException;
 import org.opensearch.ResourceAlreadyExistsException;
 import org.opensearch.action.ActionListener;
 import org.opensearch.action.StepListener;
@@ -24,6 +32,7 @@ import org.opensearch.geospatial.ip2geo.Ip2GeoTestCase;
 import org.opensearch.geospatial.ip2geo.common.DatasourceState;
 import org.opensearch.geospatial.ip2geo.jobscheduler.Datasource;
 import org.opensearch.index.engine.VersionConflictEngineException;
+import org.opensearch.jobscheduler.spi.LockModel;
 import org.opensearch.tasks.Task;
 
 public class PutDatasourceTransportActionTests extends Ip2GeoTestCase {
@@ -31,19 +40,75 @@ public class PutDatasourceTransportActionTests extends Ip2GeoTestCase {
 
     @Before
     public void init() {
-        action = new PutDatasourceTransportAction(transportService, actionFilters, threadPool, datasourceFacade, datasourceUpdateService);
+        action = new PutDatasourceTransportAction(
+            transportService,
+            actionFilters,
+            threadPool,
+            datasourceFacade,
+            datasourceUpdateService,
+            ip2GeoLockService
+        );
+    }
+
+    @SneakyThrows
+    public void testDoExecute_whenFailedToAcquireLock_thenError() {
+        validateDoExecute(null, null);
     }
 
     @SneakyThrows
     public void testDoExecute_whenValidInput_thenSucceed() {
+        String jobIndexName = GeospatialTestHelper.randomLowerCaseString();
+        String jobId = GeospatialTestHelper.randomLowerCaseString();
+        LockModel lockModel = new LockModel(jobIndexName, jobId, Instant.now(), randomPositiveLong(), false);
+        validateDoExecute(lockModel, null);
+    }
+
+    @SneakyThrows
+    public void testDoExecute_whenException_thenError() {
+        validateDoExecute(null, new RuntimeException());
+    }
+
+    private void validateDoExecute(final LockModel lockModel, final Exception exception) throws IOException {
         Task task = mock(Task.class);
+        Datasource datasource = randomDatasource();
+        when(datasourceFacade.getDatasource(datasource.getName())).thenReturn(datasource);
+        PutDatasourceRequest request = new PutDatasourceRequest(datasource.getName());
+        ActionListener<AcknowledgedResponse> listener = mock(ActionListener.class);
+
+        // Run
+        action.doExecute(task, request, listener);
+
+        // Verify
+        ArgumentCaptor<ActionListener<LockModel>> captor = ArgumentCaptor.forClass(ActionListener.class);
+        verify(ip2GeoLockService).acquireLock(eq(datasource.getName()), anyLong(), captor.capture());
+
+        if (exception == null) {
+            // Run
+            captor.getValue().onResponse(lockModel);
+
+            // Verify
+            if (lockModel == null) {
+                verify(listener).onFailure(any(OpenSearchException.class));
+            } else {
+                verify(ip2GeoLockService).releaseLock(eq(lockModel), any(ActionListener.class));
+            }
+        } else {
+            // Run
+            captor.getValue().onFailure(exception);
+            // Verify
+            verify(listener).onFailure(exception);
+        }
+    }
+
+    @SneakyThrows
+    public void testInternalDoExecute_whenValidInput_thenSucceed() {
         PutDatasourceRequest request = new PutDatasourceRequest(GeospatialTestHelper.randomLowerCaseString());
         request.setEndpoint(sampleManifestUrl());
         request.setUpdateInterval(TimeValue.timeValueDays(1));
         ActionListener<AcknowledgedResponse> listener = mock(ActionListener.class);
 
         // Run
-        action.doExecute(task, request, listener);
+        action.internalDoExecute(request, randomLockModel(), listener);
 
         // Verify
         ArgumentCaptor<StepListener> captor = ArgumentCaptor.forClass(StepListener.class);
@@ -68,7 +133,7 @@ public class PutDatasourceTransportActionTests extends Ip2GeoTestCase {
     public void testGetIndexResponseListener_whenVersionConflict_thenFailure() {
         Datasource datasource = new Datasource();
         ActionListener<AcknowledgedResponse> listener = mock(ActionListener.class);
-        action.getIndexResponseListener(datasource, listener)
+        action.getIndexResponseListener(datasource, mock(Runnable.class), listener)
             .onFailure(
                 new VersionConflictEngineException(
                     null,
@@ -86,21 +151,22 @@ public class PutDatasourceTransportActionTests extends Ip2GeoTestCase {
         datasource.getUpdateStats().setLastFailedAt(null);
 
         // Run
-        action.createDatasource(datasource);
+        action.createDatasource(datasource, mock(Runnable.class));
 
         // Verify
         assertEquals(DatasourceState.CREATE_FAILED, datasource.getState());
         assertNotNull(datasource.getUpdateStats().getLastFailedAt());
         verify(datasourceFacade).updateDatasource(datasource);
+        verify(datasourceUpdateService, never()).updateOrCreateGeoIpData(any(Datasource.class), any(Runnable.class));
     }
 
     @SneakyThrows
     public void testCreateDatasource_whenExceptionHappens_thenUpdateStateAsFailed() {
         Datasource datasource = new Datasource();
-        doThrow(new RuntimeException()).when(datasourceUpdateService).updateOrCreateGeoIpData(datasource);
+        doThrow(new RuntimeException()).when(datasourceUpdateService).updateOrCreateGeoIpData(any(Datasource.class), any(Runnable.class));
 
         // Run
-        action.createDatasource(datasource);
+        action.createDatasource(datasource, mock(Runnable.class));
 
         // Verify
         assertEquals(DatasourceState.CREATE_FAILED, datasource.getState());
@@ -112,11 +178,12 @@ public class PutDatasourceTransportActionTests extends Ip2GeoTestCase {
     public void testCreateDatasource_whenValidInput_thenUpdateStateAsCreating() {
         Datasource datasource = new Datasource();
 
+        Runnable renewLock = mock(Runnable.class);
         // Run
-        action.createDatasource(datasource);
+        action.createDatasource(datasource, renewLock);
 
         // Verify
-        verify(datasourceUpdateService).updateOrCreateGeoIpData(datasource);
+        verify(datasourceUpdateService).updateOrCreateGeoIpData(datasource, renewLock);
         assertEquals(DatasourceState.CREATING, datasource.getState());
     }
 }

--- a/src/test/java/org/opensearch/geospatial/ip2geo/common/Ip2GeoLockServiceTests.java
+++ b/src/test/java/org/opensearch/geospatial/ip2geo/common/Ip2GeoLockServiceTests.java
@@ -6,41 +6,103 @@
 package org.opensearch.geospatial.ip2geo.common;
 
 import static org.mockito.Mockito.mock;
+import static org.opensearch.geospatial.ip2geo.common.Ip2GeoLockService.LOCK_DURATION_IN_SECONDS;
+import static org.opensearch.geospatial.ip2geo.common.Ip2GeoLockService.RENEW_AFTER_IN_SECONDS;
 
 import java.time.Instant;
+import java.util.concurrent.atomic.AtomicReference;
 
 import org.junit.Before;
 import org.opensearch.action.ActionListener;
-import org.opensearch.common.unit.TimeValue;
+import org.opensearch.action.DocWriteResponse;
+import org.opensearch.action.update.UpdateRequest;
+import org.opensearch.action.update.UpdateResponse;
 import org.opensearch.geospatial.GeospatialTestHelper;
 import org.opensearch.geospatial.ip2geo.Ip2GeoTestCase;
+import org.opensearch.index.shard.ShardId;
+import org.opensearch.jobscheduler.spi.LockModel;
 
 public class Ip2GeoLockServiceTests extends Ip2GeoTestCase {
     private Ip2GeoLockService ip2GeoLockService;
+    private Ip2GeoLockService noOpsLockService;
 
     @Before
     public void init() {
-        ip2GeoLockService = new Ip2GeoLockService(clusterService, client);
+        ip2GeoLockService = new Ip2GeoLockService(clusterService, verifyingClient);
+        noOpsLockService = new Ip2GeoLockService(clusterService, client);
     }
 
     public void testAcquireLock_whenValidInput_thenSucceed() {
         // Cannot test because LockService is final class
         // Simply calling method to increase coverage
-        ip2GeoLockService.acquireLock(GeospatialTestHelper.randomLowerCaseString(), randomPositiveLong(), mock(ActionListener.class));
+        noOpsLockService.acquireLock(GeospatialTestHelper.randomLowerCaseString(), randomPositiveLong(), mock(ActionListener.class));
     }
 
     public void testReleaseLock_whenValidInput_thenSucceed() {
         // Cannot test because LockService is final class
         // Simply calling method to increase coverage
-        ip2GeoLockService.releaseLock(null, mock(ActionListener.class));
+        noOpsLockService.releaseLock(null, mock(ActionListener.class));
     }
 
     public void testRenewLock_whenCalled_thenNotBlocked() {
-        long timeoutInMillis = 10000;
         long expectedDurationInMillis = 1000;
         Instant before = Instant.now();
-        assertNull(ip2GeoLockService.renewLock(null, TimeValue.timeValueMillis(timeoutInMillis)));
+        assertNull(ip2GeoLockService.renewLock(null));
         Instant after = Instant.now();
         assertTrue(after.toEpochMilli() - before.toEpochMilli() < expectedDurationInMillis);
+    }
+
+    public void testGetRenewLockRunnable_whenLockIsFresh_thenDoNotRenew() {
+        LockModel lockModel = new LockModel(
+            GeospatialTestHelper.randomLowerCaseString(),
+            GeospatialTestHelper.randomLowerCaseString(),
+            Instant.now(),
+            LOCK_DURATION_IN_SECONDS,
+            false
+        );
+
+        verifyingClient.setExecuteVerifier((actionResponse, actionRequest) -> {
+            // Verifying
+            assertTrue(actionRequest instanceof UpdateRequest);
+            return new UpdateResponse(
+                mock(ShardId.class),
+                GeospatialTestHelper.randomLowerCaseString(),
+                randomPositiveLong(),
+                randomPositiveLong(),
+                randomPositiveLong(),
+                DocWriteResponse.Result.UPDATED
+            );
+        });
+
+        AtomicReference<LockModel> reference = new AtomicReference<>(lockModel);
+        ip2GeoLockService.getRenewLockRunnable(reference).run();
+        assertEquals(lockModel, reference.get());
+    }
+
+    public void testGetRenewLockRunnable_whenLockIsStale_thenRenew() {
+        LockModel lockModel = new LockModel(
+            GeospatialTestHelper.randomLowerCaseString(),
+            GeospatialTestHelper.randomLowerCaseString(),
+            Instant.now().minusSeconds(RENEW_AFTER_IN_SECONDS),
+            LOCK_DURATION_IN_SECONDS,
+            false
+        );
+
+        verifyingClient.setExecuteVerifier((actionResponse, actionRequest) -> {
+            // Verifying
+            assertTrue(actionRequest instanceof UpdateRequest);
+            return new UpdateResponse(
+                mock(ShardId.class),
+                GeospatialTestHelper.randomLowerCaseString(),
+                randomPositiveLong(),
+                randomPositiveLong(),
+                randomPositiveLong(),
+                DocWriteResponse.Result.UPDATED
+            );
+        });
+
+        AtomicReference<LockModel> reference = new AtomicReference<>(lockModel);
+        ip2GeoLockService.getRenewLockRunnable(reference).run();
+        assertNotEquals(lockModel, reference.get());
     }
 }

--- a/src/test/java/org/opensearch/geospatial/ip2geo/jobscheduler/DatasourceRunnerTests.java
+++ b/src/test/java/org/opensearch/geospatial/ip2geo/jobscheduler/DatasourceRunnerTests.java
@@ -6,6 +6,8 @@
 package org.opensearch.geospatial.ip2geo.jobscheduler;
 
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyLong;
+import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.doThrow;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.never;
@@ -14,52 +16,111 @@ import static org.mockito.Mockito.when;
 import static org.mockito.internal.verification.VerificationModeFactory.times;
 import static org.opensearch.geospatial.GeospatialTestHelper.randomLowerCaseString;
 
+import java.io.IOException;
 import java.time.Instant;
 
+import lombok.SneakyThrows;
+
 import org.junit.Before;
+import org.mockito.ArgumentCaptor;
+import org.opensearch.action.ActionListener;
+import org.opensearch.geospatial.GeospatialTestHelper;
 import org.opensearch.geospatial.ip2geo.Ip2GeoTestCase;
 import org.opensearch.geospatial.ip2geo.common.DatasourceState;
+import org.opensearch.geospatial.ip2geo.common.Ip2GeoLockService;
 import org.opensearch.jobscheduler.spi.JobDocVersion;
 import org.opensearch.jobscheduler.spi.JobExecutionContext;
+import org.opensearch.jobscheduler.spi.LockModel;
 import org.opensearch.jobscheduler.spi.ScheduledJobParameter;
 
 public class DatasourceRunnerTests extends Ip2GeoTestCase {
     @Before
     public void init() {
-        DatasourceRunner.getJobRunnerInstance().initialize(clusterService, datasourceUpdateService, ip2GeoExecutor, datasourceFacade);
+        DatasourceRunner.getJobRunnerInstance()
+            .initialize(clusterService, datasourceUpdateService, ip2GeoExecutor, datasourceFacade, ip2GeoLockService);
     }
 
-    public void testRunJobInvalidClass() {
+    public void testRunJob_whenInvalidClass_thenThrowException() {
         JobExecutionContext jobExecutionContext = mock(JobExecutionContext.class);
         ScheduledJobParameter jobParameter = mock(ScheduledJobParameter.class);
         expectThrows(IllegalStateException.class, () -> DatasourceRunner.getJobRunnerInstance().runJob(jobParameter, jobExecutionContext));
     }
 
-    public void testRunJob() {
+    public void testRunJob_whenValidInput_thenSucceed() {
         JobDocVersion jobDocVersion = new JobDocVersion(randomInt(), randomInt(), randomInt());
         String jobIndexName = randomLowerCaseString();
         String jobId = randomLowerCaseString();
         JobExecutionContext jobExecutionContext = new JobExecutionContext(Instant.now(), jobDocVersion, lockService, jobIndexName, jobId);
-        Datasource datasource = new Datasource();
+        Datasource datasource = randomDatasource();
 
         // Run
         DatasourceRunner.getJobRunnerInstance().runJob(datasource, jobExecutionContext);
 
         // Verify
-        verify(executorService).submit(any(Runnable.class));
+        verify(ip2GeoLockService).acquireLock(
+            eq(datasource.getName()),
+            eq(Ip2GeoLockService.LOCK_DURATION_IN_SECONDS),
+            any(ActionListener.class)
+        );
     }
 
-    public void testUpdateDatasourceNull() throws Exception {
+    @SneakyThrows
+    public void testUpdateDatasourceRunner_whenFailedToAcquireLock_thenError() {
+        validateDoExecute(null, null);
+    }
+
+    @SneakyThrows
+    public void testUpdateDatasourceRunner_whenValidInput_thenSucceed() {
+        String jobIndexName = GeospatialTestHelper.randomLowerCaseString();
+        String jobId = GeospatialTestHelper.randomLowerCaseString();
+        LockModel lockModel = new LockModel(jobIndexName, jobId, Instant.now(), randomPositiveLong(), false);
+        validateDoExecute(lockModel, null);
+    }
+
+    @SneakyThrows
+    public void testUpdateDatasourceRunner_whenException_thenError() {
+        validateDoExecute(null, new RuntimeException());
+    }
+
+    private void validateDoExecute(final LockModel lockModel, final Exception exception) throws IOException {
+        ScheduledJobParameter jobParameter = mock(ScheduledJobParameter.class);
+        when(jobParameter.getName()).thenReturn(GeospatialTestHelper.randomLowerCaseString());
+
+        // Run
+        DatasourceRunner.getJobRunnerInstance().updateDatasourceRunner(jobParameter).run();
+
+        // Verify
+        ArgumentCaptor<ActionListener<LockModel>> captor = ArgumentCaptor.forClass(ActionListener.class);
+        verify(ip2GeoLockService).acquireLock(eq(jobParameter.getName()), anyLong(), captor.capture());
+
+        if (exception == null) {
+            // Run
+            captor.getValue().onResponse(lockModel);
+
+            // Verify
+            verify(ip2GeoLockService, lockModel == null ? never() : times(1)).releaseLock(eq(lockModel), any(ActionListener.class));
+        } else {
+            // Run
+            captor.getValue().onFailure(exception);
+
+            // Verify
+            verify(ip2GeoLockService, never()).releaseLock(eq(lockModel), any(ActionListener.class));
+        }
+    }
+
+    @SneakyThrows
+    public void testUpdateDatasource_whenDatasourceDoesNotExist_thenDoNothing() {
         Datasource datasource = new Datasource();
 
         // Run
-        DatasourceRunner.getJobRunnerInstance().updateDatasource(datasource);
+        DatasourceRunner.getJobRunnerInstance().updateDatasource(datasource, mock(Runnable.class));
 
         // Verify
         verify(datasourceUpdateService, never()).deleteUnusedIndices(any());
     }
 
-    public void testUpdateDatasourceInvalidState() throws Exception {
+    @SneakyThrows
+    public void testUpdateDatasource_whenInvalidState_thenUpdateLastFailedAt() {
         Datasource datasource = new Datasource();
         datasource.enable();
         datasource.getUpdateStats().setLastFailedAt(null);
@@ -67,7 +128,7 @@ public class DatasourceRunnerTests extends Ip2GeoTestCase {
         when(datasourceFacade.getDatasource(datasource.getName())).thenReturn(datasource);
 
         // Run
-        DatasourceRunner.getJobRunnerInstance().updateDatasource(datasource);
+        DatasourceRunner.getJobRunnerInstance().updateDatasource(datasource, mock(Runnable.class));
 
         // Verify
         assertFalse(datasource.isEnabled());
@@ -75,21 +136,24 @@ public class DatasourceRunnerTests extends Ip2GeoTestCase {
         verify(datasourceFacade).updateDatasource(datasource);
     }
 
-    public void testUpdateDatasource() throws Exception {
+    @SneakyThrows
+    public void testUpdateDatasource_whenValidInput_thenSucceed() {
         Datasource datasource = new Datasource();
         datasource.setState(DatasourceState.AVAILABLE);
         datasource.setName(randomLowerCaseString());
         when(datasourceFacade.getDatasource(datasource.getName())).thenReturn(datasource);
+        Runnable renewLock = mock(Runnable.class);
 
         // Run
-        DatasourceRunner.getJobRunnerInstance().updateDatasource(datasource);
+        DatasourceRunner.getJobRunnerInstance().updateDatasource(datasource, renewLock);
 
         // Verify
         verify(datasourceUpdateService, times(2)).deleteUnusedIndices(datasource);
-        verify(datasourceUpdateService).updateOrCreateGeoIpData(datasource);
+        verify(datasourceUpdateService).updateOrCreateGeoIpData(datasource, renewLock);
     }
 
-    public void testUpdateDatasourceExceptionHandling() throws Exception {
+    @SneakyThrows
+    public void testUpdateDatasourceExceptionHandling() {
         Datasource datasource = new Datasource();
         datasource.setName(randomLowerCaseString());
         datasource.getUpdateStats().setLastFailedAt(null);
@@ -97,7 +161,7 @@ public class DatasourceRunnerTests extends Ip2GeoTestCase {
         doThrow(new RuntimeException("test failure")).when(datasourceUpdateService).deleteUnusedIndices(any());
 
         // Run
-        DatasourceRunner.getJobRunnerInstance().updateDatasource(datasource);
+        DatasourceRunner.getJobRunnerInstance().updateDatasource(datasource, mock(Runnable.class));
 
         // Verify
         assertNotNull(datasource.getUpdateStats().getLastFailedAt());

--- a/src/test/java/org/opensearch/geospatial/plugin/GeospatialPluginTests.java
+++ b/src/test/java/org/opensearch/geospatial/plugin/GeospatialPluginTests.java
@@ -37,6 +37,7 @@ import org.opensearch.geospatial.ip2geo.action.RestPutDatasourceHandler;
 import org.opensearch.geospatial.ip2geo.common.DatasourceFacade;
 import org.opensearch.geospatial.ip2geo.common.GeoIpDataFacade;
 import org.opensearch.geospatial.ip2geo.common.Ip2GeoExecutor;
+import org.opensearch.geospatial.ip2geo.common.Ip2GeoLockService;
 import org.opensearch.geospatial.ip2geo.common.Ip2GeoSettings;
 import org.opensearch.geospatial.ip2geo.jobscheduler.DatasourceUpdateService;
 import org.opensearch.geospatial.processor.FeatureProcessor;
@@ -71,7 +72,8 @@ public class GeospatialPluginTests extends OpenSearchTestCase {
         DatasourceUpdateService.class,
         DatasourceFacade.class,
         Ip2GeoExecutor.class,
-        GeoIpDataFacade.class
+        GeoIpDataFacade.class,
+        Ip2GeoLockService.class
     );
 
     @Mock


### PR DESCRIPTION
### Description
1. Acquire lock before creating a datasource to avoid race condition with update/delete datasource APIs.
2. Reduce lock duration and renew the lock during datasource update for better user experience when process die without releasing lock properly.

 
### Issues Resolved
N/A
 
### Check List
- [X] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
