### PR TITLE
persist licenses and developer fields in pom file

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ See the [CONTRIBUTING guide](./CONTRIBUTING.md#Changelog) for instructions on ho
 ### Infrastructure
 ### Documentation
 ### Maintenance
+* Persist necessary license and developer information in maven pom ([#732](https://github.com/opensearch-project/geospatial/pull/732))
 ### Refactoring
 
 ## [Unreleased 2.x](https://github.com/opensearch-project/geospatial/compare/2.19...2.x)

--- a/build.gradle
+++ b/build.gradle
@@ -116,7 +116,6 @@ test {
     include '**/*Tests.class'
     systemProperty 'tests.security.manager', 'false'
 }
-
 publishing {
     repositories {
         maven {
@@ -138,22 +137,29 @@ publishing {
                 name = pluginName
                 description = pluginDescription
                 groupId = "org.opensearch.plugin"
-                licenses {
-                    license {
-                        name = "The Apache License, Version 2.0"
-                        url = "http://www.apache.org/licenses/LICENSE-2.0.txt"
-                    }
-                }
-                developers {
-                    developer {
-                        name = "OpenSearch"
-                        url = "https://github.com/opensearch-project/geospatial"
-                    }
-                }
+            }
+        }
+        all {
+            pom {
+                name = pluginName
+                description = pluginDescription
+            }
+            pom.withXml { XmlProvider xml ->
+                Node node = xml.asNode()
+                node.appendNode('inceptionYear', '2021')
+
+                Node license = node.appendNode('licenses').appendNode('license')
+                license.appendNode('name',  "The Apache License, Version 2.0")
+                license.appendNode('url', "http://www.apache.org/licenses/LICENSE-2.0.txt")
+
+                Node developer = node.appendNode('developers').appendNode('developer')
+                developer.appendNode('name', 'OpenSearch')
+                developer.appendNode('url', 'https://github.com/opensearch-project/geospatial')
             }
         }
     }
 }
+
 
 
 configurations {

--- a/client/build.gradle
+++ b/client/build.gradle
@@ -70,22 +70,22 @@ publishing {
         }
     }
     publications {
-        pluginZip(MavenPublication) { publication ->
+        all {
             pom {
                 name = "opensearch-geospatial-client"
                 description = 'OpenSearch Geospatial client'
-                licenses {
-                    license {
-                        name = "The Apache License, Version 2.0"
-                        url = "http://www.apache.org/licenses/LICENSE-2.0.txt"
-                    }
-                }
-                developers {
-                    developer {
-                        name = "OpenSearch"
-                        url = "https://github.com/opensearch-project/geospatial"
-                    }
-                }
+            }
+            pom.withXml { XmlProvider xml ->
+                Node node = xml.asNode()
+                node.appendNode('inceptionYear', '2021')
+
+                Node license = node.appendNode('licenses').appendNode('license')
+                license.appendNode('name',  "The Apache License, Version 2.0")
+                license.appendNode('url', "http://www.apache.org/licenses/LICENSE-2.0.txt")
+
+                Node developer = node.appendNode('developers').appendNode('developer')
+                developer.appendNode('name', 'OpenSearch')
+                developer.appendNode('url', 'https://github.com/opensearch-project/geospatial')
             }
         }
     }


### PR DESCRIPTION
### Description
change plugIn clause to all clause to include information in pom files in both `org.opensearch.opensearch-geospatial`and `org.opensearch.geospatial-client`
append fields as xmlNode as in [job-schedule](https://github.com/opensearch-project/job-scheduler/blob/main/build.gradle) to persist when publshing to maven

reference: https://github.com/opensearch-project/job-scheduler/blob/main/build.gradle

### Verification
verified `<licenses> `and `<developers>` tag are properly appended to .pom files in following files:

`~/.m2/repository/org/opensearch/opensearch-geospatial/3.0.0.0-alpha1-SNAPSHOT/opensearch-geospatial-3.0.0.0-alpha1-SNAPSHOT.pom`

`~/.m2/repository/org/opensearch/geospatial-client/3.0.0.0-alpha1-SNAPSHOT/geospatial-client-3.0.0.0-alpha1-SNAPSHOT.pom`

`~/.m2/repository/org/opensearch/plugin/geospatial/3.0.0.0-alpha1-SNAPSHOT/geospatial-3.0.0.0-alpha1-SNAPSHOT.pom `

`~/.m2/repository/org/opensearch/plugin/opensearch-geospatial/3.0.0.0-alpha1-SNAPSHOT/opensearch-geospatial-3.0.0.0-alpha1-SNAPSHOT.pom`

### Related Issues
Resolves #731 

### Check List
- [ ] New functionality includes testing.
- [ ] New functionality has been documented.
- [ ] API changes companion pull request [created](https://github.com/opensearch-project/opensearch-api-specification/blob/main/DEVELOPER_GUIDE.md).
- [x] Commits are signed per the DCO using `--signoff`.
- [ ] Public documentation issue/PR [created](https://github.com/opensearch-project/documentation-website/issues/new/choose).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/geospatial/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
