### PR TITLE
Stablize ip2geo datasource creation

### DIFF
--- a/src/main/java/org/opensearch/geospatial/ip2geo/common/DatasourceFacade.java
+++ b/src/main/java/org/opensearch/geospatial/ip2geo/common/DatasourceFacade.java
@@ -173,13 +173,14 @@ public class DatasourceFacade {
      *
      */
     public void deleteDatasource(final Datasource datasource) {
-        if (client.admin()
-            .indices()
-            .prepareDelete(datasource.getIndices().toArray(new String[0]))
-            .setIndicesOptions(IndicesOptions.LENIENT_EXPAND_OPEN)
-            .execute()
-            .actionGet(clusterSettings.get(Ip2GeoSettings.TIMEOUT))
-            .isAcknowledged() == false) {
+        if (datasource.getIndices().size() != 0
+            && client.admin()
+                .indices()
+                .prepareDelete(datasource.getIndices().toArray(new String[0]))
+                .setIndicesOptions(IndicesOptions.LENIENT_EXPAND_OPEN)
+                .execute()
+                .actionGet(clusterSettings.get(Ip2GeoSettings.TIMEOUT))
+                .isAcknowledged() == false) {
             throw new OpenSearchException("failed to delete data[{}] in datasource", String.join(",", datasource.getIndices()));
         }
         DeleteResponse response = client.prepareDelete()

--- a/src/main/java/org/opensearch/geospatial/ip2geo/common/Ip2GeoExecutor.java
+++ b/src/main/java/org/opensearch/geospatial/ip2geo/common/Ip2GeoExecutor.java
@@ -5,6 +5,8 @@
 
 package org.opensearch.geospatial.ip2geo.common;
 
+import java.util.ArrayList;
+import java.util.List;
 import java.util.concurrent.ExecutorService;
 
 import org.opensearch.common.settings.Settings;
@@ -16,7 +18,8 @@ import org.opensearch.threadpool.ThreadPool;
  * Provide a list of static methods related with executors for Ip2Geo
  */
 public class Ip2GeoExecutor {
-    private static final String THREAD_POOL_NAME = "_plugin_geospatial_ip2geo_datasource_update";
+    private static final String THREAD_POOL_NAME_DATASOURCE_CREATE = "_plugin_geospatial_ip2geo_datasource_create";
+    private static final String THREAD_POOL_NAME_DATASOURCE_UPDATE = "_plugin_geospatial_ip2geo_datasource_update";
     private final ThreadPool threadPool;
 
     public Ip2GeoExecutor(final ThreadPool threadPool) {
@@ -24,14 +27,27 @@ public class Ip2GeoExecutor {
     }
 
     /**
-     * We use fixed thread count of 1 for updating datasource as updating datasource is running background
+     * Datasource creation thread pool:
+     * Use fixed thread count of 1 with zero queue size for creating datasource.
+     * This is to reduce the load on cluster by preventing multiple creation requests to be processed concurrently in a node.
+     * Queue size is zero as task in queue cannot renew lock which will cause the datasource to be modified by another request meanwhile.
+     *
+     * Datasource update thread pool:
+     * Use fixed thread count of 1 for updating datasource as updating datasource is running background
      * once a day at most and no need to expedite the task.
      *
      * @param settings the settings
      * @return the executor builder
      */
-    public static ExecutorBuilder executorBuilder(final Settings settings) {
-        return new FixedExecutorBuilder(settings, THREAD_POOL_NAME, 1, 1000, THREAD_POOL_NAME, false);
+    public static List<ExecutorBuilder<?>> executorBuilder(final Settings settings) {
+        List<ExecutorBuilder<?>> executorBuilders = new ArrayList<>();
+        executorBuilders.add(
+            new FixedExecutorBuilder(settings, THREAD_POOL_NAME_DATASOURCE_CREATE, 1, 0, THREAD_POOL_NAME_DATASOURCE_CREATE, false)
+        );
+        executorBuilders.add(
+            new FixedExecutorBuilder(settings, THREAD_POOL_NAME_DATASOURCE_UPDATE, 1, 1000, THREAD_POOL_NAME_DATASOURCE_UPDATE, false)
+        );
+        return executorBuilders;
     }
 
     /**
@@ -40,6 +56,15 @@ public class Ip2GeoExecutor {
      * @return the executor service
      */
     public ExecutorService forDatasourceUpdate() {
-        return threadPool.executor(THREAD_POOL_NAME);
+        return threadPool.executor(THREAD_POOL_NAME_DATASOURCE_UPDATE);
+    }
+
+    /**
+     * Return an executor service for datasource create task
+     *
+     * @return the executor service
+     */
+    public ExecutorService forDatasourceCreate() {
+        return threadPool.executor(THREAD_POOL_NAME_DATASOURCE_CREATE);
     }
 }

--- a/src/main/java/org/opensearch/geospatial/plugin/GeospatialPlugin.java
+++ b/src/main/java/org/opensearch/geospatial/plugin/GeospatialPlugin.java
@@ -110,7 +110,7 @@ public class GeospatialPlugin extends Plugin implements IngestPlugin, ActionPlug
     @Override
     public List<ExecutorBuilder<?>> getExecutorBuilders(Settings settings) {
         List<ExecutorBuilder<?>> executorBuilders = new ArrayList<>();
-        executorBuilders.add(Ip2GeoExecutor.executorBuilder(settings));
+        executorBuilders.addAll(Ip2GeoExecutor.executorBuilder(settings));
         return executorBuilders;
     }
 

--- a/src/test/java/org/opensearch/geospatial/ip2geo/Ip2GeoTestCase.java
+++ b/src/test/java/org/opensearch/geospatial/ip2geo/Ip2GeoTestCase.java
@@ -116,6 +116,7 @@ public abstract class Ip2GeoTestCase extends RestActionTestCase {
         when(clusterState.getMetadata()).thenReturn(metadata);
         when(clusterState.routingTable()).thenReturn(RoutingTable.EMPTY_ROUTING_TABLE);
         when(ip2GeoExecutor.forDatasourceUpdate()).thenReturn(OpenSearchExecutors.newDirectExecutorService());
+        when(ip2GeoExecutor.forDatasourceCreate()).thenReturn(OpenSearchExecutors.newDirectExecutorService());
         when(ingestService.getClusterService()).thenReturn(clusterService);
         when(threadPool.generic()).thenReturn(OpenSearchExecutors.newDirectExecutorService());
     }

--- a/src/test/java/org/opensearch/geospatial/ip2geo/common/GeoIpDataFacadeTests.java
+++ b/src/test/java/org/opensearch/geospatial/ip2geo/common/GeoIpDataFacadeTests.java
@@ -89,9 +89,7 @@ public class GeoIpDataFacadeTests extends Ip2GeoTestCase {
             CreateIndexRequest request = (CreateIndexRequest) actionRequest;
             assertEquals(index, request.index());
             assertEquals(1, (int) request.settings().getAsInt("index.number_of_shards", 0));
-            assertNull(request.settings().get("index.auto_expand_replicas"));
-            assertEquals(0, (int) request.settings().getAsInt("index.number_of_replicas", 1));
-            assertEquals(-1, (int) request.settings().getAsInt("index.refresh_interval", 0));
+            assertEquals("0-all", request.settings().get("index.auto_expand_replicas"));
             assertEquals(true, request.settings().getAsBoolean("index.hidden", false));
 
             assertEquals(
@@ -211,8 +209,6 @@ public class GeoIpDataFacadeTests extends Ip2GeoTestCase {
                 assertEquals(1, request.indices().length);
                 assertEquals(index, request.indices()[0]);
                 assertEquals(true, request.settings().getAsBoolean("index.blocks.write", false));
-                assertNull(request.settings().get("index.num_of_replica"));
-                assertEquals("0-all", request.settings().get("index.auto_expand_replicas"));
                 return null;
             } else {
                 throw new RuntimeException("invalid request is called");


### PR DESCRIPTION
### Description
Made following changes to reduce the load on cluster and avoid OOM in a cost of increased latency during datasource creation

1. Enable refresh on datasource index
2. Wait until refresh policy for bulk request
3. Allow only single datasource creation process per node
 
### Issues Resolved
N/A
 
### Check List
- [X] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
