### PR TITLE
Use bool query for array form of IPs and wrapping with try/catch

### DIFF
--- a/src/test/java/org/opensearch/geospatial/ip2geo/processor/Ip2GeoProcessorIT.java
+++ b/src/test/java/org/opensearch/geospatial/ip2geo/processor/Ip2GeoProcessorIT.java
@@ -86,7 +86,7 @@ public class Ip2GeoProcessorIT extends GeospatialRestTestCase {
                 Ip2GeoProcessor.CONFIG_TARGET_FIELD,
                 targetField,
                 Ip2GeoProcessor.CONFIG_PROPERTIES,
-                Arrays.asList(IP, CITY)
+                Arrays.asList(CITY)
             );
 
             // Create ip2geo processor
@@ -104,10 +104,10 @@ public class Ip2GeoProcessorIT extends GeospatialRestTestCase {
 
             // Verify data added to document
             List<Map<String, String>> sources = convertToListOfSources(response, targetField);
-            sources.stream().forEach(source -> {
-                assertFalse(source.containsKey(COUNTRY));
-                assertEquals(sampleData.get(source.get(IP)).get(CITY), source.get(CITY));
-            });
+            sources.stream().allMatch(source -> source.size() == 1);
+            List<String> cities = sources.stream().map(value -> value.get(CITY)).collect(Collectors.toList());
+            List<String> expectedCities = sampleData.values().stream().map(value -> value.get(CITY)).collect(Collectors.toList());
+            assertEquals(expectedCities, cities);
 
             // Delete datasource fails when there is a process using it
             ResponseException deleteException = expectThrows(ResponseException.class, () -> deleteDatasource(datasourceName));


### PR DESCRIPTION
### Description
1. Instead of msearch for array form of IPs, use bool query for better performance.
2. IP property support is removed which add ip address in enriched data. This was added at first for feature parity with geoip processor but it cannot be supported in array form as we are using bool query now.
3. Added try/catch for every possible cases so that exception one impact to other requests in the same bulk request.
 
### Issues Resolved
N/A
 
### Check List
- [X] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
