### PR TITLE
Fix typo in max multi geometries validation cluster setting

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ See the [CONTRIBUTING guide](./CONTRIBUTING.md#Changelog) for instructions on ho
 ### Features
 ### Enhancements
 ### Bug Fixes
+- Fix typo in `plugins.geospatial.geojson.max_multi_gemoetries` setting to `plugins.geospatial.geojson.max_multi_gemoetries` ([#837](https://github.com/opensearch-project/geospatial/pull/837))
 ### Infrastructure
 ### Documentation
 ### Maintenance

--- a/src/main/java/org/opensearch/geospatial/settings/GeospatialSettings.java
+++ b/src/main/java/org/opensearch/geospatial/settings/GeospatialSettings.java
@@ -26,7 +26,7 @@ public final class GeospatialSettings {
 
     // Max number of multi geometries allowed while parsing uploaded GeoJSON
     public static final Setting<Integer> MAX_MULTI_GEOMETRIES = Setting.intSetting(
-        "plugins.geospatial.geojson.max_multi_gemoetries",
+        "plugins.geospatial.geojson.max_multi_geometries",
         100,
         Setting.Property.NodeScope,
         Setting.Property.Dynamic


### PR DESCRIPTION
### Description
Fix typo in geospatial setting. Documentation already uses fixed setting.

### Check List
- [ ] New functionality includes testing.
- [ ] New functionality has been documented.
- [ ] API changes companion pull request [created](https://github.com/opensearch-project/opensearch-api-specification/blob/main/DEVELOPER_GUIDE.md).
- [ ] Commits are signed per the DCO using `--signoff`.
- [ ] Public documentation issue/PR [created](https://github.com/opensearch-project/documentation-website/issues/new/choose).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/geospatial/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
