### PR TITLE
Block redirect in IP2Geo and move validation to transport action

### DIFF
--- a/release-notes/opensearch-geospatial.release-notes-3.2.0.0.md
+++ b/release-notes/opensearch-geospatial.release-notes-3.2.0.0.md
@@ -2,6 +2,9 @@
 
 Compatible with OpenSearch and OpenSearch Dashboards version 3.2.0
 
+### Bug Fixes
+* Block redirect in IP2Geo and move validation to transport action ([#782](https://github.com/opensearch-project/geospatial/pull/782))
+
 ### Maintenance
 * Upgrade gradle to 8.14.3 and run CI checks with JDK24 ([#776](https://github.com/opensearch-project/geospatial/pull/776))
 

--- a/src/main/java/org/opensearch/geospatial/ip2geo/action/PutDatasourceRequest.java
+++ b/src/main/java/org/opensearch/geospatial/ip2geo/action/PutDatasourceRequest.java
@@ -10,7 +10,6 @@ import java.net.MalformedURLException;
 import java.net.URISyntaxException;
 import java.net.URL;
 import java.util.List;
-import java.util.Locale;
 
 import org.opensearch.action.ActionRequest;
 import org.opensearch.action.ActionRequestValidationException;
@@ -19,7 +18,6 @@ import org.opensearch.core.ParseField;
 import org.opensearch.core.common.io.stream.StreamInput;
 import org.opensearch.core.common.io.stream.StreamOutput;
 import org.opensearch.core.xcontent.ObjectParser;
-import org.opensearch.geospatial.ip2geo.common.DatasourceManifest;
 import org.opensearch.geospatial.ip2geo.common.ParameterValidator;
 
 import lombok.Getter;
@@ -106,7 +104,6 @@ public class PutDatasourceRequest extends ActionRequest {
     /**
      * Conduct following validation on endpoint
      * 1. endpoint format complies with RFC-2396
-     * 2. validate manifest file from the endpoint
      *
      * @param errors the errors to add error messages
      */
@@ -114,49 +111,9 @@ public class PutDatasourceRequest extends ActionRequest {
         try {
             URL url = new URL(endpoint);
             url.toURI(); // Validate URL complies with RFC-2396
-            validateManifestFile(url, errors);
         } catch (MalformedURLException | URISyntaxException e) {
             log.info("Invalid URL[{}] is provided", endpoint, e);
             errors.addValidationError("Invalid URL format is provided");
-        }
-    }
-
-    /**
-     * Conduct following validation on url
-     * 1. can read manifest file from the endpoint
-     * 2. the url in the manifest file complies with RFC-2396
-     * 3. updateInterval is less than validForInDays value in the manifest file
-     *
-     * @param url the url to validate
-     * @param errors the errors to add error messages
-     */
-    private void validateManifestFile(final URL url, final ActionRequestValidationException errors) {
-        DatasourceManifest manifest;
-        try {
-            manifest = DatasourceManifest.Builder.build(url);
-        } catch (Exception e) {
-            log.info("Error occurred while reading a file from {}", url, e);
-            errors.addValidationError(String.format(Locale.ROOT, "Error occurred while reading a file from %s: %s", url, e.getMessage()));
-            return;
-        }
-
-        try {
-            new URL(manifest.getUrl()).toURI(); // Validate URL complies with RFC-2396
-        } catch (MalformedURLException | URISyntaxException e) {
-            log.info("Invalid URL[{}] is provided for url field in the manifest file", manifest.getUrl(), e);
-            errors.addValidationError("Invalid URL format is provided for url field in the manifest file");
-            return;
-        }
-
-        if (manifest.getValidForInDays() != null && updateInterval.days() >= manifest.getValidForInDays()) {
-            errors.addValidationError(
-                String.format(
-                    Locale.ROOT,
-                    "updateInterval %d should be smaller than %d",
-                    updateInterval.days(),
-                    manifest.getValidForInDays()
-                )
-            );
         }
     }
 

--- a/src/main/java/org/opensearch/geospatial/ip2geo/action/UpdateDatasourceRequest.java
+++ b/src/main/java/org/opensearch/geospatial/ip2geo/action/UpdateDatasourceRequest.java
@@ -9,7 +9,6 @@ import java.io.IOException;
 import java.net.MalformedURLException;
 import java.net.URISyntaxException;
 import java.net.URL;
-import java.util.Locale;
 
 import org.opensearch.action.ActionRequest;
 import org.opensearch.action.ActionRequestValidationException;
@@ -18,7 +17,6 @@ import org.opensearch.core.ParseField;
 import org.opensearch.core.common.io.stream.StreamInput;
 import org.opensearch.core.common.io.stream.StreamOutput;
 import org.opensearch.core.xcontent.ObjectParser;
-import org.opensearch.geospatial.ip2geo.common.DatasourceManifest;
 import org.opensearch.geospatial.ip2geo.common.ParameterValidator;
 
 import lombok.EqualsAndHashCode;
@@ -124,36 +122,9 @@ public class UpdateDatasourceRequest extends ActionRequest {
         try {
             URL url = new URL(endpoint);
             url.toURI(); // Validate URL complies with RFC-2396
-            validateManifestFile(url, errors);
         } catch (MalformedURLException | URISyntaxException e) {
             log.info("Invalid URL[{}] is provided", endpoint, e);
             errors.addValidationError("Invalid URL format is provided");
-        }
-    }
-
-    /**
-     * Conduct following validation on url
-     * 1. can read manifest file from the endpoint
-     * 2. the url in the manifest file complies with RFC-2396
-     *
-     * @param url the url to validate
-     * @param errors the errors to add error messages
-     */
-    private void validateManifestFile(final URL url, final ActionRequestValidationException errors) {
-        DatasourceManifest manifest;
-        try {
-            manifest = DatasourceManifest.Builder.build(url);
-        } catch (Exception e) {
-            log.info("Error occurred while reading a file from {}", url, e);
-            errors.addValidationError(String.format(Locale.ROOT, "Error occurred while reading a file from %s: %s", url, e.getMessage()));
-            return;
-        }
-
-        try {
-            new URL(manifest.getUrl()).toURI(); // Validate URL complies with RFC-2396
-        } catch (MalformedURLException | URISyntaxException e) {
-            log.info("Invalid URL[{}] is provided for url field in the manifest file", manifest.getUrl(), e);
-            errors.addValidationError("Invalid URL format is provided for url field in the manifest file");
         }
     }
 

--- a/src/main/java/org/opensearch/geospatial/ip2geo/common/DatasourceManifest.java
+++ b/src/main/java/org/opensearch/geospatial/ip2geo/common/DatasourceManifest.java
@@ -8,6 +8,7 @@ package org.opensearch.geospatial.ip2geo.common;
 import java.io.BufferedReader;
 import java.io.IOException;
 import java.io.InputStreamReader;
+import java.net.HttpURLConnection;
 import java.net.URL;
 import java.net.URLConnection;
 import java.nio.CharBuffer;
@@ -129,6 +130,9 @@ public class DatasourceManifest {
         @SuppressForbidden(reason = "Need to connect to http endpoint to read manifest file")
         protected static DatasourceManifest internalBuild(final URLConnection connection) throws IOException {
             connection.addRequestProperty(Constants.USER_AGENT_KEY, Constants.USER_AGENT_VALUE);
+            if (connection instanceof HttpURLConnection) {
+                HttpRedirectValidator.validateNoRedirects((HttpURLConnection) connection);
+            }
             InputStreamReader inputStreamReader = new InputStreamReader(connection.getInputStream());
             try (BufferedReader reader = new BufferedReader(inputStreamReader)) {
                 CharBuffer charBuffer = CharBuffer.allocate(MANIFEST_FILE_MAX_BYTES);

--- a/src/main/java/org/opensearch/geospatial/ip2geo/common/HttpRedirectValidator.java
+++ b/src/main/java/org/opensearch/geospatial/ip2geo/common/HttpRedirectValidator.java
@@ -1,0 +1,50 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package org.opensearch.geospatial.ip2geo.common;
+
+import java.io.IOException;
+import java.net.HttpURLConnection;
+import java.util.Locale;
+
+import lombok.extern.log4j.Log4j2;
+
+/**
+ * Utility class for validating HTTP connections no redirects
+ */
+@Log4j2
+public class HttpRedirectValidator {
+    private static final int HTTP_REDIRECT_STATUS_MIN = 300;
+    private static final int HTTP_REDIRECT_STATUS_MAX = 400;
+    private static final String LOCATION_HEADER = "Location";
+
+    // Private constructor to prevent instantiation
+    private HttpRedirectValidator() {}
+
+    /**
+     * Validates that an HTTP connection does not attempt to redirect
+     *
+     * @param httpConnection the HTTP connection to validate
+     * @throws IOException if an I/O error occurs
+     * @throws IllegalArgumentException if a redirect attempt is detected
+     */
+    public static void validateNoRedirects(final HttpURLConnection httpConnection) throws IOException {
+        httpConnection.setInstanceFollowRedirects(false);
+
+        final int responseCode = httpConnection.getResponseCode();
+        if (responseCode >= HTTP_REDIRECT_STATUS_MIN && responseCode < HTTP_REDIRECT_STATUS_MAX) {
+            final String redirectLocation = httpConnection.getHeaderField(LOCATION_HEADER);
+            throw new IllegalArgumentException(
+                String.format(
+                    Locale.ROOT,
+                    "HTTP redirects are not allowed. URL [%s] attempted to redirect to [%s] with status code [%d]",
+                    httpConnection.getURL().toString(),
+                    redirectLocation != null ? redirectLocation : "unknown",
+                    responseCode
+                )
+            );
+        }
+    }
+}

--- a/src/test/java/org/opensearch/geospatial/ip2geo/Ip2GeoTestCase.java
+++ b/src/test/java/org/opensearch/geospatial/ip2geo/Ip2GeoTestCase.java
@@ -180,8 +180,18 @@ public abstract class Ip2GeoTestCase extends RestActionTestCase {
         return Paths.get(this.getClass().getClassLoader().getResource("ip2geo/manifest.json").toURI()).toUri().toURL().toExternalForm();
     }
 
+    @SneakyThrows
     @SuppressForbidden(reason = "unit test")
-    protected String sampleManifestUrlWithInvalidUrl() throws Exception {
+    protected String anotherSampleManifestUrl() {
+        return Paths.get(this.getClass().getClassLoader().getResource("ip2geo/another_manifest.json").toURI())
+            .toUri()
+            .toURL()
+            .toExternalForm();
+    }
+
+    @SneakyThrows
+    @SuppressForbidden(reason = "unit test")
+    protected String sampleManifestUrlWithInvalidUrl() {
         return Paths.get(this.getClass().getClassLoader().getResource("ip2geo/manifest_invalid_url.json").toURI())
             .toUri()
             .toURL()
@@ -222,7 +232,7 @@ public abstract class Ip2GeoTestCase extends RestActionTestCase {
         datasource.setState(randomState());
         datasource.setCurrentIndex(datasource.newIndexName(UUID.randomUUID().toString()));
         datasource.setIndices(Arrays.asList(GeospatialTestHelper.randomLowerCaseString(), GeospatialTestHelper.randomLowerCaseString()));
-        datasource.setEndpoint(String.format(Locale.ROOT, "https://%s.com/manifest.json", GeospatialTestHelper.randomLowerCaseString()));
+        datasource.setEndpoint(sampleManifestUrl());
         datasource.getDatabase()
             .setFields(Arrays.asList(GeospatialTestHelper.randomLowerCaseString(), GeospatialTestHelper.randomLowerCaseString()));
         datasource.getDatabase().setProvider(GeospatialTestHelper.randomLowerCaseString());

--- a/src/test/java/org/opensearch/geospatial/ip2geo/action/PutDatasourceRequestTests.java
+++ b/src/test/java/org/opensearch/geospatial/ip2geo/action/PutDatasourceRequestTests.java
@@ -27,21 +27,6 @@ public class PutDatasourceRequestTests extends Ip2GeoTestCase {
         assertEquals("Invalid URL format is provided", exception.validationErrors().get(0));
     }
 
-    public void testValidate_whenInvalidManifestFile_thenFails() {
-        String datasourceName = GeospatialTestHelper.randomLowerCaseString();
-        String domain = GeospatialTestHelper.randomLowerCaseString();
-        PutDatasourceRequest request = new PutDatasourceRequest(datasourceName);
-        request.setEndpoint(String.format(Locale.ROOT, "https://%s.com", domain));
-        request.setUpdateInterval(TimeValue.timeValueDays(1));
-
-        // Run
-        ActionRequestValidationException exception = request.validate();
-
-        // Verify
-        assertEquals(1, exception.validationErrors().size());
-        assertTrue(exception.validationErrors().get(0).contains("Error occurred while reading a file"));
-    }
-
     public void testValidate_whenValidInput_thenSucceed() {
         String datasourceName = GeospatialTestHelper.randomLowerCaseString();
         PutDatasourceRequest request = new PutDatasourceRequest(datasourceName);
@@ -80,34 +65,6 @@ public class PutDatasourceRequestTests extends Ip2GeoTestCase {
             String.format(Locale.ROOT, "Update interval should be equal to or larger than 1 day"),
             exception.validationErrors().get(0)
         );
-    }
-
-    public void testValidate_whenLargeUpdateInterval_thenFail() throws Exception {
-        String datasourceName = GeospatialTestHelper.randomLowerCaseString();
-        PutDatasourceRequest request = new PutDatasourceRequest(datasourceName);
-        request.setEndpoint(sampleManifestUrl());
-        request.setUpdateInterval(TimeValue.timeValueDays(30));
-
-        // Run
-        ActionRequestValidationException exception = request.validate();
-
-        // Verify
-        assertEquals(1, exception.validationErrors().size());
-        assertTrue(exception.validationErrors().get(0).contains("should be smaller"));
-    }
-
-    public void testValidate_whenInvalidUrlInsideManifest_thenFail() throws Exception {
-        String datasourceName = GeospatialTestHelper.randomLowerCaseString();
-        PutDatasourceRequest request = new PutDatasourceRequest(datasourceName);
-        request.setEndpoint(sampleManifestUrlWithInvalidUrl());
-        request.setUpdateInterval(TimeValue.timeValueDays(1));
-
-        // Run
-        ActionRequestValidationException exception = request.validate();
-
-        // Verify
-        assertEquals(1, exception.validationErrors().size());
-        assertTrue(exception.validationErrors().get(0).contains("Invalid URL format"));
     }
 
     public void testStreamInOut_whenValidInput_thenSucceed() throws Exception {

--- a/src/test/java/org/opensearch/geospatial/ip2geo/action/UpdateDatasourceRequestTests.java
+++ b/src/test/java/org/opensearch/geospatial/ip2geo/action/UpdateDatasourceRequestTests.java
@@ -44,20 +44,6 @@ public class UpdateDatasourceRequestTests extends Ip2GeoTestCase {
         assertEquals("Invalid URL format is provided", exception.validationErrors().get(0));
     }
 
-    public void testValidate_whenInvalidManifestFile_thenFails() {
-        String datasourceName = GeospatialTestHelper.randomLowerCaseString();
-        String domain = GeospatialTestHelper.randomLowerCaseString();
-        UpdateDatasourceRequest request = new UpdateDatasourceRequest(datasourceName);
-        request.setEndpoint(String.format(Locale.ROOT, "https://%s.com", domain));
-
-        // Run
-        ActionRequestValidationException exception = request.validate();
-
-        // Verify
-        assertEquals(1, exception.validationErrors().size());
-        assertTrue(exception.validationErrors().get(0).contains("Error occurred while reading a file"));
-    }
-
     @SneakyThrows
     public void testValidate_whenValidInput_thenSucceed() {
         String datasourceName = GeospatialTestHelper.randomLowerCaseString();
@@ -98,21 +84,6 @@ public class UpdateDatasourceRequestTests extends Ip2GeoTestCase {
             String.format(Locale.ROOT, "Update interval should be equal to or larger than 1 day"),
             exception.validationErrors().get(0)
         );
-    }
-
-    @SneakyThrows
-    public void testValidate_whenInvalidUrlInsideManifest_thenFail() {
-        String datasourceName = GeospatialTestHelper.randomLowerCaseString();
-        UpdateDatasourceRequest request = new UpdateDatasourceRequest(datasourceName);
-        request.setEndpoint(sampleManifestUrlWithInvalidUrl());
-        request.setUpdateInterval(TimeValue.timeValueDays(1));
-
-        // Run
-        ActionRequestValidationException exception = request.validate();
-
-        // Verify
-        assertEquals(1, exception.validationErrors().size());
-        assertTrue(exception.validationErrors().get(0).contains("Invalid URL format"));
     }
 
     @SneakyThrows

--- a/src/test/java/org/opensearch/geospatial/ip2geo/common/HttpRedirectValidatorTests.java
+++ b/src/test/java/org/opensearch/geospatial/ip2geo/common/HttpRedirectValidatorTests.java
@@ -1,0 +1,70 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package org.opensearch.geospatial.ip2geo.common;
+
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import java.net.HttpURLConnection;
+
+import org.opensearch.test.OpenSearchTestCase;
+
+import lombok.SneakyThrows;
+
+/**
+ * Unit tests for HttpRedirectValidator
+ */
+public class HttpRedirectValidatorTests extends OpenSearchTestCase {
+
+    /**
+     * Test that non-redirect status codes (200, 404, etc.) are allowed
+     */
+    @SneakyThrows
+    public void testValidateNoRedirects_whenNonRedirectStatus_thenAllowed() {
+        int[] nonRedirectCodes = { 200, 201, 400, 404, 500 };
+
+        for (int statusCode : nonRedirectCodes) {
+            HttpURLConnection connection = mock(HttpURLConnection.class);
+            when(connection.getResponseCode()).thenReturn(statusCode);
+
+            // Should not throw any exception
+            HttpRedirectValidator.validateNoRedirects(connection);
+
+            // Verify that redirects are disabled
+            verify(connection).setInstanceFollowRedirects(false);
+        }
+    }
+
+    /**
+     * Test that redirect status codes (3xx) are blocked
+     */
+    @SneakyThrows
+    public void testValidateNoRedirects_whenRedirectStatus_thenBlocked() {
+        int[] redirectCodes = { 300, 301, 302, 303, 307, 308 };
+
+        for (int statusCode : redirectCodes) {
+            HttpURLConnection connection = mock(HttpURLConnection.class);
+            when(connection.getResponseCode()).thenReturn(statusCode);
+            when(connection.getHeaderField("Location")).thenReturn("http://redirect-target.com");
+            when(connection.getURL()).thenReturn(new java.net.URL("https://example.com/test"));
+
+            IllegalArgumentException exception = expectThrows(
+                IllegalArgumentException.class,
+                () -> HttpRedirectValidator.validateNoRedirects(connection)
+            );
+
+            // Verify error message
+            assertTrue(
+                "Error message should mention redirects are not allowed",
+                exception.getMessage().contains("HTTP redirects are not allowed")
+            );
+            assertTrue("Error message should contain status code", exception.getMessage().contains(String.valueOf(statusCode)));
+            assertTrue("Error message should contain original URL", exception.getMessage().contains("https://example.com/test"));
+            assertTrue("Error message should contain redirect target", exception.getMessage().contains("http://redirect-target.com"));
+        }
+    }
+}

--- a/src/test/resources/ip2geo/another_manifest.json
+++ b/src/test/resources/ip2geo/another_manifest.json
@@ -1,0 +1,8 @@
+{
+  "url": "https://test.com/db.zip",
+  "db_name": "sample_valid.csv",
+  "sha256_hash": "safasdfaskkkesadfasdf",
+  "valid_for_in_days": 30,
+  "updated_at_in_epoch_milli": 3134012341236,
+  "provider": "sample_provider"
+}

--- a/src/test/resources/ip2geo/server/city/manifest.json
+++ b/src/test/resources/ip2geo/server/city/manifest.json
@@ -1,5 +1,5 @@
 {
-  "url": "https://github.com/opensearch-project/geospatial/raw/main/src/test/resources/ip2geo/server/city/city.zip",
+  "url": "https://raw.githubusercontent.com/opensearch-project/geospatial/main/src/test/resources/ip2geo/server/city/city.zip",
   "db_name": "data.csv",
   "sha256_hash": "oDPgEv+9+kNov7bdQQiLrhr8jQeEPdLnuJ22Hz5npvk=",
   "valid_for_in_days": 30,


### PR DESCRIPTION
### Description
1. Block redirect request
2. Move manifest validation check inside transport action

### Related Issues
N/A
<!-- List any other related issues here -->

### Check List
- [ ] New functionality includes testing.
- [ ] New functionality has been documented.
- [ ] API changes companion pull request [created](https://github.com/opensearch-project/opensearch-api-specification/blob/main/DEVELOPER_GUIDE.md).
- [X] Commits are signed per the DCO using `--signoff`.
- [ ] Public documentation issue/PR [created](https://github.com/opensearch-project/documentation-website/issues/new/choose).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/geospatial/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
