### PR TITLE
Remove IP2Geo processor validation

### DIFF
--- a/src/test/java/org/opensearch/geospatial/ip2geo/processor/Ip2GeoProcessorIT.java
+++ b/src/test/java/org/opensearch/geospatial/ip2geo/processor/Ip2GeoProcessorIT.java
@@ -8,7 +8,6 @@ package org.opensearch.geospatial.ip2geo.processor;
 import java.io.IOException;
 import java.time.Duration;
 import java.util.Arrays;
-import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Locale;
@@ -34,21 +33,6 @@ public class Ip2GeoProcessorIT extends GeospatialRestTestCase {
     private static final String COUNTRY = "country";
     private static final String IP = "ip";
     private static final String SOURCE = "_source";
-
-    @SneakyThrows
-    public void testCreateIp2GeoProcessor_whenNoSuchDatasourceExist_thenFails() {
-        String pipelineName = PREFIX + GeospatialTestHelper.randomLowerCaseString();
-
-        // Run
-        ResponseException exception = expectThrows(
-            ResponseException.class,
-            () -> createIp2GeoProcessorPipeline(pipelineName, Collections.emptyMap())
-        );
-
-        // Verify
-        assertTrue(exception.getMessage().contains("doesn't exist"));
-        assertEquals(RestStatus.BAD_REQUEST.getStatus(), exception.getResponse().getStatusLine().getStatusCode());
-    }
 
     @SneakyThrows
     public void testCreateIp2GeoProcessor_whenValidInput_thenAddData() {


### PR DESCRIPTION


### Description
Cannot query index to get data to validate IP2Geo processor. Will add validation when we decide to store some of data in cluster state metadata.
 
### Issues Resolved
N/A
 
### Check List
- [X] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
