### PR TITLE
Use instance of LockService instantiated in JobScheduler through Guice

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,3 +26,4 @@ See the [CONTRIBUTING guide](./CONTRIBUTING.md#Changelog) for instructions on ho
 ### Documentation
 ### Maintenance
 ### Refactoring
+- Use instance of LockService instantiated in JobScheduler through Guice ([#677](https://github.com/opensearch-project/geospatial/pull/677))

--- a/src/main/java/org/opensearch/geospatial/ip2geo/common/Ip2GeoLockService.java
+++ b/src/main/java/org/opensearch/geospatial/ip2geo/common/Ip2GeoLockService.java
@@ -67,6 +67,9 @@ public class Ip2GeoLockService {
      * @param listener the listener
      */
     public void acquireLock(final String datasourceName, final Long lockDurationSeconds, final ActionListener<LockModel> listener) {
+        if (lockService == null) {
+            throw new OpenSearchException("Ip2GeoLockService is not initialized");
+        }
         lockService.acquireLockWithId(JOB_INDEX_NAME, lockDurationSeconds, datasourceName, listener);
     }
 
@@ -78,6 +81,9 @@ public class Ip2GeoLockService {
      * @return lock model
      */
     public Optional<LockModel> acquireLock(final String datasourceName, final Long lockDurationSeconds) {
+        if (lockService == null) {
+            throw new OpenSearchException("Ip2GeoLockService is not initialized");
+        }
         AtomicReference<LockModel> lockReference = new AtomicReference();
         CountDownLatch countDownLatch = new CountDownLatch(1);
         lockService.acquireLockWithId(JOB_INDEX_NAME, lockDurationSeconds, datasourceName, new ActionListener<>() {
@@ -108,6 +114,9 @@ public class Ip2GeoLockService {
      * @param lockModel the lock model
      */
     public void releaseLock(final LockModel lockModel) {
+        if (lockService == null) {
+            throw new OpenSearchException("Ip2GeoLockService is not initialized");
+        }
         lockService.release(
             lockModel,
             ActionListener.wrap(released -> {}, exception -> log.error("Failed to release the lock", exception))
@@ -121,6 +130,9 @@ public class Ip2GeoLockService {
      * @return renewed lock if renew succeed and null otherwise
      */
     public LockModel renewLock(final LockModel lockModel) {
+        if (lockService == null) {
+            throw new OpenSearchException("Ip2GeoLockService is not initialized");
+        }
         AtomicReference<LockModel> lockReference = new AtomicReference();
         CountDownLatch countDownLatch = new CountDownLatch(1);
         lockService.renewLock(lockModel, new ActionListener<>() {

--- a/src/main/java/org/opensearch/geospatial/ip2geo/common/Ip2GeoLockService.java
+++ b/src/main/java/org/opensearch/geospatial/ip2geo/common/Ip2GeoLockService.java
@@ -14,7 +14,6 @@ import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicReference;
 
 import org.opensearch.OpenSearchException;
-import org.opensearch.client.Client;
 import org.opensearch.cluster.service.ClusterService;
 import org.opensearch.core.action.ActionListener;
 import org.opensearch.jobscheduler.spi.LockModel;
@@ -31,17 +30,6 @@ public class Ip2GeoLockService {
     public static final long RENEW_AFTER_IN_SECONDS = 120l;
     private final ClusterService clusterService;
     private LockService lockService;
-
-    /**
-     * Constructor
-     *
-     * @param clusterService the cluster service
-     * @param client the client
-     */
-    public Ip2GeoLockService(final ClusterService clusterService, final Client client) {
-        this.clusterService = clusterService;
-        this.lockService = new LockService(client, clusterService);
-    }
 
     /**
      * Constructor

--- a/src/main/java/org/opensearch/geospatial/ip2geo/common/Ip2GeoLockService.java
+++ b/src/main/java/org/opensearch/geospatial/ip2geo/common/Ip2GeoLockService.java
@@ -30,7 +30,7 @@ public class Ip2GeoLockService {
     public static final long LOCK_DURATION_IN_SECONDS = 300l;
     public static final long RENEW_AFTER_IN_SECONDS = 120l;
     private final ClusterService clusterService;
-    private final LockService lockService;
+    private LockService lockService;
 
     /**
      * Constructor
@@ -41,6 +41,19 @@ public class Ip2GeoLockService {
     public Ip2GeoLockService(final ClusterService clusterService, final Client client) {
         this.clusterService = clusterService;
         this.lockService = new LockService(client, clusterService);
+    }
+
+    /**
+     * Constructor
+     *
+     * @param clusterService the cluster service
+     */
+    public Ip2GeoLockService(final ClusterService clusterService) {
+        this.clusterService = clusterService;
+    }
+
+    public void initialize(final LockService lockService) {
+        this.lockService = lockService;
     }
 
     /**

--- a/src/main/java/org/opensearch/geospatial/plugin/GeospatialPlugin.java
+++ b/src/main/java/org/opensearch/geospatial/plugin/GeospatialPlugin.java
@@ -144,9 +144,9 @@ public class GeospatialPlugin extends Plugin
 
     @Override
     public Collection<Class<? extends LifecycleComponent>> getGuiceServiceClasses() {
-        final List<Class<? extends LifecycleComponent>> services = new ArrayList<>(1);
-        services.add(GuiceHolder.class);
+        final List<Class<? extends LifecycleComponent>> services = new ArrayList<>(2);
         services.add(Ip2GeoListener.class);
+        services.add(GuiceHolder.class);
         return services;
     }
 

--- a/src/main/java/org/opensearch/geospatial/plugin/GeospatialPlugin.java
+++ b/src/main/java/org/opensearch/geospatial/plugin/GeospatialPlugin.java
@@ -294,7 +294,7 @@ public class GeospatialPlugin extends Plugin
             GuiceHolder.lockService = lockService;
         }
 
-        public static LockService getLockService() {
+        static LockService getLockService() {
             return lockService;
         }
 

--- a/src/main/java/org/opensearch/geospatial/plugin/GeospatialPlugin.java
+++ b/src/main/java/org/opensearch/geospatial/plugin/GeospatialPlugin.java
@@ -285,7 +285,7 @@ public class GeospatialPlugin extends Plugin
             .initialize(this.clusterService, this.datasourceUpdateService, this.ip2GeoExecutor, this.datasourceDao, this.ip2GeoLockService);
     }
 
-    static class GuiceHolder implements LifecycleComponent {
+    public static class GuiceHolder implements LifecycleComponent {
 
         private static LockService lockService;
 

--- a/src/main/java/org/opensearch/geospatial/plugin/GeospatialPlugin.java
+++ b/src/main/java/org/opensearch/geospatial/plugin/GeospatialPlugin.java
@@ -281,10 +281,6 @@ public class GeospatialPlugin extends Plugin
         LockService lockService = GuiceHolder.getLockService();
         ip2GeoLockService.initialize(lockService);
 
-        /**
-         * We don't need to return datasource runner because it is used only by job scheduler and job scheduler
-         * does not use DI but it calls DatasourceExtension#getJobRunner to get DatasourceRunner instance.
-         */
         DatasourceRunner.getJobRunnerInstance()
             .initialize(this.clusterService, this.datasourceUpdateService, this.ip2GeoExecutor, this.datasourceDao, this.ip2GeoLockService);
     }

--- a/src/main/java/org/opensearch/geospatial/plugin/GeospatialPlugin.java
+++ b/src/main/java/org/opensearch/geospatial/plugin/GeospatialPlugin.java
@@ -285,7 +285,7 @@ public class GeospatialPlugin extends Plugin
             .initialize(this.clusterService, this.datasourceUpdateService, this.ip2GeoExecutor, this.datasourceDao, this.ip2GeoLockService);
     }
 
-    public static class GuiceHolder implements LifecycleComponent {
+    static class GuiceHolder implements LifecycleComponent {
 
         private static LockService lockService;
 

--- a/src/test/java/org/opensearch/geospatial/ClusterSettingHelper.java
+++ b/src/test/java/org/opensearch/geospatial/ClusterSettingHelper.java
@@ -24,7 +24,6 @@ import org.opensearch.common.SuppressForbidden;
 import org.opensearch.common.network.NetworkModule;
 import org.opensearch.common.settings.Settings;
 import org.opensearch.env.Environment;
-import org.opensearch.geospatial.plugin.GeospatialPlugin;
 import org.opensearch.node.MockNode;
 import org.opensearch.node.Node;
 import org.opensearch.plugins.Plugin;
@@ -49,7 +48,7 @@ public class ClusterSettingHelper {
         List<Class<? extends Plugin>> plugins = new ArrayList<>();
         plugins.add(getTestTransportPlugin());
         plugins.add(MockHttpTransport.TestPlugin.class);
-        plugins.add(GeospatialPlugin.class);
+        plugins.add(TestGeospatialPlugin.class);
         return plugins;
     }
 

--- a/src/test/java/org/opensearch/geospatial/TestGeospatialPlugin.java
+++ b/src/test/java/org/opensearch/geospatial/TestGeospatialPlugin.java
@@ -1,0 +1,29 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package org.opensearch.geospatial;
+
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.List;
+
+import org.opensearch.common.lifecycle.LifecycleComponent;
+import org.opensearch.geospatial.ip2geo.listener.Ip2GeoListener;
+import org.opensearch.geospatial.plugin.GeospatialPlugin;
+
+/**
+ * This class is needed for ClusterSettingsHelper.createMockNode to instantiate a test instance of the
+ * GeospatialPlugin without the JobSchedulerPlugin installed. Without overriding this class, the
+ * GeospatialPlugin would try to Inject JobScheduler's LockService in the GuiceHolder which will
+ * fail because JobScheduler is not installed
+ */
+public class TestGeospatialPlugin extends GeospatialPlugin {
+    @Override
+    public Collection<Class<? extends LifecycleComponent>> getGuiceServiceClasses() {
+        final List<Class<? extends LifecycleComponent>> services = new ArrayList<>(1);
+        services.add(Ip2GeoListener.class);
+        return services;
+    }
+}

--- a/src/test/java/org/opensearch/geospatial/ip2geo/common/Ip2GeoLockServiceTests.java
+++ b/src/test/java/org/opensearch/geospatial/ip2geo/common/Ip2GeoLockServiceTests.java
@@ -21,6 +21,7 @@ import org.opensearch.core.index.shard.ShardId;
 import org.opensearch.geospatial.GeospatialTestHelper;
 import org.opensearch.geospatial.ip2geo.Ip2GeoTestCase;
 import org.opensearch.jobscheduler.spi.LockModel;
+import org.opensearch.jobscheduler.spi.utils.LockService;
 
 public class Ip2GeoLockServiceTests extends Ip2GeoTestCase {
     private Ip2GeoLockService ip2GeoLockService;
@@ -28,8 +29,11 @@ public class Ip2GeoLockServiceTests extends Ip2GeoTestCase {
 
     @Before
     public void init() {
-        ip2GeoLockService = new Ip2GeoLockService(clusterService, verifyingClient);
-        noOpsLockService = new Ip2GeoLockService(clusterService, client);
+        ip2GeoLockService = new Ip2GeoLockService(clusterService);
+        noOpsLockService = new Ip2GeoLockService(clusterService);
+        // TODO Remove direct instantiation and offer a TestLockService class to plugins
+        ip2GeoLockService.initialize(new LockService(verifyingClient, clusterService));
+        noOpsLockService.initialize(new LockService(client, clusterService));
     }
 
     public void testAcquireLock_whenValidInput_thenSucceed() {

--- a/src/test/java/org/opensearch/geospatial/plugin/GeospatialPluginTests.java
+++ b/src/test/java/org/opensearch/geospatial/plugin/GeospatialPluginTests.java
@@ -167,7 +167,7 @@ public class GeospatialPluginTests extends OpenSearchTestCase {
     }
 
     public void testGetGuiceServiceClasses() {
-        Collection<Class<? extends LifecycleComponent>> classes = List.of(Ip2GeoListener.class);
+        Collection<Class<? extends LifecycleComponent>> classes = List.of(Ip2GeoListener.class, GeospatialPlugin.GuiceHolder.class);
         assertEquals(classes, plugin.getGuiceServiceClasses());
     }
 


### PR DESCRIPTION
### Description

Companion JS PR: https://github.com/opensearch-project/job-scheduler/pull/670

This PR shows how Geospatial can be refactored to use the instance of the LockService that is initialized in Job Scheduler's `createComponents`.

This PR is part of an effort to remove usages of `ThreadContext.stashContext` across the plugins: https://github.com/opensearch-project/opensearch-plugins/issues/238

Currently, geospatial instantiates its own instance of the LockService by passing in the Client given to geospatial through `createComponents`.

As part of the effort to [Strengthen System Indices in the Plugin Ecosystem](https://github.com/opensearch-project/security/issues/4439), plugins will be restricted to only perform transport actions to their own system indices. This PR is to ensure that Geospatial uses the LockService instantiated by JS (which has permission to JS system indices) vs creating its own LockService. 

### Related Issues

Related to https://github.com/opensearch-project/security/issues/4439

### Check List
- [ ] New functionality includes testing.
- [ ] New functionality has been documented.
- [ ] API changes companion pull request [created](https://github.com/opensearch-project/opensearch-api-specification/blob/main/DEVELOPER_GUIDE.md).
- [ ] Commits are signed per the DCO using `--signoff`.
- [ ] Public documentation issue/PR [created](https://github.com/opensearch-project/documentation-website/issues/new/choose).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/geospatial/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
