### PR TITLE
Upgrade gradle to 8.4

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,4 +21,5 @@ See the [CONTRIBUTING guide](./CONTRIBUTING.md#Changelog) for instructions on ho
 ### Infrastructure
 ### Documentation
 ### Maintenance
+* Upgrade gradle to 8.4 ([#596](https://github.com/opensearch-project/geospatial/pull/596))
 ### Refactoring

--- a/build.gradle
+++ b/build.gradle
@@ -75,7 +75,7 @@ buildscript {
     dependencies {
         classpath "${opensearch_group}.gradle:build-tools:${opensearch_version}"
         classpath "com.diffplug.spotless:spotless-plugin-gradle:6.3.0"
-        classpath "io.freefair.gradle:lombok-plugin:6.4.3"
+        classpath "io.freefair.gradle:lombok-plugin:8.4"
     }
 }
 apply plugin: "com.diffplug.spotless"
@@ -315,8 +315,8 @@ spotless {
 jacocoTestReport {
     dependsOn test
     reports {
-        xml.enabled = true
-        html.enabled = true
+        xml.getRequired().set(true)
+        html.getRequired().set(true)
     }
 }
 

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,5 +1,5 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-7.6-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-8.4-bin.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists

--- a/libs/h3/build.gradle
+++ b/libs/h3/build.gradle
@@ -73,3 +73,4 @@ publishing {
 }
 
 validatePluginZipPom.dependsOn(generatePomFileForNebulaPublication)
+validateNebulaPom.dependsOn(generatePomFileForPluginZipPublication)

--- a/libs/h3/build.gradle
+++ b/libs/h3/build.gradle
@@ -72,4 +72,4 @@ publishing {
     }
 }
 
-
+validatePluginZipPom.dependsOn(generatePomFileForNebulaPublication)

--- a/src/test/java/org/opensearch/geospatial/plugin/GeospatialPluginTests.java
+++ b/src/test/java/org/opensearch/geospatial/plugin/GeospatialPluginTests.java
@@ -203,6 +203,7 @@ public class GeospatialPluginTests extends OpenSearchTestCase {
             null,
             ingestService,
             client,
+            null,
             null
         );
     }


### PR DESCRIPTION
### Description
Upgrade gradle to 8.4 to support JDK-21. Refer to
https://docs.gradle.org/current/userguide/compatibility.html
 
### Check List
- [X] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
