### PR TITLE
Add Eclipse P2 mirror to avoid download.eclipse.org outages (geospatial)

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -344,7 +344,7 @@ spotless {
     java {
         removeUnusedImports()
         importOrder 'java', 'javax', 'org', 'com'
-        eclipse().configFile rootProject.file('formatterConfig.xml')
+        eclipse().withP2Mirrors(Map.of("https://download.eclipse.org/", "https://ci.opensearch.org/")).configFile rootProject.file('formatterConfig.xml')
         trimTrailingWhitespace()
         endWithNewline()
     }

--- a/client/build.gradle
+++ b/client/build.gradle
@@ -52,7 +52,7 @@ spotless {
     java {
         removeUnusedImports()
         importOrder 'java', 'javax', 'org', 'com'
-        eclipse().configFile rootProject.file('formatterConfig.xml')
+        eclipse().withP2Mirrors(Map.of("https://download.eclipse.org/", "https://ci.opensearch.org/")).configFile rootProject.file('formatterConfig.xml')
         trimTrailingWhitespace()
         endWithNewline()
     }


### PR DESCRIPTION
### Description
Add `withP2Mirrors` to both Spotless Eclipse formatter configurations so P2 artifacts use the `ci.opensearch.org/eclipse/` CloudFront mirror rather than reaching `download.eclipse.org` directly. This helps prevent CI failures when Eclipse's download server is unavailable or slow.

### Related Issues
https://github.com/opensearch-project/opensearch-build/issues/6421#issuecomment-5271186726

### Check List
- [x] Commits are signed per the DCO using `--signoff`.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/geospatial/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).