### PR TITLE
Update CI to use jdk-21

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -19,7 +19,7 @@ jobs:
     needs: Get-CI-Image-Tag
     strategy:
       matrix:
-        java: [11, 17]
+        java: [11, 17, 21]
 
     name: Build and Test geospatial Plugin
     runs-on: ubuntu-latest
@@ -52,7 +52,7 @@ jobs:
   Build-windows-macos:
     strategy:
       matrix:
-        java: [11, 17]
+        java: [11, 17, 21]
         os: [windows-latest, macos-latest]
 
     name: Build and Test geospatial Plugin

--- a/.github/workflows/test_security.yml
+++ b/.github/workflows/test_security.yml
@@ -15,7 +15,7 @@ jobs:
   Build-ad:
     strategy:
       matrix:
-        java: [ 11,17 ]
+        java: [ 11,17,21 ]
         os: [ubuntu-latest]
       fail-fast: true
 

--- a/build.gradle
+++ b/build.gradle
@@ -74,7 +74,7 @@ buildscript {
 
     dependencies {
         classpath "${opensearch_group}.gradle:build-tools:${opensearch_version}"
-        classpath "com.diffplug.spotless:spotless-plugin-gradle:6.3.0"
+        classpath "com.diffplug.spotless:spotless-plugin-gradle:6.20.0"
         classpath "io.freefair.gradle:lombok-plugin:8.4"
     }
 }

--- a/src/main/java/org/opensearch/geospatial/action/upload/geojson/IndexManager.java
+++ b/src/main/java/org/opensearch/geospatial/action/upload/geojson/IndexManager.java
@@ -8,9 +8,6 @@ package org.opensearch.geospatial.action.upload.geojson;
 import java.io.IOException;
 import java.util.Map;
 
-import lombok.AllArgsConstructor;
-import lombok.NonNull;
-
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.opensearch.action.StepListener;
@@ -19,6 +16,9 @@ import org.opensearch.client.IndicesAdminClient;
 import org.opensearch.common.xcontent.XContentFactory;
 import org.opensearch.core.action.ActionListener;
 import org.opensearch.core.xcontent.XContentBuilder;
