### PR TITLE
Set geospatial plugin 3.0.0 baseline JDK version to JDK-21

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -21,7 +21,7 @@ jobs:
     needs: Get-CI-Image-Tag
     strategy:
       matrix:
-        java: [11, 17, 21]
+        java: [21]
 
     name: Build and Test geospatial Plugin
     runs-on: ubuntu-latest
@@ -54,7 +54,7 @@ jobs:
   Build-windows-macos:
     strategy:
       matrix:
-        java: [11, 17, 21]
+        java: [21]
         os: [windows-latest, macos-latest]
 
     name: Build and Test geospatial Plugin

--- a/.github/workflows/maven-publish.yml
+++ b/.github/workflows/maven-publish.yml
@@ -20,7 +20,7 @@ jobs:
       - uses: actions/setup-java@v3
         with:
           distribution: temurin # Temurin is a distribution of adoptium
-          java-version: 11
+          java-version: 21
       - uses: actions/checkout@v3
       - uses: aws-actions/configure-aws-credentials@v1
         with:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,8 @@ See the [CONTRIBUTING guide](./CONTRIBUTING.md#Changelog) for instructions on ho
 ### Infrastructure
 ### Documentation
 ### Maintenance
+- Set geospatial plugin 3.0.0 baseline JDK version to JDK-21 ([#695](https://github.com/opensearch-project/geospatial/pull/695))
+
 ### Refactoring
 
 ## [Unreleased 2.x](https://github.com/opensearch-project/geospatial/compare/2.17...2.x)

--- a/build.gradle
+++ b/build.gradle
@@ -94,8 +94,8 @@ ext {
 allprojects {
     group = opensearch_group
     version = "${opensearch_build}"
-    targetCompatibility = JavaVersion.VERSION_11
-    sourceCompatibility = JavaVersion.VERSION_11
+    targetCompatibility = JavaVersion.VERSION_21
+    sourceCompatibility = JavaVersion.VERSION_21
 }
 
 repositories {


### PR DESCRIPTION
### Description

Set geospatial plugin 3.0.0 baseline JDK version to JDK-21

### Related Issues

Related to: https://github.com/opensearch-project/OpenSearch/issues/10745

### Check List
- [ ] New functionality includes testing.
- [ ] New functionality has been documented.
- [ ] API changes companion pull request [created](https://github.com/opensearch-project/opensearch-api-specification/blob/main/DEVELOPER_GUIDE.md).
- [ ] Commits are signed per the DCO using `--signoff`.
- [ ] Public documentation issue/PR [created](https://github.com/opensearch-project/documentation-website/issues/new/choose).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/geospatial/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
