### PR TITLE
Update on input parameter validation

### DIFF
--- a/src/main/java/org/opensearch/geospatial/ip2geo/common/InputFormatValidator.java
+++ b/src/main/java/org/opensearch/geospatial/ip2geo/common/InputFormatValidator.java
@@ -1,0 +1,47 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package org.opensearch.geospatial.ip2geo.common;
+
+import java.io.UnsupportedEncodingException;
+
+import org.opensearch.OpenSearchException;
+import org.opensearch.common.Strings;
+
+public class InputFormatValidator {
+    private static final int MAX_DATASOURCE_NAME_BYTES = 127;
+
+    public String validateDatasourceName(final String datasourceName) {
+        if (!Strings.validFileName(datasourceName)) {
+            return "datasource name must not contain the following characters " + Strings.INVALID_FILENAME_CHARS;
+        }
+        if (datasourceName.isEmpty()) {
+            return "datasource name must not be empty";
+        }
+        if (datasourceName.contains("#")) {
+            return "datasource name must not contain '#'";
+        }
+        if (datasourceName.contains(":")) {
+            return "datasource name must not contain ':'";
+        }
+        if (datasourceName.charAt(0) == '_' || datasourceName.charAt(0) == '-' || datasourceName.charAt(0) == '+') {
+            return "datasource name must not start with '_', '-', or '+'";
+        }
+        int byteCount = 0;
+        try {
+            byteCount = datasourceName.getBytes("UTF-8").length;
+        } catch (UnsupportedEncodingException e) {
+            // UTF-8 should always be supported, but rethrow this if it is not for some reason
+            throw new OpenSearchException("unable to determine length of datasource name", e);
+        }
+        if (byteCount > MAX_DATASOURCE_NAME_BYTES) {
+            return "datasource name is too long, (" + byteCount + " > " + MAX_DATASOURCE_NAME_BYTES + ")";
+        }
+        if (datasourceName.equals(".") || datasourceName.equals("..")) {
+            return "datasource name must not be '.' or '..'";
+        }
+        return null;
+    }
+}

--- a/src/test/java/org/opensearch/geospatial/ip2geo/action/PutDatasourceRequestTests.java
+++ b/src/test/java/org/opensearch/geospatial/ip2geo/action/PutDatasourceRequestTests.java
@@ -5,18 +5,19 @@
 
 package org.opensearch.geospatial.ip2geo.action;
 
-import java.util.Arrays;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+
 import java.util.Locale;
-import java.util.Map;
 
 import org.opensearch.action.ActionRequestValidationException;
 import org.opensearch.common.Randomness;
-import org.opensearch.common.Strings;
 import org.opensearch.common.io.stream.BytesStreamOutput;
 import org.opensearch.common.unit.TimeValue;
 import org.opensearch.core.common.io.stream.BytesStreamInput;
 import org.opensearch.geospatial.GeospatialTestHelper;
 import org.opensearch.geospatial.ip2geo.Ip2GeoTestCase;
