### PR TITLE
Using java-agent gradle plugin to phase off Security Manager in favor of Java-agent.

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -14,6 +14,7 @@ apply plugin: 'opensearch.pluginzip'
 apply plugin: 'opensearch.yaml-rest-test'
 apply plugin: 'jacoco'
 apply plugin: 'io.freefair.lombok'
+apply plugin: 'opensearch.java-agent'
 
 def pluginName = 'opensearch-geospatial'
 def pluginDescription = 'OpenSearch Geospatial plugin to host geospatial features'

--- a/build.gradle
+++ b/build.gradle
@@ -164,7 +164,6 @@ publishing {
 
 configurations {
     zipArchive
-    agent
 }
 
 //****************************************************************************/
@@ -184,9 +183,6 @@ dependencies {
     zipArchive group: 'org.opensearch.plugin', name:'opensearch-job-scheduler', version: "${opensearch_build}"
     compileOnly "org.opensearch:opensearch-job-scheduler-spi:${opensearch_build}"
     implementation "com.github.seancfoley:ipaddress:5.4.2"
-    agent "org.opensearch:opensearch-agent-bootstrap:${opensearch_version}"
-    agent "org.opensearch:opensearch-agent:${opensearch_version}"
-    agent "net.bytebuddy:byte-buddy:${versions.bytebuddy}"
 }
 
 licenseHeaders.enabled = true
@@ -354,14 +350,4 @@ task updateVersion {
          // String tokenization to support -SNAPSHOT
         ant.replaceregexp(file:'build.gradle', match: '"opensearch.version", "\\d.*"', replace: '"opensearch.version", "' + newVersion.tokenize('-')[0] + '-SNAPSHOT"', flags:'g', byline:true)
     }
-}
-
-task prepareAgent(type: Copy) {
-  from(configurations.agent)
-  into "$buildDir/agent"
-}
-
-tasks.withType(Test) {
-  dependsOn prepareAgent
-  jvmArgs += ["-javaagent:" + project.layout.buildDirectory.file("agent/opensearch-agent-${opensearch_version}.jar").get()]
 }

--- a/libs/h3/build.gradle
+++ b/libs/h3/build.gradle
@@ -34,10 +34,6 @@ repositories {
     maven { url "https://plugins.gradle.org/m2/" }
 }
 
-configurations {
-    agent
-}
-
 dependencies {
     api "org.apache.logging.log4j:log4j-api:${versions.log4j}"
     api "org.apache.logging.log4j:log4j-core:${versions.log4j}"
@@ -45,22 +41,7 @@ dependencies {
     testImplementation 'commons-io:commons-io:2.15.1'
     testImplementation "org.apache.commons:commons-compress:1.26.0"
     testImplementation "org.apache.lucene:lucene-spatial3d:${versions.lucene}"
-
-    agent "org.opensearch:opensearch-agent-bootstrap:${opensearch_version}"
-    agent "org.opensearch:opensearch-agent:${opensearch_version}"
-    agent "net.bytebuddy:byte-buddy:${versions.bytebuddy}"
 }
-
-task prepareAgent(type: Copy) {
-    from(configurations.agent)
-    into "$buildDir/agent"
-}
-
-tasks.withType(Test) {
-    dependsOn prepareAgent
-    jvmArgs += ["-javaagent:" + project.layout.buildDirectory.file("agent/opensearch-agent-${opensearch_version}.jar").get()]
-}
-
 licenseFile = "LICENSE.txt"
 noticeFile = "NOTICE.txt"
 

--- a/libs/h3/build.gradle
+++ b/libs/h3/build.gradle
@@ -22,6 +22,7 @@
  */
 apply plugin: 'opensearch.build'
 apply plugin: 'opensearch.publish'
+apply plugin: 'opensearch.java-agent'
 
 tasks.named('forbiddenApisMain').configure {
   replaceSignatureFiles 'jdk-signatures'


### PR DESCRIPTION
### Description
Using java-agent gradle plugin to phase off Security Manager in favor of Java-agent.

### Related Issues
Resolves #[Issue number to be closed when this PR is merged]
<!-- List any other related issues here -->

### Check List
- [ ] New functionality includes testing.
- [ ] New functionality has been documented.
- [ ] API changes companion pull request [created](https://github.com/opensearch-project/opensearch-api-specification/blob/main/DEVELOPER_GUIDE.md).
- [ ] Commits are signed per the DCO using `--signoff`.
- [ ] Public documentation issue/PR [created](https://github.com/opensearch-project/documentation-website/issues/new/choose).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/geospatial/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
