### PR TITLE
Revert datasource state when delete fails

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 * IP2Geo processor implementation ([#362](https://github.com/opensearch-project/geospatial/pull/362))
 ### Enhancements
 ### Bug Fixes
+* Revert datasource state when delete fails([#382](https://github.com/opensearch-project/geospatial/pull/382))
 ### Infrastructure
 * Make jacoco report to be generated faster in local ([#267](https://github.com/opensearch-project/geospatial/pull/267))
 * Exclude lombok generated code from jacoco coverage report ([#268](https://github.com/opensearch-project/geospatial/pull/268))


### PR DESCRIPTION
### Description
Revert datasource state when delete fails
 
### Issues Resolved
N/A
 
### Check List
- [X] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
