### PR TITLE
Add release notes for 3.1.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,14 +11,4 @@ See the [CONTRIBUTING guide](./CONTRIBUTING.md#Changelog) for instructions on ho
 ### Infrastructure
 ### Documentation
 ### Maintenance
-Fix a unit test and update github workflow to use actions/setup-java@v3.
-### Refactoring
-
-## [Unreleased 2.x](https://github.com/opensearch-project/geospatial/compare/2.19...2.x)
-### Features
-### Enhancements
-### Bug Fixes
-### Infrastructure
-### Documentation
-### Maintenance
 ### Refactoring

--- a/release-notes/opensearch-geospatial.release-notes-3.1.0.0.md
+++ b/release-notes/opensearch-geospatial.release-notes-3.1.0.0.md
@@ -1,0 +1,6 @@
+## Version 3.1.0.0 Release Notes
+
+Compatible with OpenSearch 3.1.0
+
+### Maintenance
+Fix a unit test and update github workflow to use actions/setup-java@v3.


### PR DESCRIPTION
### Description
Add release notes for 3.1.0

We have a weird failure complaining 
```
Exception in thread "main" java.lang.IllegalArgumentException: Missing plugin [opensearch-job-scheduler], dependency of [opensearch-geospatial]
```

But we have a [success](https://github.com/bzhangam/geospatial/actions/runs/15620400495) recently and we don't introduce any new change unless the simple text change to the release notes. So I think we should be good to override the failure to merge this PR.

### Related Issues
Resolves #749 


### Check List
- [ ] New functionality includes testing.
- [ ] New functionality has been documented.
- [ ] API changes companion pull request [created](https://github.com/opensearch-project/opensearch-api-specification/blob/main/DEVELOPER_GUIDE.md).
- [x] Commits are signed per the DCO using `--signoff`.
- [ ] Public documentation issue/PR [created](https://github.com/opensearch-project/documentation-website/issues/new/choose).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/geospatial/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
