### PR TITLE
Removing the security audit system index from getting deleted to fix the 2.10 integ tests failures

### DIFF
--- a/src/test/java/org/opensearch/geospatial/OpenSearchSecureRestTestCase.java
+++ b/src/test/java/org/opensearch/geospatial/OpenSearchSecureRestTestCase.java
@@ -47,6 +47,7 @@ public abstract class OpenSearchSecureRestTestCase extends OpenSearchRestTestCas
     private static final String SYS_PROPERTY_KEY_PASSWORD = "password";
     private static final String DEFAULT_SOCKET_TIMEOUT = "60s";
     private static final String INTERNAL_INDICES_PREFIX = ".";
+    private static final String SYSTEM_INDEX_PREFIX = "security-auditlog";
     private static String protocol;
 
     @Override
@@ -150,6 +151,10 @@ public abstract class OpenSearchSecureRestTestCase extends OpenSearchRestTestCas
                 .map(index -> (String) index.get("index"))
                 .filter(indexName -> indexName != null)
                 .filter(indexName -> !indexName.startsWith(INTERNAL_INDICES_PREFIX))
+                // This is hack to remove the security audit index from deletion. We will need a proper fix where
+                // we delete the indices after a test is completed.
+                // Issue: https://github.com/opensearch-project/geospatial/issues/428
+                .filter(indexName -> !indexName.startsWith(SYSTEM_INDEX_PREFIX))
                 .collect(Collectors.toList());
 
             for (String indexName : externalIndices) {


### PR DESCRIPTION
### Description
Removing the security audit system index from getting deleted to fix the 2.10 integ tests failures

This is a temporary fix. Ideally we should delete the index from the test where it is getting created. Currently due to short time I cannot do that change as there are many reference of createIndex. Will fix this code starting from main branch and then backport to 2.x

 
### Issues Resolved
https://github.com/opensearch-project/geospatial/issues/428
 
### Check List
- [X] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
