### PR TITLE
Fix maven snapshot publication

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -29,7 +29,6 @@ buildscript {
     repositories {
         mavenLocal()
         maven { url "https://central.sonatype.com/repository/maven-snapshots/" }
-        maven { url "https://aws.oss.sonatype.org/content/repositories/snapshots" }
         mavenCentral()
         maven { url "https://plugins.gradle.org/m2/" }
     }
@@ -106,7 +105,6 @@ allprojects {
 repositories {
     mavenLocal()
     maven { url "https://central.sonatype.com/repository/maven-snapshots/" }
-    maven { url "https://aws.oss.sonatype.org/content/repositories/snapshots" }
     mavenCentral()
     maven { url "https://plugins.gradle.org/m2/" }
 }

--- a/client/build.gradle
+++ b/client/build.gradle
@@ -21,7 +21,6 @@ project.forbiddenApisTest.enabled = false
 repositories {
     mavenLocal()
     maven { url "https://central.sonatype.com/repository/maven-snapshots/" }
-    maven { url "https://aws.oss.sonatype.org/content/repositories/snapshots" }
     mavenCentral()
     maven { url "https://plugins.gradle.org/m2/" }
 }

--- a/libs/h3/build.gradle
+++ b/libs/h3/build.gradle
@@ -31,7 +31,6 @@ tasks.named('forbiddenApisMain').configure {
 repositories {
     mavenLocal()
     maven { url "https://central.sonatype.com/repository/maven-snapshots/" }
-    maven { url "https://aws.oss.sonatype.org/content/repositories/snapshots" }
     mavenCentral()
     maven { url "https://plugins.gradle.org/m2/" }
 }


### PR DESCRIPTION
### Description

This PR fixes the maven snapshot publication failing on the main branch. Ref: https://github.com/opensearch-project/geospatial/actions/runs/17594013616/job/49981678007

The error suggests that its failing due to the decommissioning of https://aws.oss.sonatype.org

```
* What went wrong:
A problem occurred configuring root project 'geospatial'.
> Could not resolve all artifacts for configuration 'classpath'.
   > Could not resolve com.diffplug.spotless:spotless-plugin-gradle:6.25.0.
     Required by:
         root project :
      > Could not resolve com.diffplug.spotless:spotless-plugin-gradle:6.25.0.
         > Could not get resource 'https://aws.oss.sonatype.org/content/repositories/snapshots/com/diffplug/spotless/spotless-plugin-gradle/6.25.0/spotless-plugin-gradle-6.25.0.pom'.
            > Could not GET 'https://aws.oss.sonatype.org/content/repositories/snapshots/com/diffplug/spotless/spotless-plugin-gradle/6.25.0/spotless-plugin-gradle-6.25.0.pom'. Received status code 503 from server: Service Temporarily Unavailable
   > Could not resolve io.freefair.lombok:io.freefair.lombok.gradle.plugin:8.14.
     Required by:
         root project :
      > Could not resolve io.freefair.lombok:io.freefair.lombok.gradle.plugin:8.14.
         > Could not get resource 'https://aws.oss.sonatype.org/content/repositories/snapshots/io/freefair/lombok/io.freefair.lombok.gradle.plugin/8.14/io.freefair.lombok.gradle.plugin-8.14.pom'.
            > Could not HEAD 'https://aws.oss.sonatype.org/content/repositories/snapshots/io/freefair/lombok/io.freefair.lombok.gradle.plugin/8.14/io.freefair.lombok.gradle.plugin-8.14.pom'. Received status code 503 from server: Service Temporarily Unavailable
> There are 21 more failures with identical causes.
```

### Check List
- [ ] New functionality includes testing.
- [ ] New functionality has been documented.
- [ ] API changes companion pull request [created](https://github.com/opensearch-project/opensearch-api-specification/blob/main/DEVELOPER_GUIDE.md).
- [ ] Commits are signed per the DCO using `--signoff`.
- [ ] Public documentation issue/PR [created](https://github.com/opensearch-project/documentation-website/issues/new/choose).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/geospatial/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
