### PR TITLE
Remove deprecated URL(String) usage

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,4 +11,5 @@ See the [CONTRIBUTING guide](./CONTRIBUTING.md#Changelog) for instructions on ho
 ### Infrastructure
 ### Documentation
 ### Maintenance
+*Remove deprecated URL(String) usage ([#795](https://github.com/opensearch-project/geospatial/pull/795))
 ### Refactoring

--- a/src/main/java/org/opensearch/geospatial/ip2geo/action/PutDatasourceRequest.java
+++ b/src/main/java/org/opensearch/geospatial/ip2geo/action/PutDatasourceRequest.java
@@ -7,6 +7,7 @@ package org.opensearch.geospatial.ip2geo.action;
 
 import java.io.IOException;
 import java.net.MalformedURLException;
+import java.net.URI;
 import java.net.URISyntaxException;
 import java.net.URL;
 import java.util.List;
@@ -109,9 +110,9 @@ public class PutDatasourceRequest extends ActionRequest {
      */
     private void validateEndpoint(final ActionRequestValidationException errors) {
         try {
-            URL url = new URL(endpoint);
+            URL url = URI.create(endpoint).toURL();
             url.toURI(); // Validate URL complies with RFC-2396
-        } catch (MalformedURLException | URISyntaxException e) {
+        } catch (MalformedURLException | URISyntaxException | IllegalArgumentException e) {
             log.info("Invalid URL[{}] is provided", endpoint, e);
             errors.addValidationError("Invalid URL format is provided");
         }

--- a/src/main/java/org/opensearch/geospatial/ip2geo/action/PutDatasourceTransportAction.java
+++ b/src/main/java/org/opensearch/geospatial/ip2geo/action/PutDatasourceTransportAction.java
@@ -8,6 +8,7 @@ package org.opensearch.geospatial.ip2geo.action;
 import static org.opensearch.geospatial.ip2geo.common.Ip2GeoLockService.LOCK_DURATION_IN_SECONDS;
 
 import java.net.MalformedURLException;
+import java.net.URI;
 import java.net.URISyntaxException;
 import java.net.URL;
 import java.time.Instant;
@@ -188,7 +189,7 @@ public class PutDatasourceTransportAction extends HandledTransportAction<PutData
     private void validateManifestFile(final PutDatasourceRequest request) {
         DatasourceManifest manifest;
         try {
-            URL url = new URL(request.getEndpoint());
+            URL url = URI.create(request.getEndpoint()).toURL();
             manifest = DatasourceManifest.Builder.build(url);
         } catch (Exception e) {
             log.info("Error occurred while reading a file from {}", request.getEndpoint(), e);
@@ -198,8 +199,8 @@ public class PutDatasourceTransportAction extends HandledTransportAction<PutData
         }
 
         try {
-            new URL(manifest.getUrl()).toURI(); // Validate URL complies with RFC-2396
-        } catch (MalformedURLException | URISyntaxException e) {
+            URI.create(manifest.getUrl()).toURL().toURI(); // Validate URL complies with RFC-2396
+        } catch (MalformedURLException | URISyntaxException | IllegalArgumentException e) {
             log.info("Invalid URL[{}] is provided for url field in the manifest file", manifest.getUrl(), e);
             throw new IllegalArgumentException("Invalid URL format is provided for url field in the manifest file");
         }

--- a/src/main/java/org/opensearch/geospatial/ip2geo/action/UpdateDatasourceRequest.java
+++ b/src/main/java/org/opensearch/geospatial/ip2geo/action/UpdateDatasourceRequest.java
@@ -7,6 +7,7 @@ package org.opensearch.geospatial.ip2geo.action;
 
 import java.io.IOException;
 import java.net.MalformedURLException;
+import java.net.URI;
 import java.net.URISyntaxException;
 import java.net.URL;
 
@@ -120,9 +121,9 @@ public class UpdateDatasourceRequest extends ActionRequest {
         }
 
         try {
-            URL url = new URL(endpoint);
+            URL url = URI.create(endpoint).toURL();
             url.toURI(); // Validate URL complies with RFC-2396
-        } catch (MalformedURLException | URISyntaxException e) {
+        } catch (MalformedURLException | URISyntaxException | IllegalArgumentException e) {
             log.info("Invalid URL[{}] is provided", endpoint, e);
             errors.addValidationError("Invalid URL format is provided");
         }

--- a/src/main/java/org/opensearch/geospatial/ip2geo/action/UpdateDatasourceTransportAction.java
+++ b/src/main/java/org/opensearch/geospatial/ip2geo/action/UpdateDatasourceTransportAction.java
@@ -7,6 +7,7 @@ package org.opensearch.geospatial.ip2geo.action;
 
 import java.io.IOException;
 import java.net.MalformedURLException;
+import java.net.URI;
 import java.net.URISyntaxException;
 import java.net.URL;
 import java.security.InvalidParameterException;
@@ -194,7 +195,7 @@ public class UpdateDatasourceTransportAction extends HandledTransportAction<Upda
         }
 
         long validForInDays = isEndpointChanged(request, datasource)
-            ? DatasourceManifest.Builder.build(new URL(request.getEndpoint())).getValidForInDays()
+            ? DatasourceManifest.Builder.build(URI.create(request.getEndpoint()).toURL()).getValidForInDays()
             : datasource.getDatabase().getValidForInDays();
 
         long updateInterval = isUpdateIntervalChanged(request)
@@ -237,7 +238,7 @@ public class UpdateDatasourceTransportAction extends HandledTransportAction<Upda
 
         DatasourceManifest manifest;
         try {
-            URL url = new URL(request.getEndpoint());
+            URL url = URI.create(request.getEndpoint()).toURL();
             manifest = DatasourceManifest.Builder.build(url);
         } catch (Exception e) {
             log.info("Error occurred while reading a file from {}", request.getEndpoint(), e);
@@ -247,8 +248,8 @@ public class UpdateDatasourceTransportAction extends HandledTransportAction<Upda
         }
 
         try {
-            new URL(manifest.getUrl()).toURI(); // Validate URL complies with RFC-2396
-        } catch (MalformedURLException | URISyntaxException e) {
+            URI.create(manifest.getUrl()).toURL().toURI(); // Validate URL complies with RFC-2396
+        } catch (MalformedURLException | URISyntaxException | IllegalArgumentException e) {
             log.info("Invalid URL[{}] is provided for url field in the manifest file", manifest.getUrl(), e);
             throw new IllegalArgumentException("Invalid URL format is provided for url field in the manifest file");
         }

--- a/src/main/java/org/opensearch/geospatial/ip2geo/common/Ip2GeoSettings.java
+++ b/src/main/java/org/opensearch/geospatial/ip2geo/common/Ip2GeoSettings.java
@@ -6,8 +6,8 @@
 package org.opensearch.geospatial.ip2geo.common;
 
 import java.net.MalformedURLException;
+import java.net.URI;
 import java.net.URISyntaxException;
-import java.net.URL;
 import java.util.Arrays;
 import java.util.List;
 import java.util.function.Function;
@@ -125,8 +125,8 @@ public class Ip2GeoSettings {
         @Override
         public void validate(final String value) {
             try {
-                new URL(value).toURI();
-            } catch (MalformedURLException | URISyntaxException e) {
+                URI.create(value).toURL().toURI();
+            } catch (MalformedURLException | URISyntaxException | IllegalArgumentException e) {
                 throw new IllegalArgumentException("Invalid URL format is provided");
             }
         }

--- a/src/main/java/org/opensearch/geospatial/ip2geo/common/URLDenyListChecker.java
+++ b/src/main/java/org/opensearch/geospatial/ip2geo/common/URLDenyListChecker.java
@@ -7,6 +7,7 @@ package org.opensearch.geospatial.ip2geo.common;
 
 import java.net.InetAddress;
 import java.net.MalformedURLException;
+import java.net.URI;
 import java.net.URL;
 import java.net.UnknownHostException;
 import java.util.List;
@@ -48,7 +49,7 @@ public class URLDenyListChecker {
 
     @SuppressForbidden(reason = "Need to connect to http endpoint to read GeoIP database file")
     private URL toUrlIfNotInDenyList(final String url, final List<String> denyList) throws UnknownHostException, MalformedURLException {
-        URL urlToReturn = new URL(url);
+        URL urlToReturn = URI.create(url).toURL();
         if (isInDenyList(new IPAddressString(InetAddress.getByName(urlToReturn.getHost()).getHostAddress()), denyList)) {
             throw new IllegalArgumentException(
                 "given endpoint is blocked by deny list in cluster setting " + Ip2GeoSettings.DATASOURCE_ENDPOINT_DENYLIST.getKey()

--- a/src/main/java/org/opensearch/geospatial/ip2geo/jobscheduler/DatasourceUpdateService.java
+++ b/src/main/java/org/opensearch/geospatial/ip2geo/jobscheduler/DatasourceUpdateService.java
@@ -6,6 +6,7 @@
 package org.opensearch.geospatial.ip2geo.jobscheduler;
 
 import java.io.IOException;
+import java.net.URI;
 import java.net.URL;
 import java.time.Duration;
 import java.time.Instant;
@@ -133,7 +134,7 @@ public class DatasourceUpdateService {
      * @return header fields of geo data
      */
     public List<String> getHeaderFields(String manifestUrl) throws IOException {
-        URL url = new URL(manifestUrl);
+        URL url = URI.create(manifestUrl).toURL();
         DatasourceManifest manifest = DatasourceManifest.Builder.build(url);
 
         try (CSVParser reader = geoIpDataDao.getDatabaseReader(manifest)) {

--- a/src/test/java/org/opensearch/geospatial/ip2geo/Ip2GeoTestCase.java
+++ b/src/test/java/org/opensearch/geospatial/ip2geo/Ip2GeoTestCase.java
@@ -10,7 +10,7 @@ import static org.mockito.Mockito.spy;
 import static org.mockito.Mockito.when;
 
 import java.io.File;
-import java.net.URL;
+import java.net.URI;
 import java.nio.file.Paths;
 import java.time.Instant;
 import java.time.temporal.ChronoUnit;
@@ -120,7 +120,7 @@ public abstract class Ip2GeoTestCase extends RestActionTestCase {
         verifyingClient = spy(new VerifyingClient(this.getTestName()));
         clusterSettings = new ClusterSettings(settings, new HashSet<>(Ip2GeoSettings.settings()));
         ingestMetadata = new IngestMetadata(Collections.emptyMap());
-        when(urlDenyListChecker.toUrlIfNotInDenyList(anyString())).thenAnswer(i -> new URL(i.getArgument(0)));
+        when(urlDenyListChecker.toUrlIfNotInDenyList(anyString())).thenAnswer(i -> URI.create(i.getArgument(0)).toURL());
         when(metadata.custom(IngestMetadata.TYPE)).thenReturn(ingestMetadata);
         when(clusterService.getSettings()).thenReturn(Settings.EMPTY);
         when(clusterService.getClusterSettings()).thenReturn(clusterSettings);

--- a/src/test/java/org/opensearch/geospatial/ip2geo/common/HttpRedirectValidatorTests.java
+++ b/src/test/java/org/opensearch/geospatial/ip2geo/common/HttpRedirectValidatorTests.java
@@ -50,7 +50,7 @@ public class HttpRedirectValidatorTests extends OpenSearchTestCase {
             HttpURLConnection connection = mock(HttpURLConnection.class);
             when(connection.getResponseCode()).thenReturn(statusCode);
             when(connection.getHeaderField("Location")).thenReturn("http://redirect-target.com");
-            when(connection.getURL()).thenReturn(new java.net.URL("https://example.com/test"));
+            when(connection.getURL()).thenReturn(java.net.URI.create("https://example.com/test").toURL());
 
             IllegalArgumentException exception = expectThrows(
                 IllegalArgumentException.class,


### PR DESCRIPTION
### Description
Remove deprecated URL(String) usage

### Related Issues
N/A

### Check List
- [ ] New functionality includes testing.
- [ ] New functionality has been documented.
- [ ] API changes companion pull request [created](https://github.com/opensearch-project/opensearch-api-specification/blob/main/DEVELOPER_GUIDE.md).
- [X] Commits are signed per the DCO using `--signoff`.
- [ ] Public documentation issue/PR [created](https://github.com/opensearch-project/documentation-website/issues/new/choose).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/geospatial/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
