### PR TITLE
Add a field in datasource for current index name

### DIFF
--- a/src/main/java/org/opensearch/geospatial/ip2geo/action/GetDatasourceResponse.java
+++ b/src/main/java/org/opensearch/geospatial/ip2geo/action/GetDatasourceResponse.java
@@ -26,7 +26,7 @@ import org.opensearch.geospatial.ip2geo.jobscheduler.Datasource;
  */
 @Getter
 @Setter
-@EqualsAndHashCode
+@EqualsAndHashCode(callSuper = false)
 public class GetDatasourceResponse extends ActionResponse implements ToXContentObject {
     private static final ParseField FIELD_NAME_DATASOURCES = new ParseField("datasources");
     private static final ParseField FIELD_NAME_NAME = new ParseField("name");

--- a/src/main/java/org/opensearch/geospatial/ip2geo/action/PutDatasourceRequest.java
+++ b/src/main/java/org/opensearch/geospatial/ip2geo/action/PutDatasourceRequest.java
@@ -18,8 +18,8 @@ import lombok.Setter;
 import lombok.extern.log4j.Log4j2;
 
 import org.opensearch.OpenSearchException;
+import org.opensearch.action.ActionRequest;
 import org.opensearch.action.ActionRequestValidationException;
-import org.opensearch.action.support.master.AcknowledgedRequest;
 import org.opensearch.common.Strings;
 import org.opensearch.common.io.stream.StreamInput;
 import org.opensearch.common.io.stream.StreamOutput;
@@ -34,8 +34,8 @@ import org.opensearch.geospatial.ip2geo.common.DatasourceManifest;
 @Getter
 @Setter
 @Log4j2
-@EqualsAndHashCode
-public class PutDatasourceRequest extends AcknowledgedRequest<PutDatasourceRequest> {
+@EqualsAndHashCode(callSuper = false)
+public class PutDatasourceRequest extends ActionRequest {
     private static final int MAX_DATASOURCE_NAME_BYTES = 255;
     public static final ParseField ENDPOINT_FIELD = new ParseField("endpoint");
     public static final ParseField UPDATE_INTERVAL_IN_DAYS_FIELD = new ParseField("update_interval_in_days");

--- a/src/main/java/org/opensearch/geospatial/ip2geo/action/UpdateDatasourceRequest.java
+++ b/src/main/java/org/opensearch/geospatial/ip2geo/action/UpdateDatasourceRequest.java
@@ -16,8 +16,8 @@ import lombok.Getter;
 import lombok.Setter;
 import lombok.extern.log4j.Log4j2;
 
+import org.opensearch.action.ActionRequest;
 import org.opensearch.action.ActionRequestValidationException;
-import org.opensearch.action.support.master.AcknowledgedRequest;
 import org.opensearch.common.io.stream.StreamInput;
 import org.opensearch.common.io.stream.StreamOutput;
 import org.opensearch.common.unit.TimeValue;
@@ -32,7 +32,7 @@ import org.opensearch.geospatial.ip2geo.common.DatasourceManifest;
 @Setter
 @Log4j2
 @EqualsAndHashCode(callSuper = false)
-public class UpdateDatasourceRequest extends AcknowledgedRequest<UpdateDatasourceRequest> {
+public class UpdateDatasourceRequest extends ActionRequest {
     public static final ParseField ENDPOINT_FIELD = new ParseField("endpoint");
     public static final ParseField UPDATE_INTERVAL_IN_DAYS_FIELD = new ParseField("update_interval_in_days");
     private static final int MAX_DATASOURCE_NAME_BYTES = 255;

--- a/src/test/java/org/opensearch/geospatial/ip2geo/Ip2GeoTestCase.java
+++ b/src/test/java/org/opensearch/geospatial/ip2geo/Ip2GeoTestCase.java
@@ -208,6 +208,7 @@ public abstract class Ip2GeoTestCase extends RestActionTestCase {
         datasource.setSystemSchedule(datasource.getUserSchedule());
         datasource.setTask(randomTask());
         datasource.setState(randomState());
+        datasource.setCurrentIndex(GeospatialTestHelper.randomLowerCaseString());
         datasource.setIndices(Arrays.asList(GeospatialTestHelper.randomLowerCaseString(), GeospatialTestHelper.randomLowerCaseString()));
         datasource.setEndpoint(String.format(Locale.ROOT, "https://%s.com/manifest.json", GeospatialTestHelper.randomLowerCaseString()));
         datasource.getDatabase()

--- a/src/test/java/org/opensearch/geospatial/ip2geo/jobscheduler/DatasourceUpdateServiceTests.java
+++ b/src/test/java/org/opensearch/geospatial/ip2geo/jobscheduler/DatasourceUpdateServiceTests.java
@@ -190,6 +190,7 @@ public class DatasourceUpdateServiceTests extends Ip2GeoTestCase {
         String lingeringIndex = indexPrefix + now.minusMillis(2).toEpochMilli();
         Datasource datasource = new Datasource();
         datasource.setName(datasourceName);
+        datasource.setCurrentIndex(currentIndex);
         datasource.getIndices().add(currentIndex);
         datasource.getIndices().add(oldIndex);
         datasource.getIndices().add(lingeringIndex);


### PR DESCRIPTION
### Description
Add a field in datasource for current index name and use current time as suffix for new index name.
This is needed to handle snapshot restoring in next PR where we will create a new index always and delete any restored index.

 
### Issues Resolved
N/A
 
### Check List
- [X] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
