### PR TITLE
Update staging repo for geospatial-client and opensearch-geospatial publication

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -120,6 +120,10 @@ test {
 publishing {
     repositories {
         maven {
+            name = 'staging'
+            url = "${rootProject.buildDir}/local-staging-repo"
+        }
+        maven {
             name = "Snapshots"
             url = "https://aws.oss.sonatype.org/content/repositories/snapshots"
             credentials {

--- a/client/build.gradle
+++ b/client/build.gradle
@@ -57,6 +57,10 @@ spotless {
 publishing {
     repositories {
         maven {
+            name = 'staging'
+            url = "${rootProject.buildDir}/local-staging-repo"
+        }
+        maven {
             name = "Snapshots"
             url = "https://aws.oss.sonatype.org/content/repositories/snapshots"
             credentials {

--- a/scripts/build.sh
+++ b/scripts/build.sh
@@ -81,6 +81,7 @@ cp ${distributions}/*.zip ./$OUTPUT/plugins
 
 # Publish plugin jars to maven
 ./gradlew publishNebulaPublicationToMavenLocal -Dopensearch.version=$VERSION -Dbuild.snapshot=$SNAPSHOT -Dbuild.version_qualifier=$QUALIFIER
+./gradlew publishNebulaPublicationToStagingRepository -Dopensearch.version=$VERSION -Dbuild.snapshot=$SNAPSHOT -Dbuild.version_qualifier=$QUALIFIER
 
 # Publish plugin zips to maven
 ./gradlew publishPluginZipPublicationToMavenLocal -Dopensearch.version=$VERSION -Dbuild.snapshot=$SNAPSHOT -Dbuild.version_qualifier=$QUALIFIER


### PR DESCRIPTION

### Description
Update staging repo for geospatial-client and opensearch-geospatial publication

### Related Issues
https://github.com/opensearch-project/opensearch-build/issues/3747
```

Execution failed for task ':opensearch:compileJava'.

> Could not resolve all files for configuration ':opensearch:compileClasspath'.

   > Could not resolve org.opensearch:geospatial-client:3.0.0.0-alpha1.

     Required by:

         project :opensearch

      > Could not resolve org.opensearch:geospatial-client:3.0.0.0-alpha1.

         > Could not get resource 'https://ci.opensearch.org/ci/dbc/snapshots/lucene/org/opensearch/geospatial-client/3.0.0.0-alpha1/geospatial-client-3.0.0.0-alpha1.pom'.

            > Could not GET 'https://ci.opensearch.org/ci/dbc/snapshots/lucene/org/opensearch/geospatial-client/3.0.0.0-alpha1/geospatial-client-3.0.0.0-alpha1.pom'. Received status code 403 from server: Forbidden


```

### Check List
- ~~[ ] New functionality includes testing.~~
- ~~[ ] New functionality has been documented.~~
- ~~[ ] API changes companion pull request [created](https://github.com/opensearch-project/opensearch-api-specification/blob/main/DEVELOPER_GUIDE.md).~~
- [x] Commits are signed per the DCO using `--signoff`.
- ~~[ ] Public documentation issue/PR [created](https://github.com/opensearch-project/documentation-website/issues/new/choose).~~

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/geospatial/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
