### PR TITLE
Removed parameter and settings

### DIFF
--- a/src/main/java/org/opensearch/geospatial/ip2geo/common/Ip2GeoSettings.java
+++ b/src/main/java/org/opensearch/geospatial/ip2geo/common/Ip2GeoSettings.java
@@ -52,30 +52,6 @@ public class Ip2GeoSettings {
     );
 
     /**
-     * Bulk size for indexing GeoIP data
-     */
-    public static final Setting<Integer> INDEXING_BULK_SIZE = Setting.intSetting(
-        "plugins.geospatial.ip2geo.datasource.indexing_bulk_size",
-        10000,
-        1,
-        Setting.Property.NodeScope,
-        Setting.Property.Dynamic
-    );
-
-    /**
-     * Multi search bundle size for GeoIP data
-     *
-     * Multi search is used only when a field contains a list of ip addresses.
-     */
-    public static final Setting<Integer> MAX_BUNDLE_SIZE = Setting.intSetting(
-        "plugins.geospatial.ip2geo.processor.max_bundle_size",
-        100,
-        1,
-        Setting.Property.NodeScope,
-        Setting.Property.Dynamic
-    );
-
-    /**
      * Multi search max concurrent searches
      *
      * Multi search is used only when a field contains a list of ip addresses.
@@ -96,14 +72,7 @@ public class Ip2GeoSettings {
      * @return a list of all settings for Ip2Geo feature
      */
     public static final List<Setting<?>> settings() {
-        return List.of(
-            DATASOURCE_ENDPOINT,
-            DATASOURCE_UPDATE_INTERVAL,
-            TIMEOUT,
-            INDEXING_BULK_SIZE,
-            MAX_BUNDLE_SIZE,
-            MAX_CONCURRENT_SEARCHES
-        );
+        return List.of(DATASOURCE_ENDPOINT, DATASOURCE_UPDATE_INTERVAL, TIMEOUT, MAX_CONCURRENT_SEARCHES);
     }
 
     /**

--- a/src/main/java/org/opensearch/geospatial/ip2geo/jobscheduler/DatasourceUpdateService.java
+++ b/src/main/java/org/opensearch/geospatial/ip2geo/jobscheduler/DatasourceUpdateService.java
@@ -25,7 +25,6 @@ import org.opensearch.geospatial.ip2geo.common.DatasourceFacade;
 import org.opensearch.geospatial.ip2geo.common.DatasourceManifest;
 import org.opensearch.geospatial.ip2geo.common.DatasourceState;
 import org.opensearch.geospatial.ip2geo.common.GeoIpDataFacade;
-import org.opensearch.geospatial.ip2geo.common.Ip2GeoSettings;
 import org.opensearch.jobscheduler.spi.schedule.IntervalSchedule;
 
 @Log4j2
@@ -83,13 +82,7 @@ public class DatasourceUpdateService {
                     datasource.getDatabase().getFields().toString()
                 );
             }
-            geoIpDataFacade.putGeoIpData(
-                indexName,
-                header,
-                reader.iterator(),
-                clusterSettings.get(Ip2GeoSettings.INDEXING_BULK_SIZE),
-                renewLock
-            );
+            geoIpDataFacade.putGeoIpData(indexName, header, reader.iterator(), renewLock);
         }
 
         Instant endTime = Instant.now();

--- a/src/test/java/org/opensearch/geospatial/ip2geo/Ip2GeoTestCase.java
+++ b/src/test/java/org/opensearch/geospatial/ip2geo/Ip2GeoTestCase.java
@@ -258,7 +258,6 @@ public abstract class Ip2GeoTestCase extends RestActionTestCase {
             datasourceName,
             properties,
             true,
-            true,
             clusterSettings,
             datasourceFacade,
             geoIpDataFacade

--- a/src/test/java/org/opensearch/geospatial/ip2geo/jobscheduler/DatasourceUpdateServiceTests.java
+++ b/src/test/java/org/opensearch/geospatial/ip2geo/jobscheduler/DatasourceUpdateServiceTests.java
@@ -6,7 +6,6 @@
 package org.opensearch.geospatial.ip2geo.jobscheduler;
 
 import static org.mockito.ArgumentMatchers.any;
-import static org.mockito.ArgumentMatchers.anyInt;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.ArgumentMatchers.isA;
 import static org.mockito.Mockito.mock;
@@ -90,7 +89,6 @@ public class DatasourceUpdateServiceTests extends Ip2GeoTestCase {
             eq(datasource.currentIndexName()),
             isA(String[].class),
             any(Iterator.class),
-            anyInt(),
             any(Runnable.class)
         );
     }
@@ -167,7 +165,6 @@ public class DatasourceUpdateServiceTests extends Ip2GeoTestCase {
             eq(datasource.currentIndexName()),
             isA(String[].class),
             any(Iterator.class),
-            anyInt(),
             any(Runnable.class)
         );
     }


### PR DESCRIPTION


### Description
* Removed first_only parameter
* Removed max_concurrency and batch_size setting

first_only parameter was added as current geoip processor has it. However, the parameter have no benefit for ip2geo processor as we don't do a sequantial search for array data but use multi search.

max_concurrency and batch_size setting is removed as these are only reveal internal implementation and could be a future blocker to improve performance later.
 
### Issues Resolved
N/A
 
### Check List
- [X] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
