### PR TITLE
Delete GeoIP data indices after restoring complete

### DIFF
--- a/src/main/java/org/opensearch/geospatial/ip2geo/action/DeleteDatasourceTransportAction.java
+++ b/src/main/java/org/opensearch/geospatial/ip2geo/action/DeleteDatasourceTransportAction.java
@@ -20,6 +20,7 @@ import org.opensearch.geospatial.exceptions.ConcurrentModificationException;
 import org.opensearch.geospatial.exceptions.ResourceInUseException;
 import org.opensearch.geospatial.ip2geo.common.DatasourceFacade;
 import org.opensearch.geospatial.ip2geo.common.DatasourceState;
+import org.opensearch.geospatial.ip2geo.common.GeoIpDataFacade;
 import org.opensearch.geospatial.ip2geo.common.Ip2GeoLockService;
 import org.opensearch.geospatial.ip2geo.common.Ip2GeoProcessorFacade;
 import org.opensearch.geospatial.ip2geo.jobscheduler.Datasource;
@@ -36,6 +37,7 @@ public class DeleteDatasourceTransportAction extends HandledTransportAction<Dele
     private final Ip2GeoLockService lockService;
     private final IngestService ingestService;
     private final DatasourceFacade datasourceFacade;
+    private final GeoIpDataFacade geoIpDataFacade;
     private final Ip2GeoProcessorFacade ip2GeoProcessorFacade;
 
     /**
@@ -53,12 +55,14 @@ public class DeleteDatasourceTransportAction extends HandledTransportAction<Dele
         final Ip2GeoLockService lockService,
         final IngestService ingestService,
         final DatasourceFacade datasourceFacade,
+        final GeoIpDataFacade geoIpDataFacade,
         final Ip2GeoProcessorFacade ip2GeoProcessorFacade
     ) {
         super(DeleteDatasourceAction.NAME, transportService, actionFilters, DeleteDatasourceRequest::new);
         this.lockService = lockService;
         this.ingestService = ingestService;
         this.datasourceFacade = datasourceFacade;
+        this.geoIpDataFacade = geoIpDataFacade;
         this.ip2GeoProcessorFacade = ip2GeoProcessorFacade;
     }
 
@@ -97,6 +101,7 @@ public class DeleteDatasourceTransportAction extends HandledTransportAction<Dele
         }
 
         setDatasourceStateAsDeleting(datasource);
+        geoIpDataFacade.deleteIp2GeoDataIndex(datasource.getIndices());
         datasourceFacade.deleteDatasource(datasource);
     }
 

--- a/src/main/java/org/opensearch/geospatial/ip2geo/common/DatasourceFacade.java
+++ b/src/main/java/org/opensearch/geospatial/ip2geo/common/DatasourceFacade.java
@@ -36,7 +36,6 @@ import org.opensearch.action.get.MultiGetResponse;
 import org.opensearch.action.index.IndexRequest;
 import org.opensearch.action.index.IndexResponse;
 import org.opensearch.action.search.SearchResponse;
-import org.opensearch.action.support.IndicesOptions;
 import org.opensearch.action.support.WriteRequest;
 import org.opensearch.client.Client;
 import org.opensearch.cluster.service.ClusterService;
@@ -192,15 +191,6 @@ public class DatasourceFacade {
      *
      */
     public void deleteDatasource(final Datasource datasource) {
-        if (client.admin()
-            .indices()
-            .prepareDelete(datasource.getIndices().toArray(new String[0]))
-            .setIndicesOptions(IndicesOptions.LENIENT_EXPAND_OPEN)
-            .execute()
-            .actionGet(clusterSettings.get(Ip2GeoSettings.TIMEOUT))
-            .isAcknowledged() == false) {
-            throw new OpenSearchException("failed to delete data[{}] in datasource", String.join(",", datasource.getIndices()));
-        }
         DeleteResponse response = client.prepareDelete()
             .setIndex(DatasourceExtension.JOB_INDEX_NAME)
             .setId(datasource.getName())

--- a/src/main/java/org/opensearch/geospatial/ip2geo/jobscheduler/Datasource.java
+++ b/src/main/java/org/opensearch/geospatial/ip2geo/jobscheduler/Datasource.java
@@ -50,7 +50,7 @@ public class Datasource implements Writeable, ScheduledJobParameter {
     /**
      * Prefix of indices having Ip2Geo data
      */
-    public static final String IP2GEO_DATA_INDEX_NAME_PREFIX = ".ip2geo-data";
+    public static final String IP2GEO_DATA_INDEX_NAME_PREFIX = ".geospatial.ip2geo.data";
 
     /**
      * Default fields for job scheduling

--- a/src/main/java/org/opensearch/geospatial/ip2geo/jobscheduler/DatasourceUpdateService.java
+++ b/src/main/java/org/opensearch/geospatial/ip2geo/jobscheduler/DatasourceUpdateService.java
@@ -164,11 +164,8 @@ public class DatasourceUpdateService {
             }
 
             try {
-                if (geoIpDataFacade.deleteIp2GeoDataIndex(index).isAcknowledged()) {
-                    deletedIndices.add(index);
-                } else {
-                    log.error("Failed to delete an index [{}]", index);
-                }
+                geoIpDataFacade.deleteIp2GeoDataIndex(index);
+                deletedIndices.add(index);
             } catch (Exception e) {
                 log.error("Failed to delete an index [{}]", index, e);
             }

--- a/src/test/java/org/opensearch/geospatial/ip2geo/Ip2GeoTestCase.java
+++ b/src/test/java/org/opensearch/geospatial/ip2geo/Ip2GeoTestCase.java
@@ -17,6 +17,7 @@ import java.util.Collections;
 import java.util.HashSet;
 import java.util.Locale;
 import java.util.Set;
+import java.util.UUID;
 import java.util.concurrent.atomic.AtomicReference;
 import java.util.function.BiFunction;
 import java.util.stream.Collectors;
@@ -208,7 +209,7 @@ public abstract class Ip2GeoTestCase extends RestActionTestCase {
         datasource.setSystemSchedule(datasource.getUserSchedule());
         datasource.setTask(randomTask());
         datasource.setState(randomState());
-        datasource.setCurrentIndex(GeospatialTestHelper.randomLowerCaseString());
+        datasource.setCurrentIndex(datasource.newIndexName(UUID.randomUUID().toString()));
         datasource.setIndices(Arrays.asList(GeospatialTestHelper.randomLowerCaseString(), GeospatialTestHelper.randomLowerCaseString()));
         datasource.setEndpoint(String.format(Locale.ROOT, "https://%s.com/manifest.json", GeospatialTestHelper.randomLowerCaseString()));
         datasource.getDatabase()

--- a/src/test/java/org/opensearch/geospatial/ip2geo/action/DeleteDatasourceTransportActionTests.java
+++ b/src/test/java/org/opensearch/geospatial/ip2geo/action/DeleteDatasourceTransportActionTests.java
@@ -23,6 +23,8 @@ import lombok.SneakyThrows;
 
 import org.junit.Before;
 import org.mockito.ArgumentCaptor;
+import org.mockito.InOrder;
+import org.mockito.Mockito;
 import org.opensearch.OpenSearchException;
 import org.opensearch.ResourceNotFoundException;
 import org.opensearch.action.ActionListener;
@@ -45,6 +47,7 @@ public class DeleteDatasourceTransportActionTests extends Ip2GeoTestCase {
             ip2GeoLockService,
             ingestService,
             datasourceFacade,
+            geoIpDataFacade,
             ip2GeoProcessorFacade
         );
     }
@@ -118,7 +121,9 @@ public class DeleteDatasourceTransportActionTests extends Ip2GeoTestCase {
         // Verify
         assertEquals(DatasourceState.DELETING, datasource.getState());
         verify(datasourceFacade).updateDatasource(datasource);
-        verify(datasourceFacade).deleteDatasource(datasource);
+        InOrder inOrder = Mockito.inOrder(geoIpDataFacade, datasourceFacade);
+        inOrder.verify(geoIpDataFacade).deleteIp2GeoDataIndex(datasource.getIndices());
+        inOrder.verify(datasourceFacade).deleteDatasource(datasource);
     }
 
     @SneakyThrows
@@ -136,6 +141,7 @@ public class DeleteDatasourceTransportActionTests extends Ip2GeoTestCase {
         // Verify
         assertEquals(DatasourceState.AVAILABLE, datasource.getState());
         verify(datasourceFacade, never()).updateDatasource(datasource);
+        verify(geoIpDataFacade, never()).deleteIp2GeoDataIndex(datasource.getIndices());
         verify(datasourceFacade, never()).deleteDatasource(datasource);
     }
 
@@ -154,6 +160,7 @@ public class DeleteDatasourceTransportActionTests extends Ip2GeoTestCase {
 
         // Verify
         verify(datasourceFacade, times(2)).updateDatasource(datasource);
+        verify(geoIpDataFacade, never()).deleteIp2GeoDataIndex(datasource.getIndices());
         verify(datasourceFacade, never()).deleteDatasource(datasource);
     }
 }

--- a/src/test/java/org/opensearch/geospatial/ip2geo/common/GeoIpDataFacadeTests.java
+++ b/src/test/java/org/opensearch/geospatial/ip2geo/common/GeoIpDataFacadeTests.java
@@ -51,7 +51,7 @@ import org.opensearch.action.search.MultiSearchRequest;
 import org.opensearch.action.search.MultiSearchResponse;
 import org.opensearch.action.search.SearchRequest;
 import org.opensearch.action.search.SearchResponse;
-import org.opensearch.action.support.IndicesOptions;
+import org.opensearch.action.support.master.AcknowledgedResponse;
 import org.opensearch.common.Randomness;
 import org.opensearch.common.Strings;
 import org.opensearch.common.SuppressForbidden;
@@ -168,15 +168,14 @@ public class GeoIpDataFacadeTests extends Ip2GeoTestCase {
         verify(connection).addRequestProperty(Constants.USER_AGENT_KEY, Constants.USER_AGENT_VALUE);
     }
 
-    public void testDeleteIp2GeoDataIndex() {
+    public void testDeleteIp2GeoDataIndex_whenCalled_thenDeleteIndex() {
         String index = String.format(Locale.ROOT, "%s.%s", IP2GEO_DATA_INDEX_NAME_PREFIX, GeospatialTestHelper.randomLowerCaseString());
         verifyingClient.setExecuteVerifier((actionResponse, actionRequest) -> {
             assertTrue(actionRequest instanceof DeleteIndexRequest);
             DeleteIndexRequest request = (DeleteIndexRequest) actionRequest;
             assertEquals(1, request.indices().length);
             assertEquals(index, request.indices()[0]);
-            assertEquals(IndicesOptions.LENIENT_EXPAND_OPEN, request.indicesOptions());
-            return null;
+            return new AcknowledgedResponse(true);
         });
         verifyingGeoIpDataFacade.deleteIp2GeoDataIndex(index);
     }

--- a/src/test/java/org/opensearch/geospatial/ip2geo/jobscheduler/DatasourceUpdateServiceTests.java
+++ b/src/test/java/org/opensearch/geospatial/ip2geo/jobscheduler/DatasourceUpdateServiceTests.java
@@ -28,7 +28,6 @@ import org.apache.commons.csv.CSVFormat;
 import org.apache.commons.csv.CSVParser;
 import org.junit.Before;
 import org.opensearch.OpenSearchException;
-import org.opensearch.action.support.master.AcknowledgedResponse;
 import org.opensearch.common.SuppressForbidden;
 import org.opensearch.geospatial.GeospatialTestHelper;
 import org.opensearch.geospatial.ip2geo.Ip2GeoTestCase;
@@ -199,13 +198,13 @@ public class DatasourceUpdateServiceTests extends Ip2GeoTestCase {
         when(metadata.hasIndex(currentIndex)).thenReturn(true);
         when(metadata.hasIndex(oldIndex)).thenReturn(true);
         when(metadata.hasIndex(lingeringIndex)).thenReturn(false);
-        when(geoIpDataFacade.deleteIp2GeoDataIndex(any())).thenReturn(new AcknowledgedResponse(true));
 
         datasourceUpdateService.deleteUnusedIndices(datasource);
 
         assertEquals(1, datasource.getIndices().size());
         assertEquals(currentIndex, datasource.getIndices().get(0));
         verify(datasourceFacade).updateDatasource(datasource);
+        verify(geoIpDataFacade).deleteIp2GeoDataIndex(oldIndex);
     }
 
     public void testUpdateDatasource_whenNoChange_thenNoUpdate() {


### PR DESCRIPTION


### Description
We don't want to use restored GeoIP data indices. Therefore we delete the indices once restoring process complete.

When GeoIP metadata index is restored, we create a new GeoIP data index instead.
 
### Issues Resolved
N/A
 
### Check List
- [X] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
