### PR TITLE
Fix: Github CI build fix

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -61,10 +61,10 @@ jobs:
 
     steps:
       - name: Checkout geospatial
-        uses: actions/checkout@v4
+        uses: actions/checkout@v1
 
       - name: Setup Java ${{ matrix.java }}
-        uses: actions/setup-java@v4
+        uses: actions/setup-java@v1
         with:
           java-version: ${{ matrix.java }}
 
@@ -73,6 +73,6 @@ jobs:
           ./gradlew build
 
       - name: Upload Coverage Report
-        uses: codecov/codecov-action@v4
+        uses: codecov/codecov-action@v1
         with:
           token: ${{ secrets.CODECOV_TOKEN }}

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -29,15 +29,14 @@ jobs:
       # using the same image which is used by opensearch-build team to build the OpenSearch Distribution
       # this image tag is subject to change as more dependencies and updates will arrive over time
       image: ${{ needs.Get-CI-Image-Tag.outputs.ci-image-version-linux }}
-      # need to switch to root so that github actions can install runner binary on container without permission issues.
-      options: --user root
+      options: ${{ needs.Get-CI-Image-Tag.outputs.ci-image-start-options }}
 
     steps:
       - name: Checkout geospatial
-        uses: actions/checkout@v1
+        uses: actions/checkout@v4
 
       - name: Setup Java ${{ matrix.java }}
-        uses: actions/setup-java@v1
+        uses: actions/setup-java@v4
         with:
           java-version: ${{ matrix.java }}
 
@@ -47,7 +46,7 @@ jobs:
           su `id -un 1000` -c "./gradlew build"
 
       - name: Upload Coverage Report
-        uses: codecov/codecov-action@v1
+        uses: codecov/codecov-action@v4
         with:
           token: ${{ secrets.CODECOV_TOKEN }}
 
@@ -62,10 +61,10 @@ jobs:
 
     steps:
       - name: Checkout geospatial
-        uses: actions/checkout@v1
+        uses: actions/checkout@v4
 
       - name: Setup Java ${{ matrix.java }}
-        uses: actions/setup-java@v1
+        uses: actions/setup-java@v4
         with:
           java-version: ${{ matrix.java }}
 
@@ -74,6 +73,6 @@ jobs:
           ./gradlew build
 
       - name: Upload Coverage Report
-        uses: codecov/codecov-action@v1
+        uses: codecov/codecov-action@v4
         with:
           token: ${{ secrets.CODECOV_TOKEN }}

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -8,9 +8,6 @@ on:
     branches:
       - "*"
       - "feature/**"
-env:
-  ACTIONS_ALLOW_USE_UNSECURE_NODE_VERSION: true
-
 jobs:
   Get-CI-Image-Tag:
     uses: opensearch-project/opensearch-build/.github/workflows/get-ci-image-tag.yml@main
@@ -32,6 +29,9 @@ jobs:
       options: ${{ needs.Get-CI-Image-Tag.outputs.ci-image-start-options }}
 
     steps:
+      - name: Run start commands
+        run: ${{ needs.Get-CI-Image-Tag.outputs.ci-image-start-command }}
+
       - name: Checkout geospatial
         uses: actions/checkout@v4
 

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -38,6 +38,7 @@ jobs:
       - name: Setup Java ${{ matrix.java }}
         uses: actions/setup-java@v4
         with:
+          distribution: 'corretto'
           java-version: ${{ matrix.java }}
 
       - name: Run build

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,7 +20,7 @@ See the [CONTRIBUTING guide](./CONTRIBUTING.md#Changelog) for instructions on ho
 ### Enhancements
 ### Bug Fixes
 ### Infrastructure
-- Github ci-runner Node.js issue fix
+- Github ci-runner Node.js issue fix ([#701](https://github.com/opensearch-project/geospatial/pull/701))
 ### Documentation
 ### Maintenance
 ### Refactoring

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,7 @@ See the [CONTRIBUTING guide](./CONTRIBUTING.md#Changelog) for instructions on ho
 ### Enhancements
 ### Bug Fixes
 ### Infrastructure
+- Github ci-runner Node.js issue fix
 ### Documentation
 ### Maintenance
 ### Refactoring


### PR DESCRIPTION
### Description

To introduce additional start command for all CI build which rely on the OpnSearch Docker image, as Github rollout the deprecation of the Node 16 on all it's CI-runner, as the result all existing Github which rely on the old version of Node.JS (Ex: actions/checkout@v3) failed due to the following errors:

```
/__e/node20/bin/node: /lib64/libm.so.6: version `GLIBC_2.27' not found (required by /__e/node20/bin/node)
/__e/node20/bin/node: /lib64/libc.so.6: version `GLIBC_2.28' not found (required by /__e/node20/bin/node)
```

The issue has been discovered over https://github.com/opensearch-project/opensearch-build/issues/5178 and fix has been verified and  applied on multiple OpenSearch plugin, such as: 
 - https://github.com/opensearch-project/ml-commons/pull/3223
 - https://github.com/opensearch-project/asynchronous-search/pull/676

### Related Issues
Resolves https://github.com/opensearch-project/opensearch-build/issues/5178

### Check List
- [ ] New functionality includes testing.
- [ ] New functionality has been documented.
- [ ] API changes companion pull request [created](https://github.com/opensearch-project/opensearch-api-specification/blob/main/DEVELOPER_GUIDE.md).
- [x] Commits are signed per the DCO using `--signoff`.
- [ ] Public documentation issue/PR [created](https://github.com/opensearch-project/documentation-website/issues/new/choose).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/geospatial/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