+
+import lombok.AllArgsConstructor;
+import lombok.NonNull;
 
 /**
  * IndexManager is responsible for managing index operations like create, delete, etc...

--- a/src/main/java/org/opensearch/geospatial/action/upload/geojson/PipelineManager.java
+++ b/src/main/java/org/opensearch/geospatial/action/upload/geojson/PipelineManager.java
@@ -8,10 +8,6 @@ package org.opensearch.geospatial.action.upload.geojson;
 import java.io.IOException;
 import java.util.function.Supplier;
 
-import lombok.AllArgsConstructor;
-import lombok.NonNull;
-import lombok.extern.log4j.Log4j2;
-
 import org.opensearch.action.StepListener;
 import org.opensearch.action.ingest.DeletePipelineRequest;
 import org.opensearch.action.ingest.PutPipelineRequest;
@@ -24,6 +20,10 @@ import org.opensearch.core.common.bytes.BytesReference;
 import org.opensearch.core.xcontent.XContentBuilder;
 import org.opensearch.geospatial.processor.FeatureProcessor;
 import org.opensearch.ingest.Pipeline;
+
+import lombok.AllArgsConstructor;
+import lombok.NonNull;
+import lombok.extern.log4j.Log4j2;
 
 /**
  * PipelineManager is responsible for managing pipeline operations like create and delete

--- a/src/main/java/org/opensearch/geospatial/action/upload/geojson/UploadGeoJSONRequest.java
+++ b/src/main/java/org/opensearch/geospatial/action/upload/geojson/UploadGeoJSONRequest.java
@@ -14,16 +14,16 @@ package org.opensearch.geospatial.action.upload.geojson;
 import java.io.IOException;
 import java.util.Objects;
 
-import lombok.AllArgsConstructor;
-import lombok.Getter;
-import lombok.NonNull;
-
 import org.opensearch.action.ActionRequest;
 import org.opensearch.action.ActionRequestValidationException;
 import org.opensearch.core.common.bytes.BytesReference;
 import org.opensearch.core.common.io.stream.StreamInput;
 import org.opensearch.core.common.io.stream.StreamOutput;
 import org.opensearch.rest.RestRequest;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NonNull;
 
 @AllArgsConstructor
 @Getter

--- a/src/main/java/org/opensearch/geospatial/action/upload/geojson/UploadGeoJSONRequestContent.java
+++ b/src/main/java/org/opensearch/geospatial/action/upload/geojson/UploadGeoJSONRequestContent.java
@@ -12,12 +12,12 @@ import java.util.Locale;
 import java.util.Map;
 import java.util.Objects;
 
-import lombok.AccessLevel;
-import lombok.AllArgsConstructor;
-
 import org.opensearch.core.ParseField;
 import org.opensearch.core.common.Strings;
 import org.opensearch.geospatial.GeospatialParser;
+
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
 
 /**
  * UploadGeoJSONRequestContent is the Data model for UploadGeoJSONRequest's body

--- a/src/main/java/org/opensearch/geospatial/geojson/FeatureCollection.java
+++ b/src/main/java/org/opensearch/geospatial/geojson/FeatureCollection.java
@@ -9,10 +9,10 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
 
+import org.opensearch.geospatial.GeospatialParser;
+
 import lombok.NonNull;
 import lombok.Value;
-
-import org.opensearch.geospatial.GeospatialParser;
 
 /**
  * FeatureCollection represents GEOJSON of type FeatureCollection. A FeatureCollection object has a member

--- a/src/main/java/org/opensearch/geospatial/geojson/FeatureFactory.java
+++ b/src/main/java/org/opensearch/geospatial/geojson/FeatureFactory.java
@@ -10,9 +10,9 @@ import static org.opensearch.geospatial.geojson.Feature.TYPE;
 
 import java.util.Map;
 
-import lombok.NonNull;
-
 import org.opensearch.geospatial.geojson.Feature.FeatureBuilder;
+
+import lombok.NonNull;
 
 /**
  * FeatureFactory helps to create {@link Feature} instance based on user input

--- a/src/main/java/org/opensearch/geospatial/index/common/xyshape/XYShapeConverter.java
+++ b/src/main/java/org/opensearch/geospatial/index/common/xyshape/XYShapeConverter.java
@@ -11,10 +11,6 @@ import java.util.stream.Collectors;
 import java.util.stream.DoubleStream;
 import java.util.stream.IntStream;
 
-import lombok.AccessLevel;
-import lombok.NoArgsConstructor;
-import lombok.NonNull;
-
 import org.apache.lucene.geo.XYCircle;
 import org.apache.lucene.geo.XYLine;
 import org.apache.lucene.geo.XYPoint;
@@ -25,6 +21,10 @@ import org.opensearch.geometry.Line;
 import org.opensearch.geometry.Point;
 import org.opensearch.geometry.Polygon;
 import org.opensearch.geometry.Rectangle;
+
+import lombok.AccessLevel;
+import lombok.NoArgsConstructor;
+import lombok.NonNull;
 
 /**
  * Utility class to convert compatible shapes from opensearch to Lucene

--- a/src/main/java/org/opensearch/geospatial/index/mapper/xypoint/XYPoint.java
+++ b/src/main/java/org/opensearch/geospatial/index/mapper/xypoint/XYPoint.java
@@ -11,10 +11,6 @@ import java.io.IOException;
 import java.util.Locale;
 import java.util.Objects;
 
-import lombok.AllArgsConstructor;
-import lombok.Getter;
-import lombok.NoArgsConstructor;
-
 import org.opensearch.OpenSearchParseException;
 import org.opensearch.core.xcontent.ToXContentFragment;
 import org.opensearch.core.xcontent.XContentBuilder;
@@ -24,6 +20,10 @@ import org.opensearch.geometry.ShapeType;
 import org.opensearch.geometry.utils.StandardValidator;
 import org.opensearch.geometry.utils.WellKnownText;
 import org.opensearch.index.mapper.AbstractPointGeometryFieldMapper;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
 
 /**
  * Represents a point in a 2-dimensional planar coordinate system with no range limitations.

--- a/src/main/java/org/opensearch/geospatial/index/mapper/xypoint/XYPointIndexer.java
+++ b/src/main/java/org/opensearch/geospatial/index/mapper/xypoint/XYPointIndexer.java
@@ -9,8 +9,6 @@ import java.util.List;
 import java.util.Objects;
 import java.util.stream.Collectors;
 
-import lombok.AllArgsConstructor;
-
 import org.apache.lucene.document.XYPointField;
 import org.apache.lucene.geo.XYPoint;
 import org.apache.lucene.index.IndexableField;
@@ -18,6 +16,8 @@ import org.opensearch.geometry.Point;
 import org.opensearch.geospatial.index.common.xyshape.XYShapeConverter;
 import org.opensearch.index.mapper.AbstractGeometryFieldMapper;
 import org.opensearch.index.mapper.ParseContext;
+
+import lombok.AllArgsConstructor;
 
 /**
  * Converts points into Lucene-compatible form{@link XYPoint} for indexing in a xy_point field.

--- a/src/main/java/org/opensearch/geospatial/index/query/xypoint/XYPointQueryVisitor.java
+++ b/src/main/java/org/opensearch/geospatial/index/query/xypoint/XYPointQueryVisitor.java
@@ -13,8 +13,6 @@ import java.util.Collections;
 import java.util.Locale;
 import java.util.Objects;
 
-import lombok.AllArgsConstructor;
-
 import org.apache.lucene.document.XYDocValuesField;
 import org.apache.lucene.document.XYPointField;
 import org.apache.lucene.geo.XYCircle;
@@ -41,6 +39,8 @@ import org.opensearch.geometry.ShapeType;
 import org.opensearch.index.mapper.MappedFieldType;
 import org.opensearch.index.query.QueryShardContext;
 import org.opensearch.index.query.QueryShardException;
+
+import lombok.AllArgsConstructor;
 
 /**
  * Geometry Visitor to create a query to find all cartesian XYPoints

--- a/src/main/java/org/opensearch/geospatial/index/query/xyshape/XYShapeQueryProcessor.java
+++ b/src/main/java/org/opensearch/geospatial/index/query/xyshape/XYShapeQueryProcessor.java
@@ -8,8 +8,6 @@ package org.opensearch.geospatial.index.query.xyshape;
 import java.util.List;
 import java.util.Locale;
 
-import lombok.NonNull;
-
 import org.apache.lucene.document.ShapeField;
 import org.apache.lucene.document.XYShape;
 import org.apache.lucene.geo.XYGeometry;
@@ -22,6 +20,8 @@ import org.opensearch.geospatial.index.mapper.xyshape.XYShapeFieldMapper;
 import org.opensearch.index.mapper.MappedFieldType;
 import org.opensearch.index.query.QueryShardContext;
 import org.opensearch.index.query.QueryShardException;
+
+import lombok.NonNull;
 
 /**
  * Query Processor to convert given Geometry into Lucene query

--- a/src/main/java/org/opensearch/geospatial/ip2geo/action/DeleteDatasourceRequest.java
+++ b/src/main/java/org/opensearch/geospatial/ip2geo/action/DeleteDatasourceRequest.java
@@ -7,15 +7,15 @@ package org.opensearch.geospatial.ip2geo.action;
 
 import java.io.IOException;
 
-import lombok.AllArgsConstructor;
-import lombok.Getter;
-import lombok.Setter;
-
 import org.opensearch.action.ActionRequest;
 import org.opensearch.action.ActionRequestValidationException;
 import org.opensearch.core.common.io.stream.StreamInput;
 import org.opensearch.core.common.io.stream.StreamOutput;
 import org.opensearch.geospatial.ip2geo.common.ParameterValidator;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.Setter;
 
 /**
  * GeoIP datasource delete request

--- a/src/main/java/org/opensearch/geospatial/ip2geo/action/DeleteDatasourceTransportAction.java
+++ b/src/main/java/org/opensearch/geospatial/ip2geo/action/DeleteDatasourceTransportAction.java
@@ -7,8 +7,6 @@ package org.opensearch.geospatial.ip2geo.action;
 
 import java.io.IOException;
 
-import lombok.extern.log4j.Log4j2;
-
 import org.opensearch.ResourceNotFoundException;
 import org.opensearch.action.support.ActionFilters;
 import org.opensearch.action.support.HandledTransportAction;
@@ -28,6 +26,8 @@ import org.opensearch.ingest.IngestService;
 import org.opensearch.tasks.Task;
 import org.opensearch.threadpool.ThreadPool;
 import org.opensearch.transport.TransportService;
+
+import lombok.extern.log4j.Log4j2;
 
 /**
  * Transport action to delete datasource

--- a/src/main/java/org/opensearch/geospatial/ip2geo/action/GetDatasourceRequest.java
+++ b/src/main/java/org/opensearch/geospatial/ip2geo/action/GetDatasourceRequest.java
@@ -7,13 +7,13 @@ package org.opensearch.geospatial.ip2geo.action;
 
 import java.io.IOException;
 
-import lombok.Getter;
-import lombok.Setter;
-
 import org.opensearch.action.ActionRequest;
 import org.opensearch.action.ActionRequestValidationException;
 import org.opensearch.core.common.io.stream.StreamInput;
 import org.opensearch.core.common.io.stream.StreamOutput;
+
+import lombok.Getter;
+import lombok.Setter;
 
 /**
  * Ip2Geo datasource get request

--- a/src/main/java/org/opensearch/geospatial/ip2geo/action/GetDatasourceResponse.java
+++ b/src/main/java/org/opensearch/geospatial/ip2geo/action/GetDatasourceResponse.java
@@ -9,10 +9,6 @@ import java.io.IOException;
 import java.time.Instant;
 import java.util.List;
 
-import lombok.EqualsAndHashCode;
-import lombok.Getter;
-import lombok.Setter;
-
 import org.opensearch.core.ParseField;
 import org.opensearch.core.action.ActionResponse;
 import org.opensearch.core.common.io.stream.StreamInput;
@@ -20,6 +16,10 @@ import org.opensearch.core.common.io.stream.StreamOutput;
 import org.opensearch.core.xcontent.ToXContentObject;
 import org.opensearch.core.xcontent.XContentBuilder;
 import org.opensearch.geospatial.ip2geo.jobscheduler.Datasource;
+
+import lombok.EqualsAndHashCode;
+import lombok.Getter;
+import lombok.Setter;
 
 /**
  * Ip2Geo datasource get request

--- a/src/main/java/org/opensearch/geospatial/ip2geo/action/PutDatasourceRequest.java
+++ b/src/main/java/org/opensearch/geospatial/ip2geo/action/PutDatasourceRequest.java
@@ -12,10 +12,6 @@ import java.net.URL;
 import java.util.List;
 import java.util.Locale;
 
-import lombok.Getter;
-import lombok.Setter;
-import lombok.extern.log4j.Log4j2;
-
 import org.opensearch.action.ActionRequest;
 import org.opensearch.action.ActionRequestValidationException;
 import org.opensearch.common.unit.TimeValue;
@@ -25,6 +21,10 @@ import org.opensearch.core.common.io.stream.StreamOutput;
 import org.opensearch.core.xcontent.ObjectParser;
 import org.opensearch.geospatial.ip2geo.common.DatasourceManifest;
 import org.opensearch.geospatial.ip2geo.common.ParameterValidator;
+
+import lombok.Getter;
+import lombok.Setter;
+import lombok.extern.log4j.Log4j2;
 
 /**
  * Ip2Geo datasource creation request

--- a/src/main/java/org/opensearch/geospatial/ip2geo/action/PutDatasourceTransportAction.java
+++ b/src/main/java/org/opensearch/geospatial/ip2geo/action/PutDatasourceTransportAction.java
@@ -10,8 +10,6 @@ import static org.opensearch.geospatial.ip2geo.common.Ip2GeoLockService.LOCK_DUR
 import java.time.Instant;
 import java.util.concurrent.atomic.AtomicReference;
 
-import lombok.extern.log4j.Log4j2;
-
 import org.opensearch.ResourceAlreadyExistsException;
 import org.opensearch.action.StepListener;
 import org.opensearch.action.index.IndexResponse;
@@ -32,6 +30,8 @@ import org.opensearch.jobscheduler.spi.LockModel;
 import org.opensearch.tasks.Task;
 import org.opensearch.threadpool.ThreadPool;
 import org.opensearch.transport.TransportService;
+
+import lombok.extern.log4j.Log4j2;
 
 /**
  * Transport action to create datasource

--- a/src/main/java/org/opensearch/geospatial/ip2geo/action/UpdateDatasourceRequest.java
+++ b/src/main/java/org/opensearch/geospatial/ip2geo/action/UpdateDatasourceRequest.java
@@ -11,11 +11,6 @@ import java.net.URISyntaxException;
 import java.net.URL;
 import java.util.Locale;
 
-import lombok.EqualsAndHashCode;
-import lombok.Getter;
-import lombok.Setter;
-import lombok.extern.log4j.Log4j2;
-
 import org.opensearch.action.ActionRequest;
 import org.opensearch.action.ActionRequestValidationException;
 import org.opensearch.common.unit.TimeValue;
@@ -25,6 +20,11 @@ import org.opensearch.core.common.io.stream.StreamOutput;
 import org.opensearch.core.xcontent.ObjectParser;
 import org.opensearch.geospatial.ip2geo.common.DatasourceManifest;
 import org.opensearch.geospatial.ip2geo.common.ParameterValidator;
+
+import lombok.EqualsAndHashCode;
+import lombok.Getter;
+import lombok.Setter;
+import lombok.extern.log4j.Log4j2;
 
 /**
  * Ip2Geo datasource update request

--- a/src/main/java/org/opensearch/geospatial/ip2geo/action/UpdateDatasourceTransportAction.java
+++ b/src/main/java/org/opensearch/geospatial/ip2geo/action/UpdateDatasourceTransportAction.java
@@ -13,8 +13,6 @@ import java.time.temporal.ChronoUnit;
 import java.util.List;
 import java.util.Locale;
 
-import lombok.extern.log4j.Log4j2;
-
 import org.opensearch.ResourceNotFoundException;
 import org.opensearch.action.support.ActionFilters;
 import org.opensearch.action.support.HandledTransportAction;
@@ -34,6 +32,8 @@ import org.opensearch.jobscheduler.spi.schedule.IntervalSchedule;
 import org.opensearch.tasks.Task;
 import org.opensearch.threadpool.ThreadPool;
 import org.opensearch.transport.TransportService;
+
+import lombok.extern.log4j.Log4j2;
 
 /**
  * Transport action to update datasource

--- a/src/main/java/org/opensearch/geospatial/ip2geo/common/DatasourceManifest.java
+++ b/src/main/java/org/opensearch/geospatial/ip2geo/common/DatasourceManifest.java
@@ -14,10 +14,6 @@ import java.nio.CharBuffer;
 import java.security.AccessController;
 import java.security.PrivilegedAction;
 
-import lombok.AllArgsConstructor;
-import lombok.Getter;
-import lombok.Setter;
-
 import org.opensearch.SpecialPermission;
 import org.opensearch.common.SuppressForbidden;
 import org.opensearch.common.xcontent.json.JsonXContent;
@@ -28,6 +24,10 @@ import org.opensearch.core.xcontent.NamedXContentRegistry;
 import org.opensearch.core.xcontent.XContentParser;
 import org.opensearch.geospatial.annotation.VisibleForTesting;
 import org.opensearch.geospatial.shared.Constants;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.Setter;
 
 /**
  * Ip2Geo datasource manifest file object

--- a/src/main/java/org/opensearch/geospatial/ip2geo/common/Ip2GeoLockService.java
+++ b/src/main/java/org/opensearch/geospatial/ip2geo/common/Ip2GeoLockService.java
@@ -13,14 +13,14 @@ import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicReference;
 
-import lombok.extern.log4j.Log4j2;
-
 import org.opensearch.OpenSearchException;
 import org.opensearch.client.Client;
 import org.opensearch.cluster.service.ClusterService;
 import org.opensearch.core.action.ActionListener;
 import org.opensearch.jobscheduler.spi.LockModel;
 import org.opensearch.jobscheduler.spi.utils.LockService;
+
+import lombok.extern.log4j.Log4j2;
 
 /**
  * A wrapper of job scheduler's lock service for datasource

--- a/src/main/java/org/opensearch/geospatial/ip2geo/common/URLDenyListChecker.java
+++ b/src/main/java/org/opensearch/geospatial/ip2geo/common/URLDenyListChecker.java
@@ -11,12 +11,11 @@ import java.net.URL;
 import java.net.UnknownHostException;
 import java.util.List;
 
-import lombok.extern.log4j.Log4j2;
-
 import org.opensearch.common.SuppressForbidden;
 import org.opensearch.common.settings.ClusterSettings;
 
 import inet.ipaddr.IPAddressString;
+import lombok.extern.log4j.Log4j2;
 
 /**
  * A class to check url against a deny-list

--- a/src/main/java/org/opensearch/geospatial/ip2geo/dao/DatasourceDao.java
+++ b/src/main/java/org/opensearch/geospatial/ip2geo/dao/DatasourceDao.java
@@ -16,8 +16,6 @@ import java.util.List;
 import java.util.Objects;
 import java.util.stream.Collectors;
 
-import lombok.extern.log4j.Log4j2;
-
 import org.opensearch.OpenSearchException;
 import org.opensearch.ResourceAlreadyExistsException;
 import org.opensearch.ResourceNotFoundException;
@@ -56,6 +54,8 @@ import org.opensearch.geospatial.shared.StashedThreadContext;
 import org.opensearch.index.IndexNotFoundException;
 import org.opensearch.index.query.QueryBuilders;
 import org.opensearch.search.SearchHit;
+
+import lombok.extern.log4j.Log4j2;
 
 /**
  * Data access object for datasource

--- a/src/main/java/org/opensearch/geospatial/ip2geo/dao/GeoIpDataDao.java
+++ b/src/main/java/org/opensearch/geospatial/ip2geo/dao/GeoIpDataDao.java
@@ -29,9 +29,6 @@ import java.util.stream.Collectors;
 import java.util.zip.ZipEntry;
 import java.util.zip.ZipInputStream;
 
-import lombok.NonNull;
-import lombok.extern.log4j.Log4j2;
-
 import org.apache.commons.csv.CSVFormat;
 import org.apache.commons.csv.CSVParser;
 import org.apache.commons.csv.CSVRecord;
@@ -65,6 +62,9 @@ import org.opensearch.geospatial.ip2geo.common.URLDenyListChecker;
 import org.opensearch.geospatial.shared.Constants;
 import org.opensearch.geospatial.shared.StashedThreadContext;
 import org.opensearch.index.query.QueryBuilders;
+
+import lombok.NonNull;
+import lombok.extern.log4j.Log4j2;
 
 /**
  * Data access object  for GeoIp data

--- a/src/main/java/org/opensearch/geospatial/ip2geo/dao/Ip2GeoCachedDao.java
+++ b/src/main/java/org/opensearch/geospatial/ip2geo/dao/Ip2GeoCachedDao.java
@@ -13,11 +13,6 @@ import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ExecutionException;
 import java.util.function.Function;
 
-import lombok.AllArgsConstructor;
-import lombok.EqualsAndHashCode;
-import lombok.Getter;
-import lombok.extern.log4j.Log4j2;
-
 import org.opensearch.cluster.service.ClusterService;
 import org.opensearch.common.cache.Cache;
 import org.opensearch.common.cache.CacheBuilder;
@@ -33,6 +28,11 @@ import org.opensearch.geospatial.ip2geo.jobscheduler.Datasource;
 import org.opensearch.index.IndexNotFoundException;
 import org.opensearch.index.engine.Engine;
 import org.opensearch.index.shard.IndexingOperationListener;
+
+import lombok.AllArgsConstructor;
+import lombok.EqualsAndHashCode;
+import lombok.Getter;
+import lombok.extern.log4j.Log4j2;
 
 /**
  * Data access object for Datasource and GeoIP data with added caching layer

--- a/src/main/java/org/opensearch/geospatial/ip2geo/jobscheduler/Datasource.java
+++ b/src/main/java/org/opensearch/geospatial/ip2geo/jobscheduler/Datasource.java
@@ -14,14 +14,6 @@ import java.util.List;
 import java.util.Locale;
 import java.util.Set;
 
-import lombok.AccessLevel;
-import lombok.AllArgsConstructor;
-import lombok.EqualsAndHashCode;
-import lombok.Getter;
-import lombok.NoArgsConstructor;
-import lombok.Setter;
-import lombok.ToString;
-
 import org.opensearch.core.ParseField;
 import org.opensearch.core.common.io.stream.StreamInput;
 import org.opensearch.core.common.io.stream.StreamOutput;
@@ -37,6 +29,14 @@ import org.opensearch.geospatial.ip2geo.common.Ip2GeoLockService;
 import org.opensearch.jobscheduler.spi.ScheduledJobParameter;
 import org.opensearch.jobscheduler.spi.schedule.IntervalSchedule;
 import org.opensearch.jobscheduler.spi.schedule.ScheduleParser;
+
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.EqualsAndHashCode;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+import lombok.ToString;
 
 /**
  * Ip2Geo datasource job parameter

--- a/src/main/java/org/opensearch/geospatial/ip2geo/jobscheduler/DatasourceRunner.java
+++ b/src/main/java/org/opensearch/geospatial/ip2geo/jobscheduler/DatasourceRunner.java
@@ -11,8 +11,6 @@ import java.time.temporal.ChronoUnit;
 import java.util.Optional;
 import java.util.concurrent.atomic.AtomicReference;
 
-import lombok.extern.log4j.Log4j2;
-
 import org.opensearch.cluster.service.ClusterService;
 import org.opensearch.geospatial.annotation.VisibleForTesting;
 import org.opensearch.geospatial.ip2geo.common.DatasourceState;
@@ -24,6 +22,8 @@ import org.opensearch.jobscheduler.spi.LockModel;
 import org.opensearch.jobscheduler.spi.ScheduledJobParameter;
 import org.opensearch.jobscheduler.spi.ScheduledJobRunner;
 import org.opensearch.jobscheduler.spi.schedule.IntervalSchedule;
+
+import lombok.extern.log4j.Log4j2;
 
 /**
  * Datasource update task

--- a/src/main/java/org/opensearch/geospatial/ip2geo/jobscheduler/DatasourceUpdateService.java
+++ b/src/main/java/org/opensearch/geospatial/ip2geo/jobscheduler/DatasourceUpdateService.java
@@ -15,8 +15,6 @@ import java.util.List;
 import java.util.UUID;
 import java.util.stream.Collectors;
 
-import lombok.extern.log4j.Log4j2;
-
 import org.apache.commons.csv.CSVParser;
 import org.apache.commons.csv.CSVRecord;
 import org.opensearch.OpenSearchException;
@@ -29,6 +27,8 @@ import org.opensearch.geospatial.ip2geo.common.URLDenyListChecker;
 import org.opensearch.geospatial.ip2geo.dao.DatasourceDao;
 import org.opensearch.geospatial.ip2geo.dao.GeoIpDataDao;
 import org.opensearch.jobscheduler.spi.schedule.IntervalSchedule;
+
+import lombok.extern.log4j.Log4j2;
 
 @Log4j2
 public class DatasourceUpdateService {

--- a/src/main/java/org/opensearch/geospatial/ip2geo/listener/Ip2GeoListener.java
+++ b/src/main/java/org/opensearch/geospatial/ip2geo/listener/Ip2GeoListener.java
@@ -13,9 +13,6 @@ import java.time.temporal.ChronoUnit;
 import java.util.List;
 import java.util.stream.Collectors;
 
-import lombok.AllArgsConstructor;
-import lombok.extern.log4j.Log4j2;
-
 import org.opensearch.action.bulk.BulkResponse;
 import org.opensearch.cluster.ClusterChangedEvent;
 import org.opensearch.cluster.ClusterStateListener;
@@ -32,6 +29,9 @@ import org.opensearch.geospatial.ip2geo.jobscheduler.DatasourceExtension;
 import org.opensearch.geospatial.ip2geo.jobscheduler.DatasourceTask;
 import org.opensearch.jobscheduler.spi.schedule.IntervalSchedule;
 import org.opensearch.threadpool.ThreadPool;
+
+import lombok.AllArgsConstructor;
+import lombok.extern.log4j.Log4j2;
 
 @Log4j2
 @AllArgsConstructor(onConstructor = @__(@Inject))

--- a/src/main/java/org/opensearch/geospatial/ip2geo/processor/Ip2GeoProcessor.java
+++ b/src/main/java/org/opensearch/geospatial/ip2geo/processor/Ip2GeoProcessor.java
@@ -18,9 +18,6 @@ import java.util.Set;
 import java.util.function.BiConsumer;
 import java.util.stream.Collectors;
 
-import lombok.Getter;
-import lombok.extern.log4j.Log4j2;
-
 import org.opensearch.common.settings.ClusterSettings;
 import org.opensearch.geospatial.ip2geo.common.DatasourceState;
 import org.opensearch.geospatial.ip2geo.common.ParameterValidator;
@@ -31,6 +28,9 @@ import org.opensearch.ingest.AbstractProcessor;
 import org.opensearch.ingest.IngestDocument;
 import org.opensearch.ingest.IngestService;
 import org.opensearch.ingest.Processor;
+
+import lombok.Getter;
+import lombok.extern.log4j.Log4j2;
 
 /**
  * Ip2Geo processor

--- a/src/main/java/org/opensearch/geospatial/plugin/GeospatialPlugin.java
+++ b/src/main/java/org/opensearch/geospatial/plugin/GeospatialPlugin.java
@@ -13,8 +13,6 @@ import java.util.List;
 import java.util.Map;
 import java.util.function.Supplier;
 
-import lombok.extern.log4j.Log4j2;
-
 import org.opensearch.action.ActionRequest;
 import org.opensearch.client.Client;
 import org.opensearch.cluster.metadata.IndexNameExpressionResolver;
@@ -88,6 +86,8 @@ import org.opensearch.script.ScriptService;
 import org.opensearch.threadpool.ExecutorBuilder;
 import org.opensearch.threadpool.ThreadPool;
 import org.opensearch.watcher.ResourceWatcherService;
+
+import lombok.extern.log4j.Log4j2;
 
 /**
  * Entry point for Geospatial features. It provides additional Processors, Actions

--- a/src/main/java/org/opensearch/geospatial/search/aggregations/bucket/geogrid/GeoHexHelper.java
+++ b/src/main/java/org/opensearch/geospatial/search/aggregations/bucket/geogrid/GeoHexHelper.java
@@ -14,9 +14,9 @@ import static org.opensearch.geospatial.h3.H3.stringToH3;
 
 import java.util.Locale;
 
-import lombok.NonNull;
-
 import org.opensearch.common.geo.GeoPoint;
+
+import lombok.NonNull;
 
 /**
  * Helper class for H3 library

--- a/src/main/java/org/opensearch/geospatial/search/aggregations/bucket/geogrid/ParsedGeoHexGrid.java
+++ b/src/main/java/org/opensearch/geospatial/search/aggregations/bucket/geogrid/ParsedGeoHexGrid.java
@@ -7,11 +7,11 @@ package org.opensearch.geospatial.search.aggregations.bucket.geogrid;
 
 import java.io.IOException;
 
-import lombok.NoArgsConstructor;
-
 import org.opensearch.core.xcontent.ObjectParser;
 import org.opensearch.core.xcontent.XContentParser;
 import org.opensearch.geo.search.aggregations.bucket.geogrid.ParsedGeoGrid;
+
+import lombok.NoArgsConstructor;
 
 @NoArgsConstructor
 public class ParsedGeoHexGrid extends ParsedGeoGrid {

--- a/src/main/java/org/opensearch/geospatial/search/aggregations/bucket/geogrid/ParsedGeoHexGridBucket.java
+++ b/src/main/java/org/opensearch/geospatial/search/aggregations/bucket/geogrid/ParsedGeoHexGridBucket.java
@@ -7,11 +7,11 @@ package org.opensearch.geospatial.search.aggregations.bucket.geogrid;
 
 import java.io.IOException;
 
-import lombok.NoArgsConstructor;
-
 import org.opensearch.common.geo.GeoPoint;
 import org.opensearch.core.xcontent.XContentParser;
 import org.opensearch.geo.search.aggregations.bucket.geogrid.ParsedGeoGridBucket;
+
+import lombok.NoArgsConstructor;
 
 @NoArgsConstructor
 public class ParsedGeoHexGridBucket extends ParsedGeoGridBucket {

--- a/src/main/java/org/opensearch/geospatial/stats/upload/UploadMetric.java
+++ b/src/main/java/org/opensearch/geospatial/stats/upload/UploadMetric.java
@@ -9,14 +9,14 @@ import java.io.IOException;
 import java.util.Locale;
 import java.util.Objects;
 
-import lombok.Getter;
-
 import org.opensearch.core.common.Strings;
 import org.opensearch.core.common.io.stream.StreamInput;
 import org.opensearch.core.common.io.stream.StreamOutput;
 import org.opensearch.core.common.io.stream.Writeable;
 import org.opensearch.core.xcontent.ToXContentFragment;
 import org.opensearch.core.xcontent.XContentBuilder;
+
+import lombok.Getter;
 
 /**
  * UploadMetric stores metric for an upload API

--- a/src/test/java/org/opensearch/geospatial/exceptions/ConcurrentModificationExceptionTests.java
+++ b/src/test/java/org/opensearch/geospatial/exceptions/ConcurrentModificationExceptionTests.java
@@ -5,12 +5,12 @@
 
 package org.opensearch.geospatial.exceptions;
 
-import lombok.SneakyThrows;
-
 import org.opensearch.common.io.stream.BytesStreamOutput;
 import org.opensearch.core.common.io.stream.BytesStreamInput;
 import org.opensearch.core.rest.RestStatus;
 import org.opensearch.test.OpenSearchTestCase;
+
+import lombok.SneakyThrows;
 
 public class ConcurrentModificationExceptionTests extends OpenSearchTestCase {
     public void testConstructor_whenCreated_thenSucceed() {

--- a/src/test/java/org/opensearch/geospatial/exceptions/IncompatibleDatasourceExceptionTests.java
+++ b/src/test/java/org/opensearch/geospatial/exceptions/IncompatibleDatasourceExceptionTests.java
@@ -5,12 +5,12 @@
 
 package org.opensearch.geospatial.exceptions;
 
-import lombok.SneakyThrows;
-
 import org.opensearch.common.io.stream.BytesStreamOutput;
 import org.opensearch.core.common.io.stream.BytesStreamInput;
 import org.opensearch.core.rest.RestStatus;
 import org.opensearch.test.OpenSearchTestCase;
+
+import lombok.SneakyThrows;
 
 public class IncompatibleDatasourceExceptionTests extends OpenSearchTestCase {
     public void testConstructor_whenCreated_thenSucceed() {

--- a/src/test/java/org/opensearch/geospatial/exceptions/ResourceInUseExceptionTests.java
+++ b/src/test/java/org/opensearch/geospatial/exceptions/ResourceInUseExceptionTests.java
@@ -5,12 +5,12 @@
 
 package org.opensearch.geospatial.exceptions;
 
-import lombok.SneakyThrows;
-
 import org.opensearch.common.io.stream.BytesStreamOutput;
 import org.opensearch.core.common.io.stream.BytesStreamInput;
 import org.opensearch.core.rest.RestStatus;
 import org.opensearch.test.OpenSearchTestCase;
+
+import lombok.SneakyThrows;
 
 public class ResourceInUseExceptionTests extends OpenSearchTestCase {
     public void testConstructor_whenCreated_thenSucceed() {

--- a/src/test/java/org/opensearch/geospatial/index/common/xyshape/ShapeObjectBuilder.java
+++ b/src/test/java/org/opensearch/geospatial/index/common/xyshape/ShapeObjectBuilder.java
@@ -16,8 +16,6 @@ import java.util.List;
 import java.util.stream.Collectors;
 import java.util.stream.IntStream;
 
-import lombok.SneakyThrows;
-
 import org.apache.lucene.geo.Tessellator;
 import org.apache.lucene.geo.XYPoint;
 import org.apache.lucene.geo.XYPolygon;
@@ -41,6 +39,8 @@ import org.opensearch.geospatial.ShapeTestUtil;
 import org.opensearch.test.OpenSearchTestCase;
 
 import com.carrotsearch.randomizedtesting.generators.RandomPicks;
+
+import lombok.SneakyThrows;
 
 // Class to build various Geometry shapes for unit tests.
 public class ShapeObjectBuilder {

--- a/src/test/java/org/opensearch/geospatial/ip2geo/Ip2GeoDataServer.java
+++ b/src/test/java/org/opensearch/geospatial/ip2geo/Ip2GeoDataServer.java
@@ -11,14 +11,14 @@ import java.net.InetSocketAddress;
 import java.nio.file.Files;
 import java.nio.file.Paths;
 
-import lombok.SneakyThrows;
-import lombok.extern.log4j.Log4j2;
-
 import org.opensearch.common.SuppressForbidden;
 
 import com.sun.net.httpserver.HttpExchange;
 import com.sun.net.httpserver.HttpHandler;
 import com.sun.net.httpserver.HttpServer;
+
+import lombok.SneakyThrows;
+import lombok.extern.log4j.Log4j2;
 
 /**
  * Simple http server to serve static files under test/java/resources/ip2geo/server for integration testing

--- a/src/test/java/org/opensearch/geospatial/ip2geo/Ip2GeoTestCase.java
+++ b/src/test/java/org/opensearch/geospatial/ip2geo/Ip2GeoTestCase.java
@@ -24,8 +24,6 @@ import java.util.concurrent.atomic.AtomicReference;
 import java.util.function.BiFunction;
 import java.util.stream.Collectors;
 
-import lombok.SneakyThrows;
-
 import org.junit.After;
 import org.junit.Before;
 import org.mockito.Mock;
@@ -69,6 +67,8 @@ import org.opensearch.test.client.NoOpNodeClient;
 import org.opensearch.test.rest.RestActionTestCase;
 import org.opensearch.threadpool.ThreadPool;
 import org.opensearch.transport.TransportService;
+
+import lombok.SneakyThrows;
 
 public abstract class Ip2GeoTestCase extends RestActionTestCase {
     @Mock

--- a/src/test/java/org/opensearch/geospatial/ip2geo/action/DeleteDatasourceRequestTests.java
+++ b/src/test/java/org/opensearch/geospatial/ip2geo/action/DeleteDatasourceRequestTests.java
@@ -5,13 +5,13 @@
 
 package org.opensearch.geospatial.ip2geo.action;
 
-import lombok.SneakyThrows;
-
 import org.opensearch.action.ActionRequestValidationException;
 import org.opensearch.common.io.stream.BytesStreamOutput;
 import org.opensearch.core.common.io.stream.BytesStreamInput;
 import org.opensearch.geospatial.GeospatialTestHelper;
 import org.opensearch.geospatial.ip2geo.Ip2GeoTestCase;
+
+import lombok.SneakyThrows;
 
 public class DeleteDatasourceRequestTests extends Ip2GeoTestCase {
     @SneakyThrows

--- a/src/test/java/org/opensearch/geospatial/ip2geo/action/DeleteDatasourceTransportActionTests.java
+++ b/src/test/java/org/opensearch/geospatial/ip2geo/action/DeleteDatasourceTransportActionTests.java
@@ -20,8 +20,6 @@ import java.time.Instant;
 import java.util.Arrays;
 import java.util.Collections;
 
-import lombok.SneakyThrows;
-
 import org.junit.Before;
 import org.mockito.ArgumentCaptor;
 import org.mockito.InOrder;
@@ -36,6 +34,8 @@ import org.opensearch.geospatial.ip2geo.common.DatasourceState;
 import org.opensearch.geospatial.ip2geo.jobscheduler.Datasource;
 import org.opensearch.jobscheduler.spi.LockModel;
 import org.opensearch.tasks.Task;
+
+import lombok.SneakyThrows;
 
 public class DeleteDatasourceTransportActionTests extends Ip2GeoTestCase {
     private DeleteDatasourceTransportAction action;

--- a/src/test/java/org/opensearch/geospatial/ip2geo/action/PutDatasourceTransportActionTests.java
+++ b/src/test/java/org/opensearch/geospatial/ip2geo/action/PutDatasourceTransportActionTests.java
@@ -15,8 +15,6 @@ import static org.mockito.Mockito.verify;
 
 import java.io.IOException;
 
-import lombok.SneakyThrows;
-
 import org.junit.Before;
 import org.mockito.ArgumentCaptor;
 import org.opensearch.ResourceAlreadyExistsException;
@@ -32,6 +30,8 @@ import org.opensearch.geospatial.ip2geo.jobscheduler.Datasource;
 import org.opensearch.index.engine.VersionConflictEngineException;
 import org.opensearch.jobscheduler.spi.LockModel;
 import org.opensearch.tasks.Task;
+
+import lombok.SneakyThrows;
 
 public class PutDatasourceTransportActionTests extends Ip2GeoTestCase {
     private PutDatasourceTransportAction action;

--- a/src/test/java/org/opensearch/geospatial/ip2geo/action/RestPutDatasourceHandlerTests.java
+++ b/src/test/java/org/opensearch/geospatial/ip2geo/action/RestPutDatasourceHandlerTests.java
@@ -14,8 +14,6 @@ import java.util.HashSet;
 import java.util.Locale;
 import java.util.concurrent.atomic.AtomicBoolean;
 
-import lombok.SneakyThrows;
-
 import org.junit.Before;
 import org.opensearch.common.SuppressForbidden;
 import org.opensearch.common.settings.ClusterSettings;
@@ -29,6 +27,8 @@ import org.opensearch.geospatial.ip2geo.common.URLDenyListChecker;
 import org.opensearch.rest.RestRequest;
 import org.opensearch.test.rest.FakeRestRequest;
 import org.opensearch.test.rest.RestActionTestCase;
+
+import lombok.SneakyThrows;
 
 @SuppressForbidden(reason = "unit test")
 public class RestPutDatasourceHandlerTests extends RestActionTestCase {

--- a/src/test/java/org/opensearch/geospatial/ip2geo/action/RestUpdateDatasourceHandlerTests.java
+++ b/src/test/java/org/opensearch/geospatial/ip2geo/action/RestUpdateDatasourceHandlerTests.java
@@ -15,8 +15,6 @@ import static org.opensearch.geospatial.shared.URLBuilder.getPluginURLPrefix;
 import java.util.Locale;
 import java.util.concurrent.atomic.AtomicBoolean;
 
-import lombok.SneakyThrows;
-
 import org.junit.Before;
 import org.opensearch.common.unit.TimeValue;
 import org.opensearch.common.xcontent.XContentType;
@@ -26,6 +24,8 @@ import org.opensearch.geospatial.ip2geo.common.URLDenyListChecker;
 import org.opensearch.rest.RestRequest;
 import org.opensearch.test.rest.FakeRestRequest;
 import org.opensearch.test.rest.RestActionTestCase;
+
+import lombok.SneakyThrows;
 
 public class RestUpdateDatasourceHandlerTests extends RestActionTestCase {
     private String path;

--- a/src/test/java/org/opensearch/geospatial/ip2geo/action/UpdateDatasourceIT.java
+++ b/src/test/java/org/opensearch/geospatial/ip2geo/action/UpdateDatasourceIT.java
@@ -12,8 +12,6 @@ import java.util.List;
 import java.util.Locale;
 import java.util.Map;
 
-import lombok.SneakyThrows;
-
 import org.junit.AfterClass;
 import org.junit.BeforeClass;
 import org.opensearch.client.ResponseException;
@@ -23,6 +21,8 @@ import org.opensearch.geospatial.GeospatialRestTestCase;
 import org.opensearch.geospatial.GeospatialTestHelper;
 import org.opensearch.geospatial.ip2geo.Ip2GeoDataServer;
 import org.opensearch.geospatial.ip2geo.common.Ip2GeoSettings;
+
+import lombok.SneakyThrows;
 
 public class UpdateDatasourceIT extends GeospatialRestTestCase {
     // Use this value in resource name to avoid name conflict among tests

--- a/src/test/java/org/opensearch/geospatial/ip2geo/action/UpdateDatasourceRequestTests.java
+++ b/src/test/java/org/opensearch/geospatial/ip2geo/action/UpdateDatasourceRequestTests.java
@@ -7,8 +7,6 @@ package org.opensearch.geospatial.ip2geo.action;
 
 import java.util.Locale;
 
-import lombok.SneakyThrows;
-
 import org.opensearch.action.ActionRequestValidationException;
 import org.opensearch.common.Randomness;
 import org.opensearch.common.io.stream.BytesStreamOutput;
@@ -16,6 +14,8 @@ import org.opensearch.common.unit.TimeValue;
 import org.opensearch.core.common.io.stream.BytesStreamInput;
 import org.opensearch.geospatial.GeospatialTestHelper;
 import org.opensearch.geospatial.ip2geo.Ip2GeoTestCase;
+
+import lombok.SneakyThrows;
 
 public class UpdateDatasourceRequestTests extends Ip2GeoTestCase {
 

--- a/src/test/java/org/opensearch/geospatial/ip2geo/action/UpdateDatasourceTransportActionTests.java
+++ b/src/test/java/org/opensearch/geospatial/ip2geo/action/UpdateDatasourceTransportActionTests.java
@@ -19,8 +19,6 @@ import java.time.Instant;
 import java.time.temporal.ChronoUnit;
 import java.util.List;
 
-import lombok.SneakyThrows;
-
 import org.junit.Before;
 import org.mockito.ArgumentCaptor;
 import org.opensearch.OpenSearchException;
@@ -35,6 +33,8 @@ import org.opensearch.geospatial.ip2geo.jobscheduler.Datasource;
 import org.opensearch.geospatial.ip2geo.jobscheduler.DatasourceTask;
 import org.opensearch.jobscheduler.spi.LockModel;
 import org.opensearch.tasks.Task;
+
+import lombok.SneakyThrows;
 
 public class UpdateDatasourceTransportActionTests extends Ip2GeoTestCase {
     private UpdateDatasourceTransportAction action;

--- a/src/test/java/org/opensearch/geospatial/ip2geo/common/DatasourceManifestTests.java
+++ b/src/test/java/org/opensearch/geospatial/ip2geo/common/DatasourceManifestTests.java
@@ -13,11 +13,11 @@ import java.io.File;
 import java.io.FileInputStream;
 import java.net.URLConnection;
 
-import lombok.SneakyThrows;
-
 import org.opensearch.common.SuppressForbidden;
 import org.opensearch.geospatial.ip2geo.Ip2GeoTestCase;
 import org.opensearch.geospatial.shared.Constants;
+
+import lombok.SneakyThrows;
 
 @SuppressForbidden(reason = "unit test")
 public class DatasourceManifestTests extends Ip2GeoTestCase {

--- a/src/test/java/org/opensearch/geospatial/ip2geo/common/URLDenyListCheckerTests.java
+++ b/src/test/java/org/opensearch/geospatial/ip2geo/common/URLDenyListCheckerTests.java
@@ -9,14 +9,14 @@ import java.util.Arrays;
 import java.util.Locale;
 import java.util.Map;
 
-import lombok.SneakyThrows;
-
 import org.junit.Before;
 import org.opensearch.cluster.service.ClusterService;
 import org.opensearch.common.Randomness;
 import org.opensearch.geospatial.ClusterSettingHelper;
 import org.opensearch.node.Node;
 import org.opensearch.test.OpenSearchTestCase;
+
+import lombok.SneakyThrows;
 
 public class URLDenyListCheckerTests extends OpenSearchTestCase {
     private ClusterSettingHelper clusterSettingHelper;

--- a/src/test/java/org/opensearch/geospatial/ip2geo/dao/DatasourceDaoTests.java
+++ b/src/test/java/org/opensearch/geospatial/ip2geo/dao/DatasourceDaoTests.java
@@ -16,8 +16,6 @@ import java.time.temporal.ChronoUnit;
 import java.util.Arrays;
 import java.util.List;
 
-import lombok.SneakyThrows;
-
 import org.apache.lucene.search.TotalHits;
 import org.junit.Before;
 import org.mockito.ArgumentCaptor;
@@ -53,6 +51,8 @@ import org.opensearch.index.query.QueryBuilders;
 import org.opensearch.jobscheduler.spi.schedule.IntervalSchedule;
 import org.opensearch.search.SearchHit;
 import org.opensearch.search.SearchHits;
+
+import lombok.SneakyThrows;
 
 public class DatasourceDaoTests extends Ip2GeoTestCase {
     private DatasourceDao datasourceDao;

--- a/src/test/java/org/opensearch/geospatial/ip2geo/dao/GeoIpDataDaoTests.java
+++ b/src/test/java/org/opensearch/geospatial/ip2geo/dao/GeoIpDataDaoTests.java
@@ -23,8 +23,6 @@ import java.util.Iterator;
 import java.util.Locale;
 import java.util.Map;
 
-import lombok.SneakyThrows;
-
 import org.apache.commons.csv.CSVFormat;
 import org.apache.commons.csv.CSVParser;
 import org.apache.commons.csv.CSVRecord;
@@ -51,6 +49,8 @@ import org.opensearch.geospatial.shared.Constants;
 import org.opensearch.index.query.QueryBuilders;
 import org.opensearch.search.SearchHit;
 import org.opensearch.search.SearchHits;
+
+import lombok.SneakyThrows;
 
 @SuppressForbidden(reason = "unit test")
 public class GeoIpDataDaoTests extends Ip2GeoTestCase {

--- a/src/test/java/org/opensearch/geospatial/ip2geo/dao/Ip2GeoCachedDaoTests.java
+++ b/src/test/java/org/opensearch/geospatial/ip2geo/dao/Ip2GeoCachedDaoTests.java
@@ -15,8 +15,6 @@ import java.util.Collections;
 import java.util.List;
 import java.util.Map;
 
-import lombok.SneakyThrows;
-
 import org.junit.Before;
 import org.opensearch.common.network.NetworkAddress;
 import org.opensearch.common.xcontent.XContentFactory;
@@ -28,6 +26,8 @@ import org.opensearch.geospatial.ip2geo.common.DatasourceState;
 import org.opensearch.geospatial.ip2geo.jobscheduler.Datasource;
 import org.opensearch.index.IndexNotFoundException;
 import org.opensearch.index.engine.Engine;
+
+import lombok.SneakyThrows;
 
 public class Ip2GeoCachedDaoTests extends Ip2GeoTestCase {
     private Ip2GeoCachedDao ip2GeoCachedDao;

--- a/src/test/java/org/opensearch/geospatial/ip2geo/jobscheduler/DatasourceRunnerTests.java
+++ b/src/test/java/org/opensearch/geospatial/ip2geo/jobscheduler/DatasourceRunnerTests.java
@@ -20,8 +20,6 @@ import java.time.Instant;
 import java.time.temporal.ChronoUnit;
 import java.util.Optional;
 
-import lombok.SneakyThrows;
-
 import org.junit.Before;
 import org.mockito.ArgumentCaptor;
 import org.opensearch.geospatial.GeospatialTestHelper;
@@ -33,6 +31,8 @@ import org.opensearch.jobscheduler.spi.JobExecutionContext;
 import org.opensearch.jobscheduler.spi.LockModel;
 import org.opensearch.jobscheduler.spi.ScheduledJobParameter;
 import org.opensearch.jobscheduler.spi.schedule.IntervalSchedule;
+
+import lombok.SneakyThrows;
 
 public class DatasourceRunnerTests extends Ip2GeoTestCase {
     @Before

--- a/src/test/java/org/opensearch/geospatial/ip2geo/jobscheduler/DatasourceTests.java
+++ b/src/test/java/org/opensearch/geospatial/ip2geo/jobscheduler/DatasourceTests.java
@@ -13,12 +13,12 @@ import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Locale;
 
-import lombok.SneakyThrows;
-
 import org.opensearch.common.xcontent.XContentFactory;
 import org.opensearch.geospatial.GeospatialTestHelper;
 import org.opensearch.geospatial.ip2geo.Ip2GeoTestCase;
 import org.opensearch.jobscheduler.spi.schedule.IntervalSchedule;
+
+import lombok.SneakyThrows;
 
 public class DatasourceTests extends Ip2GeoTestCase {
 

--- a/src/test/java/org/opensearch/geospatial/ip2geo/jobscheduler/DatasourceUpdateServiceTests.java
+++ b/src/test/java/org/opensearch/geospatial/ip2geo/jobscheduler/DatasourceUpdateServiceTests.java
@@ -23,8 +23,6 @@ import java.util.Arrays;
 import java.util.Iterator;
 import java.util.List;
 
-import lombok.SneakyThrows;
-
 import org.apache.commons.csv.CSVFormat;
 import org.apache.commons.csv.CSVParser;
 import org.junit.Before;
@@ -36,6 +34,8 @@ import org.opensearch.geospatial.ip2geo.Ip2GeoTestCase;
 import org.opensearch.geospatial.ip2geo.common.DatasourceManifest;
 import org.opensearch.geospatial.ip2geo.common.DatasourceState;
 import org.opensearch.jobscheduler.spi.schedule.IntervalSchedule;
+
+import lombok.SneakyThrows;
 
 @SuppressForbidden(reason = "unit test")
 public class DatasourceUpdateServiceTests extends Ip2GeoTestCase {

--- a/src/test/java/org/opensearch/geospatial/ip2geo/processor/Ip2GeoProcessorIT.java
+++ b/src/test/java/org/opensearch/geospatial/ip2geo/processor/Ip2GeoProcessorIT.java
@@ -16,8 +16,6 @@ import java.util.Map;
 import java.util.Optional;
 import java.util.stream.Collectors;
 
-import lombok.SneakyThrows;
-
 import org.junit.AfterClass;
 import org.junit.BeforeClass;
 import org.opensearch.client.Response;
@@ -29,6 +27,8 @@ import org.opensearch.geospatial.GeospatialTestHelper;
 import org.opensearch.geospatial.ip2geo.Ip2GeoDataServer;
 import org.opensearch.geospatial.ip2geo.action.PutDatasourceRequest;
 import org.opensearch.geospatial.ip2geo.common.Ip2GeoSettings;
+
+import lombok.SneakyThrows;
 
 public class Ip2GeoProcessorIT extends GeospatialRestTestCase {
     // Use this value in resource name to avoid name conflict among tests

--- a/src/test/java/org/opensearch/geospatial/ip2geo/processor/Ip2GeoProcessorTests.java
+++ b/src/test/java/org/opensearch/geospatial/ip2geo/processor/Ip2GeoProcessorTests.java
@@ -20,8 +20,6 @@ import java.util.List;
 import java.util.Map;
 import java.util.function.BiConsumer;
 
-import lombok.SneakyThrows;
-
 import org.junit.Before;
 import org.mockito.ArgumentCaptor;
 import org.opensearch.OpenSearchException;
@@ -32,6 +30,8 @@ import org.opensearch.geospatial.ip2geo.common.DatasourceState;
 import org.opensearch.geospatial.ip2geo.common.ParameterValidator;
 import org.opensearch.geospatial.ip2geo.jobscheduler.Datasource;
 import org.opensearch.ingest.IngestDocument;
+
+import lombok.SneakyThrows;
 
 public class Ip2GeoProcessorTests extends Ip2GeoTestCase {
     private static final String DEFAULT_TARGET_FIELD = "ip2geo";

--- a/src/test/java/org/opensearch/geospatial/search/aggregations/bucket/geogrid/GeoHexGridAggregatorTests.java
+++ b/src/test/java/org/opensearch/geospatial/search/aggregations/bucket/geogrid/GeoHexGridAggregatorTests.java
@@ -64,27 +64,17 @@ public class GeoHexGridAggregatorTests extends AggregatorTestCase {
     private static final double TOLERANCE = 1E-5D;
 
     public void testNoDocs() throws IOException {
-        testCase(
-            new MatchAllDocsQuery(),
-            GEO_POINT_FIELD_NAME,
-            randomPrecision(),
-            null,
-            geoGrid -> { assertEquals(0, geoGrid.getBuckets().size()); },
-            iw -> {
-                // Intentionally not writing any docs
-            }
-        );
+        testCase(new MatchAllDocsQuery(), GEO_POINT_FIELD_NAME, randomPrecision(), null, geoGrid -> {
+            assertEquals(0, geoGrid.getBuckets().size());
+        }, iw -> {
+            // Intentionally not writing any docs
+        });
     }
 
     public void testUnmapped() throws IOException {
-        testCase(
-            new MatchAllDocsQuery(),
-            randomLowerCaseString(),
-            randomPrecision(),
-            null,
-            geoGrid -> { assertEquals(0, geoGrid.getBuckets().size()); },
-            iw -> { iw.addDocument(Collections.singleton(new LatLonDocValuesField(GEO_POINT_FIELD_NAME, 10D, 10D))); }
-        );
+        testCase(new MatchAllDocsQuery(), randomLowerCaseString(), randomPrecision(), null, geoGrid -> {
+            assertEquals(0, geoGrid.getBuckets().size());
+        }, iw -> { iw.addDocument(Collections.singleton(new LatLonDocValuesField(GEO_POINT_FIELD_NAME, 10D, 10D))); });
     }
 
     public void testUnmappedMissing() throws IOException {


### PR DESCRIPTION
### Description
This updates the CI system to use jdk-21, which is latest LTS supported version.
Coming from https://github.com/opensearch-project/OpenSearch/issues/10334 
 
### Check List
- [X] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
