### PR TITLE
Use _primary in query preference

### DIFF
--- a/src/main/java/org/opensearch/geospatial/ip2geo/common/Ip2GeoSettings.java
+++ b/src/main/java/org/opensearch/geospatial/ip2geo/common/Ip2GeoSettings.java
@@ -41,6 +41,17 @@ public class Ip2GeoSettings {
     );
 
     /**
+     * Bulk size for indexing GeoIP data
+     */
+    public static final Setting<Integer> BATCH_SIZE = Setting.intSetting(
+        "plugins.geospatial.ip2geo.datasource.batch_size",
+        10000,
+        1,
+        Setting.Property.NodeScope,
+        Setting.Property.Dynamic
+    );
+
+    /**
      * Timeout value for Ip2Geo processor
      */
     public static final Setting<TimeValue> TIMEOUT = Setting.timeSetting(
@@ -67,7 +78,7 @@ public class Ip2GeoSettings {
      * @return a list of all settings for Ip2Geo feature
      */
     public static final List<Setting<?>> settings() {
-        return List.of(DATASOURCE_ENDPOINT, DATASOURCE_UPDATE_INTERVAL, TIMEOUT, CACHE_SIZE);
+        return List.of(DATASOURCE_ENDPOINT, DATASOURCE_UPDATE_INTERVAL, BATCH_SIZE, TIMEOUT, CACHE_SIZE);
     }
 
     /**

--- a/src/main/resources/mappings/ip2geo_datasource.json
+++ b/src/main/resources/mappings/ip2geo_datasource.json
@@ -1,75 +1,130 @@
 {
-  "properties" : {
-    "database" : {
-      "properties" : {
-        "fields" : {
-          "type" : "text"
+  "properties": {
+    "database": {
+      "properties": {
+        "fields": {
+          "type": "text"
         },
-        "sha256_hash" : {
-          "type" : "text"
+        "provider": {
+          "type": "text"
         },
-        "provider" : {
-          "type" : "text"
+        "sha256_hash": {
+          "type": "text"
         },
-        "updated_at_in_epoch_millis" : {
-          "type" : "long"
+        "updated_at_in_epoch_millis": {
+          "type": "long"
         },
-        "valid_for_in_days" : {
-          "type" : "long"
+        "valid_for_in_days": {
+          "type": "long"
         }
       }
     },
-    "enabled_time" : {
-      "type" : "long"
+    "enabled_time": {
+      "type": "long"
     },
-    "endpoint" : {
-      "type" : "text"
+    "endpoint": {
+      "type": "text"
     },
-    "name" : {
-      "type" : "text"
+    "indices": {
+      "type": "text"
     },
-    "indices" : {
-      "type" : "text"
+    "last_update_time": {
+      "type": "long"
     },
-    "last_update_time" : {
-      "type" : "long"
+    "name": {
+      "type": "text"
     },
-    "schedule" : {
-      "properties" : {
-        "interval" : {
-          "properties" : {
-            "period" : {
-              "type" : "long"
+    "schedule": {
+      "properties": {
+        "interval": {
+          "properties": {
+            "period": {
+              "type": "long"
             },
-            "start_time" : {
-              "type" : "long"
+            "start_time": {
+              "type": "long"
             },
-            "unit" : {
-              "type" : "text"
+            "unit": {
+              "type": "text"
             }
           }
         }
       }
     },
-    "state" : {
-      "type" : "text"
+    "state": {
+      "type": "text"
     },
-    "update_enabled" : {
-      "type" : "boolean"
+    "system_schedule": {
+      "properties": {
+        "interval": {
+          "properties": {
+            "period": {
+              "type": "long"
+            },
+            "start_time": {
+              "type": "long"
+            },
+            "unit": {
+              "type": "text",
+              "fields": {
+                "keyword": {
+                  "type": "keyword",
+                  "ignore_above": 256
+                }
+              }
+            }
+          }
+        }
+      }
     },
-    "update_stats" : {
-      "properties" : {
-        "last_failed_at_in_epoch_millis" : {
-          "type" : "long"
+    "task": {
+      "type": "text",
+      "fields": {
+        "keyword": {
+          "type": "keyword",
+          "ignore_above": 256
+        }
+      }
+    },
+    "update_enabled": {
+      "type": "boolean"
+    },
+    "update_stats": {
+      "properties": {
+        "last_failed_at_in_epoch_millis": {
+          "type": "long"
         },
-        "last_processing_time_in_millis" : {
-          "type" : "long"
+        "last_processing_time_in_millis": {
+          "type": "long"
         },
-        "last_skipped_at_in_epoch_millis" : {
-          "type" : "long"
+        "last_skipped_at_in_epoch_millis": {
+          "type": "long"
         },
-        "last_succeeded_at_in_epoch_millis" : {
-          "type" : "long"
+        "last_succeeded_at_in_epoch_millis": {
+          "type": "long"
+        }
+      }
+    },
+    "user_schedule": {
+      "properties": {
+        "interval": {
+          "properties": {
+            "period": {
+              "type": "long"
+            },
+            "start_time": {
+              "type": "long"
+            },
+            "unit": {
+              "type": "text",
+              "fields": {
+                "keyword": {
+                  "type": "keyword",
+                  "ignore_above": 256
+                }
+              }
+            }
+          }
         }
       }
     }

--- a/src/test/java/org/opensearch/geospatial/ip2geo/dao/DatasourceDaoTests.java
+++ b/src/test/java/org/opensearch/geospatial/ip2geo/dao/DatasourceDaoTests.java
@@ -39,6 +39,7 @@ import org.opensearch.action.index.IndexRequest;
 import org.opensearch.action.search.SearchRequest;
 import org.opensearch.action.search.SearchResponse;
 import org.opensearch.action.support.WriteRequest;
+import org.opensearch.cluster.routing.Preference;
 import org.opensearch.common.Randomness;
 import org.opensearch.common.bytes.BytesReference;
 import org.opensearch.common.xcontent.json.JsonXContent;
@@ -205,6 +206,7 @@ public class DatasourceDaoTests extends Ip2GeoTestCase {
             GetRequest request = (GetRequest) actionRequest;
             assertEquals(datasource.getName(), request.id());
             assertEquals(DatasourceExtension.JOB_INDEX_NAME, request.index());
+            assertEquals(Preference.PRIMARY.type(), request.preference());
             GetResponse response = getMockedGetResponse(isExist ? datasource : null);
             if (exception != null) {
                 throw exception;
@@ -262,6 +264,7 @@ public class DatasourceDaoTests extends Ip2GeoTestCase {
             assertTrue(actionRequest instanceof MultiGetRequest);
             MultiGetRequest request = (MultiGetRequest) actionRequest;
             assertEquals(2, request.getItems().size());
+            assertEquals(Preference.PRIMARY.type(), request.preference());
             for (MultiGetRequest.Item item : request.getItems()) {
                 assertEquals(DatasourceExtension.JOB_INDEX_NAME, item.index());
                 assertTrue(datasources.stream().filter(datasource -> datasource.getName().equals(item.id())).findAny().isPresent());
@@ -295,6 +298,7 @@ public class DatasourceDaoTests extends Ip2GeoTestCase {
             assertEquals(DatasourceExtension.JOB_INDEX_NAME, request.indices()[0]);
             assertEquals(QueryBuilders.matchAllQuery(), request.source().query());
             assertEquals(1000, request.source().size());
+            assertEquals(Preference.PRIMARY.type(), request.preference());
 
             SearchResponse response = mock(SearchResponse.class);
             when(response.getHits()).thenReturn(searchHits);
@@ -322,6 +326,7 @@ public class DatasourceDaoTests extends Ip2GeoTestCase {
             assertEquals(DatasourceExtension.JOB_INDEX_NAME, request.indices()[0]);
             assertEquals(QueryBuilders.matchAllQuery(), request.source().query());
             assertEquals(1000, request.source().size());
+            assertEquals(Preference.PRIMARY.type(), request.preference());
 
             SearchResponse response = mock(SearchResponse.class);
             when(response.getHits()).thenReturn(searchHits);

--- a/src/test/java/org/opensearch/geospatial/ip2geo/dao/GeoIpDataDaoTests.java
+++ b/src/test/java/org/opensearch/geospatial/ip2geo/dao/GeoIpDataDaoTests.java
@@ -41,6 +41,7 @@ import org.opensearch.action.bulk.BulkResponse;
 import org.opensearch.action.search.SearchRequest;
 import org.opensearch.action.search.SearchResponse;
 import org.opensearch.action.support.master.AcknowledgedResponse;
+import org.opensearch.cluster.routing.Preference;
 import org.opensearch.common.Strings;
 import org.opensearch.common.SuppressForbidden;
 import org.opensearch.common.bytes.BytesReference;
@@ -236,7 +237,7 @@ public class GeoIpDataDaoTests extends Ip2GeoTestCase {
         verifyingClient.setExecuteVerifier((actionResponse, actionRequest) -> {
             assert actionRequest instanceof SearchRequest;
             SearchRequest request = (SearchRequest) actionRequest;
-            assertEquals("_local", request.preference());
+            assertEquals(Preference.LOCAL.type(), request.preference());
             assertEquals(1, request.source().size());
             assertEquals(QueryBuilders.termQuery(IP_RANGE_FIELD_NAME, ip), request.source().query());
 
@@ -269,7 +270,7 @@ public class GeoIpDataDaoTests extends Ip2GeoTestCase {
         verifyingClient.setExecuteVerifier((actionResponse, actionRequest) -> {
             assert actionRequest instanceof SearchRequest;
             SearchRequest request = (SearchRequest) actionRequest;
-            assertEquals("_local", request.preference());
+            assertEquals(Preference.LOCAL.type(), request.preference());
             assertEquals(1, request.source().size());
             assertEquals(QueryBuilders.termQuery(IP_RANGE_FIELD_NAME, ip), request.source().query());
 


### PR DESCRIPTION

### Description
1. Use _primary preference to get datasource metadata so that it can read the latest data. RefreshPolicy.IMMEDIATE won't refresh replica shards immediately according to #346
2. Update datasource metadata index mapping
3. Move batch size from static value to setting
 
### Issues Resolved
#346
 
### Check List
- [X] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
