### PR TITLE
[Backport 2.x] Fix typo in License.TXT (#639)

### DIFF
--- a/libs/h3/LICENSE.txt
+++ b/libs/h3/LICENSE.txt
@@ -46,7 +46,7 @@
       separable from, or merely link (or bind by name) to the interfaces of,
       the Work and Derivative Works thereof.
 
-      "Contribution" shall mean any workg of authorship, including
+      "Contribution" shall mean any work of authorship, including
       the original version of the Work and any modifications or additions
       to that Work or Derivative Works thereof, that is intentionally
       submitted to Licensor for inclusion in the Work by the copyright owner


### PR DESCRIPTION
### Description
Backport https://github.com/opensearch-project/geospatial/commit/6d9a6af5ae1308a0558669dcd3ff76e356b62743 from https://github.com/opensearch-project/geospatial/pull/639