### PR TITLE
Replace Strings util package with OpenSearch core Strings package

### DIFF
--- a/src/main/java/org/opensearch/geospatial/ip2geo/dao/GeoIpDataDao.java
+++ b/src/main/java/org/opensearch/geospatial/ip2geo/dao/GeoIpDataDao.java
@@ -32,7 +32,6 @@ import java.util.zip.ZipInputStream;
 import org.apache.commons.csv.CSVFormat;
 import org.apache.commons.csv.CSVParser;
 import org.apache.commons.csv.CSVRecord;
-import org.apache.logging.log4j.util.Strings;
 import org.opensearch.OpenSearchException;
 import org.opensearch.SpecialPermission;
 import org.opensearch.action.DocWriteRequest;
@@ -53,6 +52,7 @@ import org.opensearch.common.unit.TimeValue;
 import org.opensearch.common.xcontent.XContentFactory;
 import org.opensearch.common.xcontent.XContentHelper;
 import org.opensearch.common.xcontent.XContentType;
+import org.opensearch.core.common.Strings;
 import org.opensearch.core.xcontent.XContentBuilder;
 import org.opensearch.geospatial.annotation.VisibleForTesting;
 import org.opensearch.geospatial.constants.IndexSetting;
@@ -230,7 +230,7 @@ public class GeoIpDataDao {
         builder.field(IP_RANGE_FIELD_NAME, values[0]);
         builder.startObject(DATA_FIELD_NAME);
         for (int i = 1; i < fields.length; i++) {
-            if (Strings.isBlank(values[i])) {
+            if (!Strings.hasText(values[i])) {
                 continue;
             }
             builder.field(fields[i], values[i]);


### PR DESCRIPTION
### Description
Replace `org.apache.logging.log4j.util.Strings` with `org.opensearch.core.common.Strings` to fix failing CI.
https://github.com/opensearch-project/geospatial/actions/runs/10207619595/job/28962936440?pr=671
```
> Task :forbiddenApisResources
Forbidden class/interface use: org.apache.logging.log4j.util.Strings [use org.opensearch.core.common.Strings instead.]

  in org.opensearch.geospatial.ip2geo.dao.GeoIpDataDao (GeoIpDataDao.java:233)
> Task :forbiddenApisMain FAILED
Scanned 126 class file(s) for forbidden API invocations (in 0.29s), 1 error(s).


> Task :generateTestEffectiveLombokConfig
FAILURE: Build failed with an exception.


Deprecated Gradle features were used in this build, making it incompatible with Gradle 9.0.
* What went wrong:

Execution failed for task ':forbiddenApisMain'.
```

### Check List
- [ ] New functionality includes testing.
- [ ] New functionality has been documented.
- [ ] API changes companion pull request [created](https://github.com/opensearch-project/opensearch-api-specification/blob/main/DEVELOPER_GUIDE.md).
- [x] Commits are signed per the DCO using `--signoff`.
- [ ] Public documentation issue/PR [created](https://github.com/opensearch-project/documentation-website/issues/new/choose).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/geospatial/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
