### PR TITLE
Version bump for spotlss and apache commons

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,4 +28,5 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 * Refactor LifecycleComponent package path ([#377](https://github.com/opensearch-project/geospatial/pull/377))
 * [Refactor] Strings utility methods to core library ([#379](https://github.com/opensearch-project/geospatial/pull/379))
 * Fixed compilation errors after refactoring in core foundation classes ([#380](https://github.com/opensearch-project/geospatial/pull/380))
+* Version bump for spotlss and apache commons([#400](https://github.com/opensearch-project/geospatial/pull/400))
 ### Refactoring

--- a/build.gradle
+++ b/build.gradle
@@ -74,7 +74,7 @@ buildscript {
 
     dependencies {
         classpath "${opensearch_group}.gradle:build-tools:${opensearch_version}"
-        classpath "com.diffplug.spotless:spotless-plugin-gradle:5.6.1"
+        classpath "com.diffplug.spotless:spotless-plugin-gradle:6.3.0"
         classpath "io.freefair.gradle:lombok-plugin:6.4.3"
     }
 }
@@ -158,7 +158,7 @@ dependencies {
     yamlRestTestRuntimeOnly "org.apache.logging.log4j:log4j-core:${versions.log4j}"
     testImplementation "org.hamcrest:hamcrest:${versions.hamcrest}"
     testImplementation 'org.json:json:20230227'
-    implementation "org.apache.commons:commons-lang3:3.12.0"
+    implementation "org.apache.commons:commons-lang3:3.13.0"
     implementation "org.locationtech.spatial4j:spatial4j:${versions.spatial4j}"
     implementation "org.locationtech.jts:jts-core:${versions.jts}"
     implementation "org.apache.commons:commons-csv:1.10.0"


### PR DESCRIPTION
### Description
Spotless fails in 2.x branch with old version with following error `Caused by: java.lang.NoSuchMethodError: 'long com.sun.tools.javac.tree.DCTree$DCReference.getSourcePosition(com.sun.tools.javac.tree.DCTree$DCDocComment)'`
 
### Issues Resolved
N/A
 
### Check List
- [Z] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
