### PR TITLE
Add ip2geo processor integ test for failure case

### DIFF
--- a/src/main/java/org/opensearch/geospatial/ip2geo/processor/Ip2GeoProcessor.java
+++ b/src/main/java/org/opensearch/geospatial/ip2geo/processor/Ip2GeoProcessor.java
@@ -43,6 +43,14 @@ import org.opensearch.ingest.Processor;
 public final class Ip2GeoProcessor extends AbstractProcessor {
     private static final Map<String, Object> DATA_EXPIRED = Map.of("error", "ip2geo_data_expired");
     private static final String PROPERTY_IP = "ip";
+
+    public static final String CONFIG_FIELD = "field";
+    public static final String CONFIG_TARGET_FIELD = "target_field";
+    public static final String CONFIG_DATASOURCE = "datasource";
+    public static final String CONFIG_PROPERTIES = "target_field";
+    public static final String CONFIG_IGNORE_MISSING = "ignore_missing";
+    public static final String CONFIG_FIRST_ONLY = "first_only";
+
     private final String field;
     private final String targetField;
     /**
@@ -352,12 +360,12 @@ public final class Ip2GeoProcessor extends AbstractProcessor {
             final String description,
             final Map<String, Object> config
         ) throws IOException {
-            String ipField = readStringProperty(TYPE, processorTag, config, "field");
-            String targetField = readStringProperty(TYPE, processorTag, config, "target_field", "ip2geo");
-            String datasourceName = readStringProperty(TYPE, processorTag, config, "datasource");
-            List<String> propertyNames = readOptionalList(TYPE, processorTag, config, "properties");
-            boolean ignoreMissing = readBooleanProperty(TYPE, processorTag, config, "ignore_missing", false);
-            boolean firstOnly = readBooleanProperty(TYPE, processorTag, config, "first_only", true);
+            String ipField = readStringProperty(TYPE, processorTag, config, CONFIG_FIELD);
+            String targetField = readStringProperty(TYPE, processorTag, config, CONFIG_TARGET_FIELD, "ip2geo");
+            String datasourceName = readStringProperty(TYPE, processorTag, config, CONFIG_DATASOURCE);
+            List<String> propertyNames = readOptionalList(TYPE, processorTag, config, CONFIG_PROPERTIES);
+            boolean ignoreMissing = readBooleanProperty(TYPE, processorTag, config, CONFIG_IGNORE_MISSING, false);
+            boolean firstOnly = readBooleanProperty(TYPE, processorTag, config, CONFIG_FIRST_ONLY, true);
 
             // Skip validation for the call by cluster applier service
             if (Thread.currentThread().getName().contains(CLUSTER_UPDATE_THREAD_NAME) == false) {

--- a/src/test/java/org/opensearch/geospatial/ip2geo/processor/Ip2GeoProcessorIT.java
+++ b/src/test/java/org/opensearch/geospatial/ip2geo/processor/Ip2GeoProcessorIT.java
@@ -1,0 +1,54 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package org.opensearch.geospatial.ip2geo.processor;
+
+import java.io.IOException;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Optional;
+
+import lombok.SneakyThrows;
+
+import org.opensearch.client.Response;
+import org.opensearch.client.ResponseException;
+import org.opensearch.geospatial.GeospatialRestTestCase;
+import org.opensearch.geospatial.GeospatialTestHelper;
+
+public class Ip2GeoProcessorIT extends GeospatialRestTestCase {
+
+    @SneakyThrows
+    public void testCreateIp2GeoProcessor_whenNoSuchDatasourceExist_thenFails() {
+        String pipelineName = GeospatialTestHelper.randomLowerCaseString();
+
+        // Run
+        ResponseException exception = expectThrows(
+            ResponseException.class,
+            () -> createIp2GeoProcessorPipeline(pipelineName, Collections.emptyMap())
+        );
+
+        // Verify
+        assertTrue(exception.getMessage().contains("doesn't exist"));
+    }
+
+    private Response createIp2GeoProcessorPipeline(final String pipelineName, final Map<String, String> properties) throws IOException {
+        String field = GeospatialTestHelper.randomLowerCaseString();
+        String datasourceName = GeospatialTestHelper.randomLowerCaseString();
+        Map<String, String> defaultProperties = Map.of(
+            Ip2GeoProcessor.CONFIG_FIELD,
+            field,
+            Ip2GeoProcessor.CONFIG_DATASOURCE,
+            datasourceName
+        );
+        Map<String, String> baseProperties = new HashMap<>();
+        baseProperties.putAll(defaultProperties);
+        baseProperties.putAll(properties);
+        Map<String, Object> processorConfig = buildProcessorConfig(Ip2GeoProcessor.TYPE, baseProperties);
+
+        return createPipeline(pipelineName, Optional.empty(), Arrays.asList(processorConfig));
+    }
+}


### PR DESCRIPTION
### Description
Add integration test which fails creation of Ip2Geo processor when specified datasource does not exist
 
### Issues Resolved
N/A
 
### Check List
- [X] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
