### PR TITLE
Remove _primary preference from get/mget requests

### DIFF
--- a/src/main/java/org/opensearch/geospatial/ip2geo/dao/DatasourceDao.java
+++ b/src/main/java/org/opensearch/geospatial/ip2geo/dao/DatasourceDao.java
@@ -217,7 +217,7 @@ public class DatasourceDao {
      * @throws IOException exception
      */
     public Datasource getDatasource(final String name) throws IOException {
-        GetRequest request = new GetRequest(DatasourceExtension.JOB_INDEX_NAME, name).preference(Preference.PRIMARY.type());
+        GetRequest request = new GetRequest(DatasourceExtension.JOB_INDEX_NAME, name);
         GetResponse response;
         try {
             response = StashedThreadContext.run(client, () -> client.get(request).actionGet(clusterSettings.get(Ip2GeoSettings.TIMEOUT)));
@@ -244,7 +244,7 @@ public class DatasourceDao {
      * @param actionListener the action listener
      */
     public void getDatasource(final String name, final ActionListener<Datasource> actionListener) {
-        GetRequest request = new GetRequest(DatasourceExtension.JOB_INDEX_NAME, name).preference(Preference.PRIMARY.type());
+        GetRequest request = new GetRequest(DatasourceExtension.JOB_INDEX_NAME, name);
         StashedThreadContext.run(client, () -> client.get(request, new ActionListener<>() {
             @Override
             public void onResponse(final GetResponse response) {
@@ -282,7 +282,6 @@ public class DatasourceDao {
             client,
             () -> client.prepareMultiGet()
                 .add(DatasourceExtension.JOB_INDEX_NAME, names)
-                .setPreference(Preference.PRIMARY.type())
                 .execute(createGetDataSourceQueryActionLister(MultiGetResponse.class, actionListener))
         );
     }

--- a/src/test/java/org/opensearch/geospatial/ip2geo/dao/DatasourceDaoTests.java
+++ b/src/test/java/org/opensearch/geospatial/ip2geo/dao/DatasourceDaoTests.java
@@ -206,7 +206,6 @@ public class DatasourceDaoTests extends Ip2GeoTestCase {
             GetRequest request = (GetRequest) actionRequest;
             assertEquals(datasource.getName(), request.id());
             assertEquals(DatasourceExtension.JOB_INDEX_NAME, request.index());
-            assertEquals(Preference.PRIMARY.type(), request.preference());
             GetResponse response = getMockedGetResponse(isExist ? datasource : null);
             if (exception != null) {
                 throw exception;
@@ -264,7 +263,6 @@ public class DatasourceDaoTests extends Ip2GeoTestCase {
             assertTrue(actionRequest instanceof MultiGetRequest);
             MultiGetRequest request = (MultiGetRequest) actionRequest;
             assertEquals(2, request.getItems().size());
-            assertEquals(Preference.PRIMARY.type(), request.preference());
             for (MultiGetRequest.Item item : request.getItems()) {
                 assertEquals(DatasourceExtension.JOB_INDEX_NAME, item.index());
                 assertTrue(datasources.stream().filter(datasource -> datasource.getName().equals(item.id())).findAny().isPresent());


### PR DESCRIPTION
### Description
With https://github.com/opensearch-project/OpenSearch/issues/8536, core now ensures realtime reads for segment replication enabled indices as well. Thus, there is no need to pass `_primary` preference for get/mget requests.
 
### Issues Resolved
#346
 
### Check List
- [ ] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
