### PR TITLE
Change index setting from read_only_allow_delete to write

### DIFF
--- a/src/main/java/org/opensearch/geospatial/ip2geo/common/GeoIpDataFacade.java
+++ b/src/main/java/org/opensearch/geospatial/ip2geo/common/GeoIpDataFacade.java
@@ -70,10 +70,7 @@ public class GeoIpDataFacade {
     private static final Tuple<String, Integer> INDEX_SETTING_REFRESH_INTERVAL = new Tuple<>("index.refresh_interval", -1);
     private static final Tuple<String, String> INDEX_SETTING_AUTO_EXPAND_REPLICAS = new Tuple<>("index.auto_expand_replicas", "0-all");
     private static final Tuple<String, Boolean> INDEX_SETTING_HIDDEN = new Tuple<>("index.hidden", true);
-    private static final Tuple<String, Boolean> INDEX_SETTING_READ_ONLY_ALLOW_DELETE = new Tuple<>(
-        "index.blocks.read_only_allow_delete",
-        true
-    );
+    private static final Tuple<String, Boolean> INDEX_SETTING_BLOCKS_WRITE = new Tuple<>("index.blocks.write", true);
     private final ClusterService clusterService;
     private final ClusterSettings clusterSettings;
     private final Client client;
@@ -116,8 +113,7 @@ public class GeoIpDataFacade {
             client.admin().indices().prepareRefresh(indexName).execute().actionGet(timeout);
             client.admin().indices().prepareForceMerge(indexName).setMaxNumSegments(1).execute().actionGet(timeout);
             Map<String, Object> settings = new HashMap<>();
-            settings.put(INDEX_SETTING_READ_ONLY_ALLOW_DELETE.v1(), INDEX_SETTING_READ_ONLY_ALLOW_DELETE.v2());
-            settings.put(INDEX_SETTING_NUM_OF_REPLICAS.v1(), null);
+            settings.put(INDEX_SETTING_BLOCKS_WRITE.v1(), INDEX_SETTING_BLOCKS_WRITE.v2());
             settings.put(INDEX_SETTING_AUTO_EXPAND_REPLICAS.v1(), INDEX_SETTING_AUTO_EXPAND_REPLICAS.v2());
             client.admin()
                 .indices()

--- a/src/test/java/org/opensearch/geospatial/ip2geo/common/GeoIpDataFacadeTests.java
+++ b/src/test/java/org/opensearch/geospatial/ip2geo/common/GeoIpDataFacadeTests.java
@@ -210,7 +210,7 @@ public class GeoIpDataFacadeTests extends Ip2GeoTestCase {
                 UpdateSettingsRequest request = (UpdateSettingsRequest) actionRequest;
                 assertEquals(1, request.indices().length);
                 assertEquals(index, request.indices()[0]);
-                assertEquals(true, request.settings().getAsBoolean("index.blocks.read_only_allow_delete", false));
+                assertEquals(true, request.settings().getAsBoolean("index.blocks.write", false));
                 assertNull(request.settings().get("index.num_of_replica"));
                 assertEquals("0-all", request.settings().get("index.auto_expand_replicas"));
                 return null;


### PR DESCRIPTION


### Description
read_only_allow_delete does not block write to an index. The disk-based shard allocator may add and remove this block automatically. Therefore, use index.blocks.write instead.
 
### Issues Resolved
N/A
 
### Check List
- [X] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
