### PR TITLE
Refresh the Ip2Geo cache and retry one more time when we run into an issue

### DIFF
--- a/release-notes/opensearch-geospatial.release-notes-3.1.0.0.md
+++ b/release-notes/opensearch-geospatial.release-notes-3.1.0.0.md
@@ -4,6 +4,6 @@ Compatible with OpenSearch 3.1.0
 
 ### Bug Fixes
 * Reset datasource metadata when failed to update it in postIndex and postDelete to force refresh it from the primary index shard. ([#761](https://github.com/opensearch-project/geospatial/pull/761))
-
+* Refresh the Ip2Geo cache and retry one more time when we run into an issue. ([#766](https://github.com/opensearch-project/geospatial/pull/766))
 ### Maintenance
 * Fix a unit test and update github workflow to use actions/setup-java@v3.

--- a/src/main/java/org/opensearch/geospatial/ip2geo/action/IpEnrichmentTransportAction.java
+++ b/src/main/java/org/opensearch/geospatial/ip2geo/action/IpEnrichmentTransportAction.java
@@ -55,7 +55,7 @@ public class IpEnrichmentTransportAction extends HandledTransportAction<ActionRe
         String ipString = enrichmentRequest.getIpString();
         String dataSourceName = enrichmentRequest.getDatasourceName();
         String indexName = ip2GeoCachedDao.getIndexName(dataSourceName);
-        Map<String, Object> geoLocationData = ip2GeoCachedDao.getGeoData(indexName, ipString);
+        Map<String, Object> geoLocationData = ip2GeoCachedDao.getGeoData(indexName, ipString, dataSourceName);
         log.debug("GeoSpatial IP lookup on IP: [{}], and result [{}]", ipString, geoLocationData);
         listener.onResponse(new IpEnrichmentResponse(geoLocationData));
     }

--- a/src/main/java/org/opensearch/geospatial/ip2geo/processor/Ip2GeoProcessor.java
+++ b/src/main/java/org/opensearch/geospatial/ip2geo/processor/Ip2GeoProcessor.java
@@ -158,7 +158,7 @@ public final class Ip2GeoProcessor extends AbstractProcessor {
             return;
         }
 
-        Map<String, Object> geoData = ip2GeoCachedDao.getGeoData(indexName, ip);
+        Map<String, Object> geoData = ip2GeoCachedDao.getGeoData(indexName, ip, datasourceName);
         if (geoData.isEmpty() == false) {
             ingestDocument.setFieldValue(targetField, filteredGeoData(geoData));
         }
@@ -222,7 +222,7 @@ public final class Ip2GeoProcessor extends AbstractProcessor {
         }
 
         List<Map<String, Object>> geoDataList = ips.stream()
-            .map(ip -> ip2GeoCachedDao.getGeoData(indexName, (String) ip))
+            .map(ip -> ip2GeoCachedDao.getGeoData(indexName, (String) ip, datasourceName))
             .filter(geoData -> geoData.isEmpty() == false)
             .map(this::filteredGeoData)
             .collect(Collectors.toList());

--- a/src/test/java/org/opensearch/geospatial/ip2geo/processor/Ip2GeoProcessorTests.java
+++ b/src/test/java/org/opensearch/geospatial/ip2geo/processor/Ip2GeoProcessorTests.java
@@ -120,7 +120,7 @@ public class Ip2GeoProcessorTests extends Ip2GeoTestCase {
         when(ip2GeoCachedDao.getState(datasourceName)).thenReturn(DatasourceState.AVAILABLE);
         when(ip2GeoCachedDao.isExpired(datasourceName)).thenReturn(true);
         Map<String, Object> geoData = Map.of("city", "Seattle", "country", "USA");
-        when(ip2GeoCachedDao.getGeoData(eq(indexName), any())).thenReturn(geoData);
+        when(ip2GeoCachedDao.getGeoData(eq(indexName), any(), any())).thenReturn(geoData);
 
         // Run for single ip
         String ip = randomIpAddress();
@@ -153,7 +153,7 @@ public class Ip2GeoProcessorTests extends Ip2GeoTestCase {
         when(ip2GeoCachedDao.getState(datasourceName)).thenReturn(DatasourceState.CREATE_FAILED);
         when(ip2GeoCachedDao.isExpired(datasourceName)).thenReturn(false);
         Map<String, Object> geoData = Map.of("city", "Seattle", "country", "USA");
-        when(ip2GeoCachedDao.getGeoData(eq(indexName), any())).thenReturn(geoData);
+        when(ip2GeoCachedDao.getGeoData(eq(indexName), any(), any())).thenReturn(geoData);
 
         // Run for single ip
         String ip = randomIpAddress();
@@ -183,7 +183,7 @@ public class Ip2GeoProcessorTests extends Ip2GeoTestCase {
         when(ip2GeoCachedDao.getState(datasourceName)).thenReturn(DatasourceState.AVAILABLE);
         when(ip2GeoCachedDao.isExpired(datasourceName)).thenReturn(false);
         Map<String, Object> geoData = Map.of("city", "Seattle", "country", "USA");
-        when(ip2GeoCachedDao.getGeoData(eq(indexName), any())).thenReturn(geoData);
+        when(ip2GeoCachedDao.getGeoData(eq(indexName), any(), any())).thenReturn(geoData);
 
         // Run for single ip
         String ip = randomIpAddress();
@@ -218,7 +218,7 @@ public class Ip2GeoProcessorTests extends Ip2GeoTestCase {
         when(ip2GeoCachedDao.getState(datasourceName)).thenReturn(DatasourceState.AVAILABLE);
         when(ip2GeoCachedDao.isExpired(datasourceName)).thenReturn(false);
         Map<String, Object> geoData = Map.of("city", "Seattle", "country", "USA");
-        when(ip2GeoCachedDao.getGeoData(eq(indexName), any())).thenReturn(geoData);
+        when(ip2GeoCachedDao.getGeoData(eq(indexName), any(), any())).thenReturn(geoData);
 
         // Run for single ip
         String ip = randomIpAddress();


### PR DESCRIPTION
### Description
Refresh the Ip2Geo cache and retry one more time when we run into an issue.

After we update the datasouce in the primary shard if we fail to send the request to the nodes with replica shard we will not update the cache. Even later the replica is recovered from the primary shard the cache update logic will not be triggered. So and this change to refresh the cache and retry when we run into an issue.

### Related Issues
N/A

### Check List
- [ ] New functionality includes testing.
- [ ] New functionality has been documented.
- [ ] API changes companion pull request [created](https://github.com/opensearch-project/opensearch-api-specification/blob/main/DEVELOPER_GUIDE.md).
- [x] Commits are signed per the DCO using `--signoff`.
- [ ] Public documentation issue/PR [created](https://github.com/opensearch-project/documentation-website/issues/new/choose).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/geospatial/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