+import org.opensearch.geospatial.ip2geo.common.InputFormatValidator;
 
 public class PutDatasourceRequestTests extends Ip2GeoTestCase {
 
@@ -45,12 +46,16 @@ public class PutDatasourceRequestTests extends Ip2GeoTestCase {
         assertTrue(exception.validationErrors().get(0).contains("Error occurred while reading a file"));
     }
 
-    public void testValidate_whenValidInput_thenSucceed() throws Exception {
+    public void testValidate_whenValidInput_thenSucceed() {
         String datasourceName = GeospatialTestHelper.randomLowerCaseString();
         PutDatasourceRequest request = new PutDatasourceRequest(datasourceName);
+        InputFormatValidator inputFormatValidator = mock(InputFormatValidator.class);
         request.setEndpoint(sampleManifestUrl());
         request.setUpdateInterval(TimeValue.timeValueDays(1));
+        request.setInputFormatValidator(inputFormatValidator);
+
         assertNull(request.validate());
+        verify(inputFormatValidator).validateDatasourceName(datasourceName);
     }
 
     public void testValidate_whenZeroUpdateInterval_thenFails() throws Exception {
@@ -98,60 +103,6 @@ public class PutDatasourceRequestTests extends Ip2GeoTestCase {
         assertTrue(exception.validationErrors().get(0).contains("Invalid URL format"));
     }
 
-    public void testValidate_whenInvalidDatasourceNames_thenFails() throws Exception {
-        String validDatasourceName = GeospatialTestHelper.randomLowerCaseString();
-        String domain = GeospatialTestHelper.randomLowerCaseString();
-        PutDatasourceRequest request = new PutDatasourceRequest(validDatasourceName);
-        request.setEndpoint(sampleManifestUrl());
-        request.setUpdateInterval(TimeValue.timeValueDays(Randomness.get().nextInt(10) + 1));
-
-        // Run
-        ActionRequestValidationException exception = request.validate();
-
-        // Verify
-        assertNull(exception);
-
-        String fileNameChar = validDatasourceName + Strings.INVALID_FILENAME_CHARS.stream()
-            .skip(Randomness.get().nextInt(Strings.INVALID_FILENAME_CHARS.size() - 1))
-            .findFirst();
-        String startsWith = Arrays.asList("_", "-", "+").get(Randomness.get().nextInt(3)) + validDatasourceName;
-        String empty = "";
-        String hash = validDatasourceName + "#";
-        String colon = validDatasourceName + ":";
-        StringBuilder longName = new StringBuilder();
-        while (longName.length() < 256) {
-            longName.append(GeospatialTestHelper.randomLowerCaseString());
-        }
-        String point = Arrays.asList(".", "..").get(Randomness.get().nextInt(2));
-        Map<String, String> nameToError = Map.of(
-            fileNameChar,
-            "not contain the following characters",
-            empty,
-            "must not be empty",
-            hash,
-            "must not contain '#'",
-            colon,
-            "must not contain ':'",
-            startsWith,
-            "must not start with",
-            longName.toString(),
-            "name is too long",
-            point,
-            "must not be '.' or '..'"
-        );
-
-        for (Map.Entry<String, String> entry : nameToError.entrySet()) {
-            request.setName(entry.getKey());
-
-            // Run
-            exception = request.validate();
-
-            // Verify
-            assertEquals(1, exception.validationErrors().size());
-            assertTrue(exception.validationErrors().get(0).contains(entry.getValue()));
-        }
-    }
-
     public void testStreamInOut_whenValidInput_thenSucceed() throws Exception {
         String datasourceName = GeospatialTestHelper.randomLowerCaseString();
         String domain = GeospatialTestHelper.randomLowerCaseString();
@@ -166,6 +117,8 @@ public class PutDatasourceRequestTests extends Ip2GeoTestCase {
         PutDatasourceRequest copiedRequest = new PutDatasourceRequest(input);
 
         // Verify
-        assertEquals(request, copiedRequest);
+        assertEquals(request.getName(), copiedRequest.getName());
+        assertEquals(request.getUpdateInterval(), copiedRequest.getUpdateInterval());
+        assertEquals(request.getEndpoint(), copiedRequest.getEndpoint());
     }
 }

--- a/src/test/java/org/opensearch/geospatial/ip2geo/common/InputFormatValidatorTests.java
+++ b/src/test/java/org/opensearch/geospatial/ip2geo/common/InputFormatValidatorTests.java
@@ -1,0 +1,69 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package org.opensearch.geospatial.ip2geo.common;
+
+import java.util.Arrays;
+import java.util.Map;
+
+import org.opensearch.common.Randomness;
+import org.opensearch.common.Strings;
+import org.opensearch.geospatial.GeospatialTestHelper;
+import org.opensearch.geospatial.ip2geo.Ip2GeoTestCase;
+
+public class InputFormatValidatorTests extends Ip2GeoTestCase {
+    public void testValidateDatasourceName_whenValidName_thenSucceed() {
+        InputFormatValidator inputFormatValidator = new InputFormatValidator();
+        String validDatasourceName = GeospatialTestHelper.randomLowerCaseString();
+
+        // Run
+        String errorMsg = inputFormatValidator.validateDatasourceName(validDatasourceName);
+
+        // Verify
+        assertNull(errorMsg);
+    }
+
+    public void testValidate_whenInvalidDatasourceNames_thenFails() {
+        InputFormatValidator inputFormatValidator = new InputFormatValidator();
+        String validDatasourceName = GeospatialTestHelper.randomLowerCaseString();
+        String fileNameChar = validDatasourceName + Strings.INVALID_FILENAME_CHARS.stream()
+            .skip(Randomness.get().nextInt(Strings.INVALID_FILENAME_CHARS.size() - 1))
+            .findFirst();
+        String startsWith = Arrays.asList("_", "-", "+").get(Randomness.get().nextInt(3)) + validDatasourceName;
+        String empty = "";
+        String hash = validDatasourceName + "#";
+        String colon = validDatasourceName + ":";
+        StringBuilder longName = new StringBuilder();
+        while (longName.length() < 127) {
+            longName.append(GeospatialTestHelper.randomLowerCaseString());
+        }
+        String point = Arrays.asList(".", "..").get(Randomness.get().nextInt(2));
+        Map<String, String> nameToError = Map.of(
+            fileNameChar,
+            "not contain the following characters",
+            empty,
+            "must not be empty",
+            hash,
+            "must not contain '#'",
+            colon,
+            "must not contain ':'",
+            startsWith,
+            "must not start with",
+            longName.toString(),
+            "name is too long",
+            point,
+            "must not be '.' or '..'"
+        );
+
+        for (Map.Entry<String, String> entry : nameToError.entrySet()) {
+
+            // Run
+            String errorMsg = inputFormatValidator.validateDatasourceName(entry.getKey());
+
+            // Verify
+            assertNotNull(errorMsg);
+        }
+    }
+}


### PR DESCRIPTION
### Description
1. Reduce max byte size of datasource name from 255 to 127
2. Add datasource name validation on IP2Geo processor creation logic
3. Throw correct exception when acquring of lock failed during update/delete of datasource
 
### Issues Resolved
N/A
 
### Check List
- [X] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
