### PR TITLE
Return null index name for expired data

### DIFF
--- a/src/main/java/org/opensearch/geospatial/ip2geo/jobscheduler/Datasource.java
+++ b/src/main/java/org/opensearch/geospatial/ip2geo/jobscheduler/Datasource.java
@@ -307,7 +307,7 @@ public class Datasource implements Writeable, ScheduledJobParameter {
      * @return Current index name of a datasource
      */
     public String currentIndexName() {
-        return indexNameFor(database.updatedAt.toEpochMilli());
+        return isExpired() ? null : indexNameFor(database.updatedAt.toEpochMilli());
     }
 
     /**


### PR DESCRIPTION


### Description
Return null index name for expired data so that it can be deleted by clean up process. Clean up process exclude current index from deleting.
 
### Issues Resolved
N/A
 
### Check List
- [X] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
