### PR TITLE
Switch from XContentType to MediaType to fix compilation errors

### DIFF
--- a/src/main/java/org/opensearch/geospatial/rest/action/upload/geojson/RestUploadGeoJSONAction.java
+++ b/src/main/java/org/opensearch/geospatial/rest/action/upload/geojson/RestUploadGeoJSONAction.java
@@ -14,8 +14,8 @@ import java.util.List;
 
 import org.opensearch.client.node.NodeClient;
 import org.opensearch.common.collect.Tuple;
-import org.opensearch.common.xcontent.XContentType;
 import org.opensearch.core.common.bytes.BytesReference;
+import org.opensearch.core.xcontent.MediaType;
 import org.opensearch.geospatial.action.upload.geojson.UploadGeoJSONAction;
 import org.opensearch.geospatial.action.upload.geojson.UploadGeoJSONRequest;
 import org.opensearch.rest.BaseRestHandler;
@@ -84,7 +84,7 @@ public class RestUploadGeoJSONAction extends BaseRestHandler {
 
     @Override
     protected RestChannelConsumer prepareRequest(RestRequest restRequest, NodeClient client) {
-        Tuple<XContentType, BytesReference> sourceTuple = restRequest.contentOrSourceParam();
+        Tuple<MediaType, BytesReference> sourceTuple = restRequest.contentOrSourceParam();
         RestRequest.Method method = restRequest.getHttpRequest().method();
         UploadGeoJSONRequest request = new UploadGeoJSONRequest(method, sourceTuple.v2());
         return channel -> client.execute(UploadGeoJSONAction.INSTANCE, request, new RestToXContentListener<>(channel));

--- a/src/test/java/org/opensearch/geospatial/OpenSearchSecureRestTestCase.java
+++ b/src/test/java/org/opensearch/geospatial/OpenSearchSecureRestTestCase.java
@@ -39,8 +39,8 @@ import org.opensearch.client.RestClientBuilder;
 import org.opensearch.common.settings.Settings;
 import org.opensearch.common.unit.TimeValue;
 import org.opensearch.common.util.concurrent.ThreadContext;
-import org.opensearch.common.xcontent.XContentType;
 import org.opensearch.core.xcontent.DeprecationHandler;
+import org.opensearch.core.xcontent.MediaType;
 import org.opensearch.core.xcontent.NamedXContentRegistry;
 import org.opensearch.core.xcontent.XContentParser;
 import org.opensearch.test.rest.OpenSearchRestTestCase;
@@ -151,9 +151,9 @@ public abstract class OpenSearchSecureRestTestCase extends OpenSearchRestTestCas
     @After
     public void deleteExternalIndices() throws IOException {
         Response response = client().performRequest(new Request("GET", "/_cat/indices?format=json&expand_wildcards=all"));
-        XContentType xContentType = XContentType.fromMediaType(response.getEntity().getContentType());
+        MediaType mediaType = MediaType.fromMediaType(response.getEntity().getContentType());
         try (
-            XContentParser parser = xContentType.xContent()
+            XContentParser parser = mediaType.xContent()
                 .createParser(
                     NamedXContentRegistry.EMPTY,
                     DeprecationHandler.THROW_UNSUPPORTED_OPERATION,


### PR DESCRIPTION
### Description
Switch from XContentType to MediaType to fix compilation errors
 
### Issues Resolved
N/A
 
### Check List
- [X] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
