### PR TITLE
Add denylist ip config for datasource endpoint

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ See the [CONTRIBUTING guide](./CONTRIBUTING.md#Changelog) for instructions on ho
 
 ## [Unreleased 2.x](https://github.com/opensearch-project/geospatial/compare/2.11...2.x)
 ### Features
+* Add denylist ip config for datasource endpoint ([#573](https://github.com/opensearch-project/geospatial/pull/573))
 ### Enhancements
 ### Bug Fixes
 ### Infrastructure

--- a/build.gradle
+++ b/build.gradle
@@ -164,6 +164,7 @@ dependencies {
     implementation "org.apache.commons:commons-csv:1.10.0"
     zipArchive group: 'org.opensearch.plugin', name:'opensearch-job-scheduler', version: "${opensearch_build}"
     compileOnly "org.opensearch:opensearch-job-scheduler-spi:${opensearch_build}"
+    implementation "com.github.seancfoley:ipaddress:5.4.0"
 }
 
 licenseHeaders.enabled = true

--- a/src/main/java/org/opensearch/geospatial/ip2geo/common/Ip2GeoSettings.java
+++ b/src/main/java/org/opensearch/geospatial/ip2geo/common/Ip2GeoSettings.java
@@ -8,7 +8,9 @@ package org.opensearch.geospatial.ip2geo.common;
 import java.net.MalformedURLException;
 import java.net.URISyntaxException;
 import java.net.URL;
+import java.util.Collections;
 import java.util.List;
+import java.util.function.Function;
 
 import org.opensearch.common.settings.Setting;
 import org.opensearch.common.unit.TimeValue;
@@ -74,11 +76,22 @@ public class Ip2GeoSettings {
     );
 
     /**
+     * A list of CIDR which will be blocked to be used as datasource endpoint
+     */
+    public static final Setting<List<String>> DATASOURCE_ENDPOINT_DENYLIST = Setting.listSetting(
+        "plugins.geospatial.ip2geo.datasource.endpoint.denylist",
+        Collections.emptyList(),
+        Function.identity(),
+        Setting.Property.NodeScope,
+        Setting.Property.Dynamic
+    );
+
+    /**
      * Return all settings of Ip2Geo feature
      * @return a list of all settings for Ip2Geo feature
      */
     public static final List<Setting<?>> settings() {
-        return List.of(DATASOURCE_ENDPOINT, DATASOURCE_UPDATE_INTERVAL, BATCH_SIZE, TIMEOUT, CACHE_SIZE);
+        return List.of(DATASOURCE_ENDPOINT, DATASOURCE_UPDATE_INTERVAL, BATCH_SIZE, TIMEOUT, CACHE_SIZE, DATASOURCE_ENDPOINT_DENYLIST);
     }
 
     /**

--- a/src/main/java/org/opensearch/geospatial/ip2geo/common/URLDenyListChecker.java
+++ b/src/main/java/org/opensearch/geospatial/ip2geo/common/URLDenyListChecker.java
@@ -1,0 +1,64 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package org.opensearch.geospatial.ip2geo.common;
+
+import java.net.InetAddress;
+import java.net.MalformedURLException;
+import java.net.URL;
+import java.net.UnknownHostException;
+import java.util.List;
+
+import lombok.extern.log4j.Log4j2;
+
+import org.opensearch.common.SuppressForbidden;
+import org.opensearch.common.settings.ClusterSettings;
+
+import inet.ipaddr.IPAddressString;
+
+/**
+ * A class to check url against a deny-list
+ */
+@Log4j2
+public class URLDenyListChecker {
+    private final ClusterSettings clusterSettings;
+
+    public URLDenyListChecker(final ClusterSettings clusterSettings) {
+        this.clusterSettings = clusterSettings;
+    }
+
+    /**
+     * Convert String to URL after verifying the url is not on a deny-list
+     *
+     * @param url value to validate and convert to URL
+     * @return value in URL type
+     */
+    public URL toUrlIfNotInDenyList(final String url) {
+        try {
+            return toUrlIfNotInDenyList(url, clusterSettings.get(Ip2GeoSettings.DATASOURCE_ENDPOINT_DENYLIST));
+        } catch (UnknownHostException e) {
+            log.error("Unknown host", e);
+            throw new IllegalArgumentException("host provided in the datasource endpoint is unknown");
+        } catch (MalformedURLException e) {
+            log.error("Malformed URL", e);
+            throw new IllegalArgumentException("URL provided in the datasource endpoint is malformed");
+        }
+    }
+
+    @SuppressForbidden(reason = "Need to connect to http endpoint to read GeoIP database file")
+    private URL toUrlIfNotInDenyList(final String url, final List<String> denyList) throws UnknownHostException, MalformedURLException {
+        URL urlToReturn = new URL(url);
+        if (isInDenyList(new IPAddressString(InetAddress.getByName(urlToReturn.getHost()).getHostAddress()), denyList)) {
+            throw new IllegalArgumentException(
+                "given endpoint is blocked by deny list in cluster setting " + Ip2GeoSettings.DATASOURCE_ENDPOINT_DENYLIST.getKey()
+            );
+        }
+        return urlToReturn;
+    }
+
+    private boolean isInDenyList(final IPAddressString url, final List<String> denyList) {
+        return denyList.stream().map(cidr -> new IPAddressString(cidr)).anyMatch(cidr -> cidr.contains(url));
+    }
+}

--- a/src/test/java/org/opensearch/geospatial/ClusterSettingHelper.java
+++ b/src/test/java/org/opensearch/geospatial/ClusterSettingHelper.java
@@ -1,0 +1,64 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package org.opensearch.geospatial;
+
+import static org.apache.lucene.tests.util.LuceneTestCase.createTempDir;
+import static org.opensearch.test.NodeRoles.dataNode;
+import static org.opensearch.test.OpenSearchTestCase.getTestTransportPlugin;
+import static org.opensearch.test.OpenSearchTestCase.getTestTransportType;
+import static org.opensearch.test.OpenSearchTestCase.randomLong;
+
+import java.io.File;
+import java.io.FileWriter;
+import java.io.IOException;
+import java.nio.file.Path;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+
+import org.opensearch.cluster.ClusterName;
+import org.opensearch.common.SuppressForbidden;
+import org.opensearch.common.network.NetworkModule;
+import org.opensearch.common.settings.Settings;
+import org.opensearch.env.Environment;
+import org.opensearch.geospatial.plugin.GeospatialPlugin;
+import org.opensearch.node.MockNode;
+import org.opensearch.node.Node;
+import org.opensearch.plugins.Plugin;
+import org.opensearch.test.InternalTestCluster;
+import org.opensearch.test.MockHttpTransport;
+
+@SuppressForbidden(reason = "used only for testing")
+public class ClusterSettingHelper {
+    public Node createMockNode(Map<String, Object> configSettings) throws IOException {
+        Path configDir = createTempDir();
+        File configFile = configDir.resolve("opensearch.yml").toFile();
+        FileWriter configFileWriter = new FileWriter(configFile);
+
+        for (Map.Entry<String, Object> setting : configSettings.entrySet()) {
+            configFileWriter.write("\"" + setting.getKey() + "\": " + setting.getValue());
+        }
+        configFileWriter.close();
+        return new MockNode(baseSettings().build(), basePlugins(), configDir, true);
+    }
+
+    private List<Class<? extends Plugin>> basePlugins() {
+        List<Class<? extends Plugin>> plugins = new ArrayList<>();
+        plugins.add(getTestTransportPlugin());
+        plugins.add(MockHttpTransport.TestPlugin.class);
+        plugins.add(GeospatialPlugin.class);
+        return plugins;
+    }
+
+    private static Settings.Builder baseSettings() {
+        final Path tempDir = createTempDir();
+        return Settings.builder()
+            .put(ClusterName.CLUSTER_NAME_SETTING.getKey(), InternalTestCluster.clusterName("single-node-cluster", randomLong()))
+            .put(Environment.PATH_HOME_SETTING.getKey(), tempDir)
+            .put(NetworkModule.TRANSPORT_TYPE_KEY, getTestTransportType())
+            .put(dataNode());
+    }
+}

--- a/src/test/java/org/opensearch/geospatial/ip2geo/Ip2GeoTestCase.java
+++ b/src/test/java/org/opensearch/geospatial/ip2geo/Ip2GeoTestCase.java
@@ -47,6 +47,7 @@ import org.opensearch.geospatial.ip2geo.common.DatasourceState;
 import org.opensearch.geospatial.ip2geo.common.Ip2GeoExecutor;
 import org.opensearch.geospatial.ip2geo.common.Ip2GeoLockService;
 import org.opensearch.geospatial.ip2geo.common.Ip2GeoSettings;
+import org.opensearch.geospatial.ip2geo.common.URLDenyListChecker;
 import org.opensearch.geospatial.ip2geo.dao.DatasourceDao;
 import org.opensearch.geospatial.ip2geo.dao.GeoIpDataDao;
 import org.opensearch.geospatial.ip2geo.dao.Ip2GeoCachedDao;
@@ -98,6 +99,7 @@ public abstract class Ip2GeoTestCase extends RestActionTestCase {
     protected Ip2GeoProcessorDao ip2GeoProcessorDao;
     @Mock
     protected RoutingTable routingTable;
+    protected URLDenyListChecker urlDenyListChecker;
     protected IngestMetadata ingestMetadata;
     protected NoOpNodeClient client;
     protected VerifyingClient verifyingClient;
@@ -115,6 +117,7 @@ public abstract class Ip2GeoTestCase extends RestActionTestCase {
         clusterSettings = new ClusterSettings(settings, new HashSet<>(Ip2GeoSettings.settings()));
         lockService = new LockService(client, clusterService);
         ingestMetadata = new IngestMetadata(Collections.emptyMap());
+        urlDenyListChecker = spy(new URLDenyListChecker(clusterSettings));
         when(metadata.custom(IngestMetadata.TYPE)).thenReturn(ingestMetadata);
         when(clusterService.getSettings()).thenReturn(Settings.EMPTY);
         when(clusterService.getClusterSettings()).thenReturn(clusterSettings);

--- a/src/test/java/org/opensearch/geospatial/ip2geo/action/RestPutDatasourceHandlerTests.java
+++ b/src/test/java/org/opensearch/geospatial/ip2geo/action/RestPutDatasourceHandlerTests.java
@@ -5,12 +5,16 @@
 
 package org.opensearch.geospatial.ip2geo.action;
 
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
 import static org.opensearch.geospatial.shared.URLBuilder.URL_DELIMITER;
 import static org.opensearch.geospatial.shared.URLBuilder.getPluginURLPrefix;
 
 import java.util.HashSet;
 import java.util.Locale;
 import java.util.concurrent.atomic.AtomicBoolean;
+
+import lombok.SneakyThrows;
 
 import org.junit.Before;
 import org.opensearch.common.SuppressForbidden;
@@ -21,6 +25,7 @@ import org.opensearch.common.xcontent.XContentType;
 import org.opensearch.core.common.bytes.BytesArray;
 import org.opensearch.geospatial.GeospatialTestHelper;
 import org.opensearch.geospatial.ip2geo.common.Ip2GeoSettings;
+import org.opensearch.geospatial.ip2geo.common.URLDenyListChecker;
 import org.opensearch.rest.RestRequest;
 import org.opensearch.test.rest.FakeRestRequest;
 import org.opensearch.test.rest.RestActionTestCase;
@@ -29,17 +34,22 @@ import org.opensearch.test.rest.RestActionTestCase;
 public class RestPutDatasourceHandlerTests extends RestActionTestCase {
     private String path;
     private RestPutDatasourceHandler action;
+    private URLDenyListChecker urlDenyListChecker;
 
     @Before
     public void setupAction() {
-        action = new RestPutDatasourceHandler(new ClusterSettings(Settings.EMPTY, new HashSet(Ip2GeoSettings.settings())));
+        ClusterSettings clusterSettings = new ClusterSettings(Settings.EMPTY, new HashSet(Ip2GeoSettings.settings()));
+        urlDenyListChecker = mock(URLDenyListChecker.class);
+        action = new RestPutDatasourceHandler(clusterSettings, urlDenyListChecker);
         controller().registerHandler(action);
         path = String.join(URL_DELIMITER, getPluginURLPrefix(), "ip2geo/datasource/%s");
     }
 
+    @SneakyThrows
     public void testPrepareRequest() {
+        String endpoint = "https://test.com";
         String datasourceName = GeospatialTestHelper.randomLowerCaseString();
-        String content = "{\"endpoint\":\"https://test.com\", \"update_interval_in_days\":1}";
+        String content = String.format(Locale.ROOT, "{\"endpoint\":\"%s\", \"update_interval_in_days\":1}", endpoint);
         RestRequest request = new FakeRestRequest.Builder(xContentRegistry()).withMethod(RestRequest.Method.PUT)
             .withPath(String.format(Locale.ROOT, path, datasourceName))
             .withContent(new BytesArray(content), XContentType.JSON)
@@ -49,7 +59,7 @@ public class RestPutDatasourceHandlerTests extends RestActionTestCase {
         verifyingClient.setExecuteLocallyVerifier((actionResponse, actionRequest) -> {
             assertTrue(actionRequest instanceof PutDatasourceRequest);
             PutDatasourceRequest putDatasourceRequest = (PutDatasourceRequest) actionRequest;
-            assertEquals("https://test.com", putDatasourceRequest.getEndpoint());
+            assertEquals(endpoint, putDatasourceRequest.getEndpoint());
             assertEquals(TimeValue.timeValueDays(1), putDatasourceRequest.getUpdateInterval());
             assertEquals(datasourceName, putDatasourceRequest.getName());
             isExecuted.set(true);
@@ -58,9 +68,12 @@ public class RestPutDatasourceHandlerTests extends RestActionTestCase {
 
         dispatchRequest(request);
         assertTrue(isExecuted.get());
+        verify(urlDenyListChecker).toUrlIfNotInDenyList(endpoint);
     }
 
+    @SneakyThrows
     public void testPrepareRequestDefaultValue() {
+        String endpoint = "https://geoip.maps.opensearch.org/v1/geolite2-city/manifest.json";
         String datasourceName = GeospatialTestHelper.randomLowerCaseString();
         RestRequest request = new FakeRestRequest.Builder(xContentRegistry()).withMethod(RestRequest.Method.PUT)
             .withPath(String.format(Locale.ROOT, path, datasourceName))
@@ -70,7 +83,7 @@ public class RestPutDatasourceHandlerTests extends RestActionTestCase {
         verifyingClient.setExecuteLocallyVerifier((actionResponse, actionRequest) -> {
             assertTrue(actionRequest instanceof PutDatasourceRequest);
             PutDatasourceRequest putDatasourceRequest = (PutDatasourceRequest) actionRequest;
-            assertEquals("https://geoip.maps.opensearch.org/v1/geolite2-city/manifest.json", putDatasourceRequest.getEndpoint());
+            assertEquals(endpoint, putDatasourceRequest.getEndpoint());
             assertEquals(TimeValue.timeValueDays(3), putDatasourceRequest.getUpdateInterval());
             assertEquals(datasourceName, putDatasourceRequest.getName());
             isExecuted.set(true);
@@ -79,5 +92,6 @@ public class RestPutDatasourceHandlerTests extends RestActionTestCase {
 
         dispatchRequest(request);
         assertTrue(isExecuted.get());
+        verify(urlDenyListChecker).toUrlIfNotInDenyList(endpoint);
     }
 }

--- a/src/test/java/org/opensearch/geospatial/ip2geo/common/URLDenyListCheckerTests.java
+++ b/src/test/java/org/opensearch/geospatial/ip2geo/common/URLDenyListCheckerTests.java
@@ -1,0 +1,73 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package org.opensearch.geospatial.ip2geo.common;
+
+import java.util.Arrays;
+import java.util.Locale;
+import java.util.Map;
+
+import lombok.SneakyThrows;
+
+import org.junit.Before;
+import org.opensearch.cluster.service.ClusterService;
+import org.opensearch.common.Randomness;
+import org.opensearch.geospatial.ClusterSettingHelper;
+import org.opensearch.node.Node;
+import org.opensearch.test.OpenSearchTestCase;
+
+public class URLDenyListCheckerTests extends OpenSearchTestCase {
+    private ClusterSettingHelper clusterSettingHelper;
+
+    @Before
+    public void init() {
+        clusterSettingHelper = new ClusterSettingHelper();
+    }
+
+    @SneakyThrows
+    public void testToUrlIfNotInDenyListWithBlockedAddress() {
+        Node mockNode = clusterSettingHelper.createMockNode(
+            Map.of(Ip2GeoSettings.DATASOURCE_ENDPOINT_DENYLIST.getKey(), Arrays.asList("127.0.0.0/8"))
+        );
+        mockNode.start();
+        try {
+            ClusterService clusterService = mockNode.injector().getInstance(ClusterService.class);
+            URLDenyListChecker urlDenyListChecker = new URLDenyListChecker(clusterService.getClusterSettings());
+            String endpoint = String.format(
+                Locale.ROOT,
+                "https://127.%d.%d.%d/v1/manifest.json",
+                Randomness.get().nextInt(256),
+                Randomness.get().nextInt(256),
+                Randomness.get().nextInt(256)
+            );
+            expectThrows(IllegalArgumentException.class, () -> urlDenyListChecker.toUrlIfNotInDenyList(endpoint));
+        } finally {
+            mockNode.close();
+        }
+    }
+
+    @SneakyThrows
+    public void testToUrlIfNotInDenyListWithNonBlockedAddress() {
+        Node mockNode = clusterSettingHelper.createMockNode(
+            Map.of(Ip2GeoSettings.DATASOURCE_ENDPOINT_DENYLIST.getKey(), Arrays.asList("127.0.0.0/8"))
+        );
+        mockNode.start();
+        try {
+            ClusterService clusterService = mockNode.injector().getInstance(ClusterService.class);
+            URLDenyListChecker urlDenyListChecker = new URLDenyListChecker(clusterService.getClusterSettings());
+            String endpoint = String.format(
+                Locale.ROOT,
+                "https://128.%d.%d.%d/v1/manifest.json",
+                Randomness.get().nextInt(256),
+                Randomness.get().nextInt(256),
+                Randomness.get().nextInt(256)
+            );
+            // Expect no exception
+            urlDenyListChecker.toUrlIfNotInDenyList(endpoint);
+        } finally {
+            mockNode.close();
+        }
+    }
+}

--- a/src/test/java/org/opensearch/geospatial/ip2geo/dao/GeoIpDataDaoTests.java
+++ b/src/test/java/org/opensearch/geospatial/ip2geo/dao/GeoIpDataDaoTests.java
@@ -61,8 +61,8 @@ public class GeoIpDataDaoTests extends Ip2GeoTestCase {
 
     @Before
     public void init() {
-        noOpsGeoIpDataDao = new GeoIpDataDao(clusterService, client);
-        verifyingGeoIpDataDao = new GeoIpDataDao(clusterService, verifyingClient);
+        noOpsGeoIpDataDao = new GeoIpDataDao(clusterService, client, urlDenyListChecker);
+        verifyingGeoIpDataDao = new GeoIpDataDao(clusterService, verifyingClient, urlDenyListChecker);
     }
 
     public void testCreateIndexIfNotExistsWithExistingIndex() {
@@ -131,6 +131,7 @@ public class GeoIpDataDaoTests extends Ip2GeoTestCase {
         assertArrayEquals(expectedHeader, parser.iterator().next().values());
         String[] expectedValues = { "1.0.0.0/24", "Australia" };
         assertArrayEquals(expectedValues, parser.iterator().next().values());
+        verify(urlDenyListChecker).toUrlIfNotInDenyList(manifest.getUrl());
     }
 
     public void testGetDatabaseReaderNoFile() throws Exception {
@@ -145,6 +146,7 @@ public class GeoIpDataDaoTests extends Ip2GeoTestCase {
         );
         Exception exception = expectThrows(IllegalArgumentException.class, () -> noOpsGeoIpDataDao.getDatabaseReader(manifest));
         assertTrue(exception.getMessage().contains("does not exist"));
+        verify(urlDenyListChecker).toUrlIfNotInDenyList(manifest.getUrl());
     }
 
     @SneakyThrows

--- a/src/test/java/org/opensearch/geospatial/ip2geo/jobscheduler/DatasourceUpdateServiceTests.java
+++ b/src/test/java/org/opensearch/geospatial/ip2geo/jobscheduler/DatasourceUpdateServiceTests.java
@@ -43,7 +43,7 @@ public class DatasourceUpdateServiceTests extends Ip2GeoTestCase {
 
     @Before
     public void init() {
-        datasourceUpdateService = new DatasourceUpdateService(clusterService, datasourceDao, geoIpDataDao);
+        datasourceUpdateService = new DatasourceUpdateService(clusterService, datasourceDao, geoIpDataDao, urlDenyListChecker);
     }
 
     @SneakyThrows
@@ -64,6 +64,7 @@ public class DatasourceUpdateServiceTests extends Ip2GeoTestCase {
         // Verify
         assertNotNull(datasource.getUpdateStats().getLastSkippedAt());
         verify(datasourceDao).updateDatasource(datasource);
+        verify(urlDenyListChecker).toUrlIfNotInDenyList(datasource.getEndpoint());
     }
 
     @SneakyThrows
@@ -87,6 +88,7 @@ public class DatasourceUpdateServiceTests extends Ip2GeoTestCase {
 
         // Verify
         verify(geoIpDataDao).putGeoIpData(eq(datasource.currentIndexName()), isA(String[].class), any(Iterator.class), any(Runnable.class));
+        verify(urlDenyListChecker).toUrlIfNotInDenyList(datasource.getEndpoint());
     }
 
     @SneakyThrows
@@ -108,6 +110,7 @@ public class DatasourceUpdateServiceTests extends Ip2GeoTestCase {
 
         // Run
         expectThrows(OpenSearchException.class, () -> datasourceUpdateService.updateOrCreateGeoIpData(datasource, mock(Runnable.class)));
+        verify(urlDenyListChecker).toUrlIfNotInDenyList(datasource.getEndpoint());
     }
 
     @SneakyThrows
@@ -127,6 +130,7 @@ public class DatasourceUpdateServiceTests extends Ip2GeoTestCase {
 
         // Run
         expectThrows(OpenSearchException.class, () -> datasourceUpdateService.updateOrCreateGeoIpData(datasource, mock(Runnable.class)));
+        verify(urlDenyListChecker).toUrlIfNotInDenyList(datasource.getEndpoint());
     }
 
     @SneakyThrows
@@ -161,6 +165,7 @@ public class DatasourceUpdateServiceTests extends Ip2GeoTestCase {
         assertNotNull(datasource.getUpdateStats().getLastProcessingTimeInMillis());
         verify(datasourceDao, times(2)).updateDatasource(datasource);
         verify(geoIpDataDao).putGeoIpData(eq(datasource.currentIndexName()), isA(String[].class), any(Iterator.class), any(Runnable.class));
+        verify(urlDenyListChecker).toUrlIfNotInDenyList(datasource.getEndpoint());
     }
 
     public void testWaitUntilAllShardsStarted_whenTimedOut_thenThrowException() {

--- a/src/test/java/org/opensearch/geospatial/plugin/GeospatialPluginTests.java
+++ b/src/test/java/org/opensearch/geospatial/plugin/GeospatialPluginTests.java
@@ -40,6 +40,7 @@ import org.opensearch.geospatial.ip2geo.action.RestUpdateDatasourceHandler;
 import org.opensearch.geospatial.ip2geo.common.Ip2GeoExecutor;
 import org.opensearch.geospatial.ip2geo.common.Ip2GeoLockService;
 import org.opensearch.geospatial.ip2geo.common.Ip2GeoSettings;
+import org.opensearch.geospatial.ip2geo.common.URLDenyListChecker;
 import org.opensearch.geospatial.ip2geo.dao.DatasourceDao;
 import org.opensearch.geospatial.ip2geo.dao.GeoIpDataDao;
 import org.opensearch.geospatial.ip2geo.dao.Ip2GeoCachedDao;
@@ -63,12 +64,13 @@ import org.opensearch.watcher.ResourceWatcherService;
 
 public class GeospatialPluginTests extends OpenSearchTestCase {
     private final ClusterSettings clusterSettings = new ClusterSettings(Settings.EMPTY, new HashSet(Ip2GeoSettings.settings()));
+    private final URLDenyListChecker urlDenyListChecker = new URLDenyListChecker(clusterSettings);
     private final List<RestHandler> SUPPORTED_REST_HANDLERS = List.of(
         new RestUploadGeoJSONAction(),
         new RestUploadStatsAction(),
-        new RestPutDatasourceHandler(clusterSettings),
+        new RestPutDatasourceHandler(clusterSettings, urlDenyListChecker),
         new RestGetDatasourceHandler(),
-        new RestUpdateDatasourceHandler(),
+        new RestUpdateDatasourceHandler(urlDenyListChecker),
         new RestDeleteDatasourceHandler()
     );
 


### PR DESCRIPTION
### Description
Add a denylist ip config for datasource endpoint so that admin can block certain ip addresses from being used in datasource endpoint
This PR mimicked https://github.com/opensearch-project/sql/pull/2042

When IP address is in the deny list, following message will be returned.
```
{
	"error": {
		"root_cause": [
			{
				"type": "illegal_argument_exception",
				"reason": "Given endpoint is blocked by deny list in cluster setting plugins.geospatial.ip2geo.datasource.endpoint.denylist"
			}
		],
		"type": "illegal_argument_exception",
		"reason": "Given endpoint is blocked by deny list in cluster setting plugins.geospatial.ip2geo.datasource.endpoint.denylist"
	},
	"status": 400
}
```
### Issues Resolved
N/A
 
### Check List
- [X] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
