### PR TITLE
Fix typo in License.TXT

### DIFF
--- a/libs/h3/LICENSE.txt
+++ b/libs/h3/LICENSE.txt
@@ -46,7 +46,7 @@
       separable from, or merely link (or bind by name) to the interfaces of,
       the Work and Derivative Works thereof.
 
-      "Contribution" shall mean any workg of authorship, including
+      "Contribution" shall mean any work of authorship, including
       the original version of the Work and any modifications or additions
       to that Work or Derivative Works thereof, that is intentionally
       submitted to Licensor for inclusion in the Work by the copyright owner


### PR DESCRIPTION
### Description
Fixing typo in LICENSE.TXT [https://github.com/opensearch-project/geospatial/pull/638/files](https://github.com/opensearch-project/geospatial/pull/638/files)

 
### Check List
- [ ] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
