### PR TITLE
Add ci.opensearch.org maven2 mirror to avoid throttling (geospatial)

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -29,6 +29,7 @@ buildscript {
     repositories {
         mavenLocal()
         maven { url "https://ci.opensearch.org/ci/dbc/snapshots/maven/" }
+        maven { url "https://ci.opensearch.org/maven2/" }
         mavenCentral()
         maven { url "https://plugins.gradle.org/m2/" }
     }
@@ -107,6 +108,7 @@ allprojects {
 repositories {
     mavenLocal()
     maven { url "https://ci.opensearch.org/ci/dbc/snapshots/maven/" }
+    maven { url "https://ci.opensearch.org/maven2/" }
     mavenCentral()
     maven { url "https://plugins.gradle.org/m2/" }
 }

--- a/client/build.gradle
+++ b/client/build.gradle
@@ -21,6 +21,7 @@ project.forbiddenApisTest.enabled = false
 repositories {
     mavenLocal()
     maven { url "https://ci.opensearch.org/ci/dbc/snapshots/maven/" }
+    maven { url "https://ci.opensearch.org/maven2/" }
     mavenCentral()
     maven { url "https://plugins.gradle.org/m2/" }
 }

--- a/libs/h3/build.gradle
+++ b/libs/h3/build.gradle
@@ -31,6 +31,7 @@ tasks.named('forbiddenApisMain').configure {
 repositories {
     mavenLocal()
     maven { url "https://ci.opensearch.org/ci/dbc/snapshots/maven/" }
+    maven { url "https://ci.opensearch.org/maven2/" }
     mavenCentral()
     maven { url "https://plugins.gradle.org/m2/" }
 }

--- a/settings.gradle
+++ b/settings.gradle
@@ -7,6 +7,14 @@
  * in the user manual at https://docs.gradle.org/6.5.1/userguide/multi_project_builds.html
  */
 
+pluginManagement {
+    repositories {
+        maven { url "https://ci.opensearch.org/maven2/" }
+        gradlePluginPortal()
+        mavenCentral()
+    }
+}
+
 rootProject.name = 'geospatial'
 
 include ":libs"


### PR DESCRIPTION
### Description
Add ci.opensearch.org maven2 mirror to avoid throttling (geospatial)

### Related Issues
https://github.com/opensearch-project/opensearch-build/issues/6062

### Check List
- [ ] New functionality includes testing.
- [ ] New functionality has been documented.
- [ ] API changes companion pull request [created](https://github.com/opensearch-project/opensearch-api-specification/blob/main/DEVELOPER_GUIDE.md).
- [x] Commits are signed per the DCO using `--signoff`.
- [ ] Public documentation issue/PR [created](https://github.com/opensearch-project/documentation-website/issues/new/choose).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/geospatial/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
